### PR TITLE
fix: typos in memgpt/autogen/memgpt_agent.py

### DIFF
--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -80,7 +80,7 @@ class MemGPTAgent(ConversableAgent):
     def pretty_concat(messages):
         """AutoGen expects a single response, but MemGPT may take many steps.
         
-        To accomadate AutoGen, concatenate all of MemGPT's steps into one and return as a single message.
+        To accommodate AutoGen, concatenate all of MemGPT's steps into one and return as a single message.
         """
         ret = {
             'role': 'assistant',


### PR DESCRIPTION
This pull request fixes typo `accomadate -> accommodate` in `memgpt/autogen/memgpt_agent.py`. I kindly request the repository maintainers to review and merge it. Thanks! :heart: 