### PR TITLE
CLI overhaul

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Run main.py
-      run: python main.py
+    - name: Run main.py with input
+      run: |
+        echo -e "\n\n\nn" | python main.py

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# MemGPT config files
+configs/

--- a/README.md
+++ b/README.md
@@ -110,11 +110,22 @@ To create a new starter user or starter persona (that MemGPT gets initialized wi
 
 ```sh
 # assuming you created a new file /memgpt/humans/examples/me.txt
+python main.py
+# Select me.txt during configuration process
+```
+-- OR --
+```sh
+# assuming you created a new file /memgpt/humans/examples/me.txt
 python main.py --human me.txt
 ```
 
 ### GPT-3.5 support
 You can run MemGPT with GPT-3.5 as the LLM instead of GPT-4:
+```sh
+python main.py
+# Select gpt-3.5 during configuration process
+```
+-- OR --
 ```sh
 python main.py --model gpt-3.5-turbo
 ```
@@ -124,6 +135,15 @@ python main.py --model gpt-3.5-turbo
 Please report any bugs you encounter regarding MemGPT running on GPT-3.5 to  https://github.com/cpacker/MemGPT/issues/59.
 
 ### `main.py` flags
+```text
+--first
+  allows you to send the first message in the chat (by default, MemGPT will send the first message)
+--debug
+  enables debugging output
+```
+
+<details>
+<summary>Configure via legacy flags</summary>
 
 ```text
 --model
@@ -132,10 +152,6 @@ Please report any bugs you encounter regarding MemGPT running on GPT-3.5 to  htt
   load a specific persona file
 --human
   load a specific human file
---first
-  allows you to send the first message in the chat (by default, MemGPT will send the first message)
---debug
-  enables debugging output
 --archival_storage_faiss_path=<ARCHIVAL_STORAGE_FAISS_PATH>
   load in document database (backed by FAISS index)
 --archival_storage_files="<ARCHIVAL_STORAGE_FILES_GLOB_PATTERN>"
@@ -145,6 +161,8 @@ Please report any bugs you encounter regarding MemGPT running on GPT-3.5 to  htt
 --archival_storage_sqldb=<SQLDB_PATH>
   load in SQL database
 ```
+</details>
+
 
 ### Interactive CLI commands
 
@@ -153,8 +171,6 @@ These are the commands for the CLI, **not the Discord bot**! The Discord bot has
 While using MemGPT via the CLI (not Discord!) you can run various commands:
 
 ```text
-//
-  enter multiline input mode (type // again when done)
 /exit
   exit the CLI
 /save

--- a/README.md
+++ b/README.md
@@ -75,13 +75,6 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
-Extra step for Windows:
-
-```sh
-# only needed on Windows
-pip install pyreadline3
-```
-
 Add your OpenAI API key to your environment:
 
 ```sh

--- a/config.py
+++ b/config.py
@@ -66,7 +66,8 @@ class Config:
                 f"Would you like to recompute embeddings? Do this if your files have changed.\nFiles:{self.archival_storage_files}",
                 default=False,
             )
-        await self.configure_archival_storage(recompute_embeddings)
+        if self.archival_storage_files:
+            await self.configure_archival_storage(recompute_embeddings)
         return self
 
     @classmethod
@@ -120,7 +121,7 @@ class Config:
         print(self.memgpt_persona)
 
         self.human_persona = await questionary.select(
-            "Which persona would you like to use?",
+            "Which user would you like to use?",
             Config.get_user_personas(),
         ).ask_async()
 
@@ -223,14 +224,40 @@ class Config:
         if dir_path is None:
             dir_path = Config.personas_dir
         all_personas = Config.get_personas(dir_path)
-        return Config.get_persona_choices([p for p in all_personas], get_persona_text)
+        default_personas = [
+            "sam",
+            "sam_pov",
+            "memgpt_starter",
+            "memgpt_doc",
+            "sam_simple_pov_gpt35",
+        ]
+        custom_personas = list(set(all_personas) - set(default_personas))
+        return Config.get_persona_choices(
+            [p for p in custom_personas + default_personas], get_persona_text
+        ) + [
+            questionary.Separator(),
+            questionary.Choice(
+                f"📝 You can create your own personas by adding .txt files to {dir_path}.",
+                disabled=True,
+            ),
+        ]
 
     @staticmethod
     def get_user_personas(dir_path=None):
         if dir_path is None:
             dir_path = Config.humans_dir
         all_personas = Config.get_personas(dir_path)
-        return Config.get_persona_choices([p for p in all_personas], get_human_text)
+        default_personas = ["basic", "cs_phd"]
+        custom_personas = list(set(all_personas) - set(default_personas))
+        return Config.get_persona_choices(
+            [p for p in custom_personas + default_personas], get_human_text
+        ) + [
+            questionary.Separator(),
+            questionary.Choice(
+                f"📝 You can create your own human profiles by adding .txt files to {dir_path}.",
+                disabled=True,
+            ),
+        ]
 
     @staticmethod
     def get_personas(dir_path) -> List[str]:

--- a/config.py
+++ b/config.py
@@ -276,6 +276,3 @@ def indent(text, num_lines=5):
     if len(lines) > num_lines:
         lines = lines[: num_lines - 1] + ["... (truncated)", lines[-1]]
     return "     " + "\n     ".join(lines)
-
-
-config = Config()

--- a/config.py
+++ b/config.py
@@ -259,6 +259,7 @@ class Config:
     def get_most_recent_config(configs_dir=None):
         if configs_dir is None:
             configs_dir = Config.configs_dir
+        os.makedirs(configs_dir, exist_ok=True)
         files = [
             os.path.join(configs_dir, f)
             for f in os.listdir(configs_dir)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,280 @@
+import asyncio
+import glob
+import json
+import os
+import textwrap
+
+import interface
+
+import questionary
+
+from colorama import Fore, Style, init
+from rich.console import Console
+
+console = Console()
+
+from typing import List, Type
+
+import memgpt.utils as utils
+
+from memgpt.personas.personas import get_persona_text
+from memgpt.humans.humans import get_human_text
+
+model_choices = [
+    questionary.Choice("gpt-4"),
+    questionary.Choice(
+        "gpt-3.5-turbo (experimental! function-calling performance is not quite at the level of gpt-4 yet)",
+        value="gpt-3.5-turbo",
+    ),
+]
+
+
+class Config:
+    personas_dir = os.path.join("memgpt", "personas", "examples")
+    humans_dir = os.path.join("memgpt", "humans", "examples")
+    configs_dir = "configs"
+
+    def __init__(self):
+        self.load_type = None
+        self.archival_storage_files = None
+        self.compute_embeddings = False
+        self.agent_save_file = None
+        self.persistence_manager_save_file = None
+
+    @classmethod
+    async def legacy_flags_init(
+        cls: Type["config"],
+        model: str,
+        memgpt_persona: str,
+        human_persona: str,
+        load_type: str = None,
+        archival_storage_files: str = None,
+        archival_storage_index: str = None,
+        compute_embeddings: bool = False,
+    ):
+        self = cls()
+        self.model = model
+        self.memgpt_persona = memgpt_persona
+        self.human_persona = human_persona
+        self.load_type = load_type
+        self.archival_storage_files = archival_storage_files
+        self.archival_storage_index = archival_storage_index
+        self.compute_embeddings = compute_embeddings
+        recompute_embeddings = self.compute_embeddings
+        if self.archival_storage_index:
+            recompute_embeddings = questionary.confirm(
+                f"Would you like to recompute embeddings? Do this if your files have changed.\nFiles:{self.archival_storage_files}",
+                default=False,
+            )
+        await self.configure_archival_storage(recompute_embeddings)
+        return self
+
+    @classmethod
+    async def config_init(cls: Type["Config"], config_file: str = None):
+        self = cls()
+        self.config_file = config_file
+        if self.config_file is None:
+            cfg = Config.get_most_recent_config()
+            use_cfg = False
+            if cfg:
+                print(
+                    f"{Style.BRIGHT}{Fore.MAGENTA}⚙️ Found saved config file.{Style.RESET_ALL}"
+                )
+                use_cfg = await questionary.confirm(
+                    f"Use most recent config file '{cfg}'?"
+                ).ask_async()
+            if use_cfg:
+                self.config_file = cfg
+
+        if self.config_file:
+            self.load_config(self.config_file)
+            recompute_embeddings = False
+            if self.compute_embeddings:
+                if self.archival_storage_index:
+                    recompute_embeddings = await questionary.confirm(
+                        f"Would you like to recompute embeddings? Do this if your files have changed.\n    Files: {self.archival_storage_files}",
+                        default=False,
+                    ).ask_async()
+                else:
+                    recompute_embeddings = True
+            if self.load_type:
+                await self.configure_archival_storage(recompute_embeddings)
+                self.write_config()
+            return self
+
+        # print("No settings file found, configuring MemGPT...")
+        print(
+            f"{Style.BRIGHT}{Fore.MAGENTA}⚙️ No settings file found, configuring MemGPT...{Style.RESET_ALL}"
+        )
+
+        self.model = await questionary.select(
+            "Which model would you like to use?",
+            model_choices,
+            default=model_choices[0],
+        ).ask_async()
+
+        self.memgpt_persona = await questionary.select(
+            "Which persona would you like MemGPT to use?",
+            Config.get_memgpt_personas(),
+        ).ask_async()
+        print(self.memgpt_persona)
+
+        self.human_persona = await questionary.select(
+            "Which persona would you like to use?",
+            Config.get_user_personas(),
+        ).ask_async()
+
+        self.archival_storage_index = None
+        self.preload_archival = await questionary.confirm(
+            "Would you like to preload anything into MemGPT's archival memory?"
+        ).ask_async()
+        if self.preload_archival:
+            self.load_type = await questionary.select(
+                "What would you like to load?",
+                choices=[
+                    questionary.Choice("A folder or file", value="folder"),
+                    questionary.Choice("A SQL database", value="sql"),
+                    questionary.Choice("A glob pattern", value="glob"),
+                ],
+            ).ask_async()
+            if self.load_type == "folder" or self.load_type == "sql":
+                archival_storage_path = await questionary.path(
+                    "Please enter the folder or file (tab for autocomplete):"
+                ).ask_async()
+                if os.path.isdir(archival_storage_path):
+                    self.archival_storage_files = os.path.join(
+                        archival_storage_path, "*"
+                    )
+                else:
+                    self.archival_storage_files = archival_storage_path
+            else:
+                self.archival_storage_files = await questionary.path(
+                    "Please enter the glob pattern (tab for autocomplete):"
+                ).ask_async()
+            self.compute_embeddings = await questionary.confirm(
+                "Would you like to compute embeddings over these files to enable embeddings search?"
+            ).ask_async()
+            await self.configure_archival_storage(self.compute_embeddings)
+
+        self.write_config()
+        return self
+
+    async def configure_archival_storage(self, recompute_embeddings):
+        if recompute_embeddings:
+            self.archival_storage_index = (
+                await utils.prepare_archival_index_from_files_compute_embeddings(
+                    self.archival_storage_files
+                )
+            )
+        if self.compute_embeddings and self.archival_storage_index:
+            self.index, self.archival_database = utils.prepare_archival_index(
+                self.archival_storage_index
+            )
+        else:
+            self.archival_database = utils.prepare_archival_index_from_files(
+                self.archival_storage_files
+            )
+
+    def to_dict(self):
+        return {
+            "model": self.model,
+            "memgpt_persona": self.memgpt_persona,
+            "human_persona": self.human_persona,
+            "preload_archival": self.preload_archival,
+            "archival_storage_files": self.archival_storage_files,
+            "archival_storage_index": self.archival_storage_index,
+            "compute_embeddings": self.compute_embeddings,
+            "load_type": self.load_type,
+            "agent_save_file": self.agent_save_file,
+            "persistence_manager_save_file": self.persistence_manager_save_file,
+        }
+
+    def load_config(self, config_file):
+        with open(config_file, "rt") as f:
+            cfg = json.load(f)
+        self.model = cfg["model"]
+        self.memgpt_persona = cfg["memgpt_persona"]
+        self.human_persona = cfg["human_persona"]
+        self.preload_archival = cfg["preload_archival"]
+        self.archival_storage_files = cfg["archival_storage_files"]
+        self.archival_storage_index = cfg["archival_storage_index"]
+        self.compute_embeddings = cfg["compute_embeddings"]
+        self.load_type = cfg["load_type"]
+        self.agent_save_file = cfg["agent_save_file"]
+        self.persistence_manager_save_file = cfg["persistence_manager_save_file"]
+
+    def write_config(self, configs_dir=None):
+        if configs_dir is None:
+            configs_dir = Config.configs_dir
+        os.makedirs(configs_dir, exist_ok=True)
+        if self.config_file is None:
+            filename = os.path.join(
+                configs_dir, utils.get_local_time().replace(" ", "_").replace(":", "_")
+            )
+            self.config_file = f"{filename}.json"
+        with open(self.config_file, "wt") as f:
+            json.dump(self.to_dict(), f, indent=4)
+        print(
+            f"{Style.BRIGHT}{Fore.MAGENTA}⚙️ Saved config file to {self.config_file}.{Style.RESET_ALL}"
+        )
+
+    @staticmethod
+    def get_memgpt_personas(dir_path=None):
+        if dir_path is None:
+            dir_path = Config.personas_dir
+        all_personas = Config.get_personas(dir_path)
+        return Config.get_persona_choices([p for p in all_personas], get_persona_text)
+
+    @staticmethod
+    def get_user_personas(dir_path=None):
+        if dir_path is None:
+            dir_path = Config.humans_dir
+        all_personas = Config.get_personas(dir_path)
+        return Config.get_persona_choices([p for p in all_personas], get_human_text)
+
+    @staticmethod
+    def get_personas(dir_path) -> List[str]:
+        files = sorted(glob.glob(os.path.join(dir_path, "*.txt")))
+        stems = []
+        for f in files:
+            filename = os.path.basename(f)
+            stem, _ = os.path.splitext(filename)
+            stems.append(stem)
+        return stems
+
+    @staticmethod
+    def get_persona_choices(personas, text_getter):
+        return [
+            questionary.Choice(
+                title=[
+                    ("class:question", f"{p}"),
+                    ("class:text", f"\n{indent(text_getter(p))}"),
+                ],
+                value=p,
+            )
+            for p in personas
+        ]
+
+    @staticmethod
+    def get_most_recent_config(configs_dir=None):
+        if configs_dir is None:
+            configs_dir = Config.configs_dir
+        files = [
+            os.path.join(configs_dir, f)
+            for f in os.listdir(configs_dir)
+            if os.path.isfile(os.path.join(configs_dir, f))
+        ]
+        # Return the file with the most recent modification time
+        if len(files) == 0:
+            return None
+        return max(files, key=os.path.getmtime)
+
+
+def indent(text, num_lines=5):
+    lines = textwrap.fill(text, width=100).split("\n")
+    if len(lines) > num_lines:
+        lines = lines[: num_lines - 1] + ["... (truncated)", lines[-1]]
+    return "     " + "\n     ".join(lines)
+
+
+config = Config()

--- a/interface.py
+++ b/interface.py
@@ -10,131 +10,172 @@ init(autoreset=True)
 # DEBUG = True  # puts full message outputs in the terminal
 DEBUG = False  # only dumps important messages in the terminal
 
+
 def important_message(msg):
-    print(f'{Fore.MAGENTA}{Style.BRIGHT}{msg}{Style.RESET_ALL}')
+    print(f"{Fore.MAGENTA}{Style.BRIGHT}{msg}{Style.RESET_ALL}")
+
+
+def warning_message(msg):
+    print(f"{Fore.RED}{Style.BRIGHT}{msg}{Style.RESET_ALL}")
+
 
 async def internal_monologue(msg):
     # ANSI escape code for italic is '\x1B[3m'
-    print(f'\x1B[3m{Fore.LIGHTBLACK_EX}💭 {msg}{Style.RESET_ALL}')
+    print(f"\x1B[3m{Fore.LIGHTBLACK_EX}💭 {msg}{Style.RESET_ALL}")
+
 
 async def assistant_message(msg):
-    print(f'{Fore.YELLOW}{Style.BRIGHT}🤖 {Fore.YELLOW}{msg}{Style.RESET_ALL}')
+    print(f"{Fore.YELLOW}{Style.BRIGHT}🤖 {Fore.YELLOW}{msg}{Style.RESET_ALL}")
+
 
 async def memory_message(msg):
-    print(f'{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}🧠 {Fore.LIGHTMAGENTA_EX}{msg}{Style.RESET_ALL}')
+    print(
+        f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}🧠 {Fore.LIGHTMAGENTA_EX}{msg}{Style.RESET_ALL}"
+    )
+
 
 async def system_message(msg):
-    printd(f'{Fore.MAGENTA}{Style.BRIGHT}🖥️ [system] {Fore.MAGENTA}{msg}{Style.RESET_ALL}')
+    printd(
+        f"{Fore.MAGENTA}{Style.BRIGHT}🖥️ [system] {Fore.MAGENTA}{msg}{Style.RESET_ALL}"
+    )
+
 
 async def user_message(msg, raw=False):
     if isinstance(msg, str):
         if raw:
-            printd(f'{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg}{Style.RESET_ALL}')
+            printd(f"{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg}{Style.RESET_ALL}")
             return
         else:
             try:
                 msg_json = json.loads(msg)
             except:
                 printd(f"Warning: failed to parse user message into json")
-                printd(f'{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg}{Style.RESET_ALL}')
+                printd(
+                    f"{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg}{Style.RESET_ALL}"
+                )
                 return
 
-    if msg_json['type'] == 'user_message':
-        msg_json.pop('type')
-        printd(f'{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg_json}{Style.RESET_ALL}')
-    elif msg_json['type'] == 'heartbeat':
+    if msg_json["type"] == "user_message":
+        msg_json.pop("type")
+        printd(f"{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg_json}{Style.RESET_ALL}")
+    elif msg_json["type"] == "heartbeat":
         if DEBUG:
-            msg_json.pop('type')
-            printd(f'{Fore.GREEN}{Style.BRIGHT}💓 {Fore.GREEN}{msg_json}{Style.RESET_ALL}')
-    elif msg_json['type'] == 'system_message':
-        msg_json.pop('type')
-        printd(f'{Fore.GREEN}{Style.BRIGHT}🖥️ {Fore.GREEN}{msg_json}{Style.RESET_ALL}')
+            msg_json.pop("type")
+            printd(
+                f"{Fore.GREEN}{Style.BRIGHT}💓 {Fore.GREEN}{msg_json}{Style.RESET_ALL}"
+            )
+    elif msg_json["type"] == "system_message":
+        msg_json.pop("type")
+        printd(f"{Fore.GREEN}{Style.BRIGHT}🖥️ {Fore.GREEN}{msg_json}{Style.RESET_ALL}")
     else:
-        printd(f'{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg_json}{Style.RESET_ALL}')
+        printd(f"{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg_json}{Style.RESET_ALL}")
+
 
 async def function_message(msg):
-
     if isinstance(msg, dict):
-        printd(f'{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}')
+        printd(f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}")
         return
 
-    if msg.startswith('Success: '):
-        printd(f'{Fore.RED}{Style.BRIGHT}⚡🟢 [function] {Fore.RED}{msg}{Style.RESET_ALL}')
-    elif msg.startswith('Error: '):
-        printd(f'{Fore.RED}{Style.BRIGHT}⚡🔴 [function] {Fore.RED}{msg}{Style.RESET_ALL}')
-    elif msg.startswith('Running '):
+    if msg.startswith("Success: "):
+        printd(
+            f"{Fore.RED}{Style.BRIGHT}⚡🟢 [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+        )
+    elif msg.startswith("Error: "):
+        printd(
+            f"{Fore.RED}{Style.BRIGHT}⚡🔴 [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+        )
+    elif msg.startswith("Running "):
         if DEBUG:
-            printd(f'{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}')
+            printd(
+                f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+            )
         else:
-            if 'memory' in msg:
-                match = re.search(r'Running (\w+)\((.*)\)', msg)
+            if "memory" in msg:
+                match = re.search(r"Running (\w+)\((.*)\)", msg)
                 if match:
                     function_name = match.group(1)
                     function_args = match.group(2)
-                    print(f'{Fore.RED}{Style.BRIGHT}⚡🧠 [function] {Fore.RED}updating memory with {function_name}{Style.RESET_ALL}:')
+                    print(
+                        f"{Fore.RED}{Style.BRIGHT}⚡🧠 [function] {Fore.RED}updating memory with {function_name}{Style.RESET_ALL}:"
+                    )
                     try:
                         msg_dict = eval(function_args)
-                        if function_name == 'archival_memory_search':
-                            print(f'{Fore.RED}\tquery: {msg_dict["query"]}, page: {msg_dict["page"]}')
+                        if function_name == "archival_memory_search":
+                            print(
+                                f'{Fore.RED}\tquery: {msg_dict["query"]}, page: {msg_dict["page"]}'
+                            )
                         else:
-                            print(f'{Fore.RED}{Style.BRIGHT}\t{Fore.RED} {msg_dict["old_content"]}\n\t{Fore.GREEN}→ {msg_dict["new_content"]}')
+                            print(
+                                f'{Fore.RED}{Style.BRIGHT}\t{Fore.RED} {msg_dict["old_content"]}\n\t{Fore.GREEN}→ {msg_dict["new_content"]}'
+                            )
                     except Exception as e:
                         printd(e)
                         printd(msg_dict)
                         pass
                 else:
                     printd(f"Warning: did not recognize function message")
-                    printd(f'{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}')
-            elif 'send_message' in msg:
+                    printd(
+                        f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+                    )
+            elif "send_message" in msg:
                 # ignore in debug mode
                 pass
             else:
-                printd(f'{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}')
+                printd(
+                    f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+                )
     else:
         try:
             msg_dict = json.loads(msg)
             if "status" in msg_dict and msg_dict["status"] == "OK":
-                printd(f'{Fore.GREEN}{Style.BRIGHT}⚡ [function] {Fore.GREEN}{msg}{Style.RESET_ALL}')
+                printd(
+                    f"{Fore.GREEN}{Style.BRIGHT}⚡ [function] {Fore.GREEN}{msg}{Style.RESET_ALL}"
+                )
         except Exception:
             printd(f"Warning: did not recognize function message {type(msg)} {msg}")
-            printd(f'{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}')
+            printd(
+                f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+            )
+
 
 async def print_messages(message_sequence):
     for msg in message_sequence:
-        role = msg['role']
-        content = msg['content']
+        role = msg["role"]
+        content = msg["content"]
 
-        if role == 'system':
+        if role == "system":
             await system_message(content)
-        elif role == 'assistant':
+        elif role == "assistant":
             # Differentiate between internal monologue, function calls, and messages
-            if msg.get('function_call'):
+            if msg.get("function_call"):
                 if content is not None:
                     await internal_monologue(content)
-                await function_message(msg['function_call'])
+                await function_message(msg["function_call"])
                 # assistant_message(content)
             else:
                 await internal_monologue(content)
-        elif role == 'user':
+        elif role == "user":
             await user_message(content)
-        elif role == 'function':
+        elif role == "function":
             await function_message(content)
         else:
-            print(f'Unknown role: {content}')
+            print(f"Unknown role: {content}")
+
 
 async def print_messages_simple(message_sequence):
     for msg in message_sequence:
-        role = msg['role']
-        content = msg['content']
+        role = msg["role"]
+        content = msg["content"]
 
-        if role == 'system':
+        if role == "system":
             await system_message(content)
-        elif role == 'assistant':
+        elif role == "assistant":
             await assistant_message(content)
-        elif role == 'user':
+        elif role == "user":
             await user_message(content, raw=True)
         else:
-            print(f'Unknown role: {content}')
+            print(f"Unknown role: {content}")
+
 
 async def print_messages_raw(message_sequence):
     for msg in message_sequence:

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import pickle
 import readline
 
 from rich.console import Console
+
 console = Console()
 
 import interface  # for printing to terminal
@@ -18,25 +19,68 @@ import memgpt.presets as presets
 import memgpt.constants as constants
 import memgpt.personas.personas as personas
 import memgpt.humans.humans as humans
-from memgpt.persistence_manager import InMemoryStateManager, InMemoryStateManagerWithPreloadedArchivalMemory, InMemoryStateManagerWithFaiss
+from memgpt.persistence_manager import (
+    InMemoryStateManager,
+    InMemoryStateManagerWithPreloadedArchivalMemory,
+    InMemoryStateManagerWithFaiss,
+)
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string("persona", default=None, required=False, help="Specify persona")
 flags.DEFINE_string("human", default=None, required=False, help="Specify human")
-flags.DEFINE_string("model", default=constants.DEFAULT_MEMGPT_MODEL, required=False, help="Specify the LLM model")
-flags.DEFINE_boolean("first", default=False, required=False, help="Use -first to send the first message in the sequence")
-flags.DEFINE_boolean("debug", default=False, required=False, help="Use -debug to enable debugging output")
-flags.DEFINE_boolean("no_verify", default=False, required=False, help="Bypass message verification")
-flags.DEFINE_string("archival_storage_faiss_path", default="", required=False, help="Specify archival storage with FAISS index to load (a folder with a .index and .json describing documents to be loaded)")
-flags.DEFINE_string("archival_storage_files", default="", required=False, help="Specify files to pre-load into archival memory (glob pattern)")
-flags.DEFINE_string("archival_storage_files_compute_embeddings", default="", required=False, help="Specify files to pre-load into archival memory (glob pattern), and compute embeddings over them")
-flags.DEFINE_string("archival_storage_sqldb", default="", required=False, help="Specify SQL database to pre-load into archival memory")
+flags.DEFINE_string(
+    "model",
+    default=constants.DEFAULT_MEMGPT_MODEL,
+    required=False,
+    help="Specify the LLM model",
+)
+flags.DEFINE_boolean(
+    "first",
+    default=False,
+    required=False,
+    help="Use -first to send the first message in the sequence",
+)
+flags.DEFINE_boolean(
+    "debug", default=False, required=False, help="Use -debug to enable debugging output"
+)
+flags.DEFINE_boolean(
+    "no_verify", default=False, required=False, help="Bypass message verification"
+)
+flags.DEFINE_string(
+    "archival_storage_faiss_path",
+    default="",
+    required=False,
+    help="Specify archival storage with FAISS index to load (a folder with a .index and .json describing documents to be loaded)",
+)
+flags.DEFINE_string(
+    "archival_storage_files",
+    default="",
+    required=False,
+    help="Specify files to pre-load into archival memory (glob pattern)",
+)
+flags.DEFINE_string(
+    "archival_storage_files_compute_embeddings",
+    default="",
+    required=False,
+    help="Specify files to pre-load into archival memory (glob pattern), and compute embeddings over them",
+)
+flags.DEFINE_string(
+    "archival_storage_sqldb",
+    default="",
+    required=False,
+    help="Specify SQL database to pre-load into archival memory",
+)
 # Support for Azure OpenAI (see: https://github.com/openai/openai-python#microsoft-azure-endpoints)
-flags.DEFINE_boolean("use_azure_openai", default=False, required=False, help="Use Azure OpenAI (requires additional environment variables)")
+flags.DEFINE_boolean(
+    "use_azure_openai",
+    default=False,
+    required=False,
+    help="Use Azure OpenAI (requires additional environment variables)",
+)
 
 
 def clear_line():
-    if os.name == 'nt':  # for windows
+    if os.name == "nt":  # for windows
         console.print("\033[A\033[K", end="")
     else:  # for linux
         sys.stdout.write("\033[2K\033[G")
@@ -44,9 +88,9 @@ def clear_line():
 
 
 def save(memgpt_agent):
-    filename = utils.get_local_time().replace(' ', '_').replace(':', '_')
+    filename = utils.get_local_time().replace(" ", "_").replace(":", "_")
     filename = f"{filename}.json"
-    filename = os.path.join('saved_state', filename)
+    filename = os.path.join("saved_state", filename)
     try:
         if not os.path.exists("saved_state"):
             os.makedirs("saved_state")
@@ -56,7 +100,7 @@ def save(memgpt_agent):
         print(f"Saving state to {filename} failed with: {e}")
 
     # save the persistence manager too
-    filename = filename.replace('.json', '.persistence.pickle')
+    filename = filename.replace(".json", ".persistence.pickle")
     try:
         memgpt_agent.persistence_manager.save(filename)
         print(f"Saved persistence manager to: {filename}")
@@ -66,8 +110,8 @@ def save(memgpt_agent):
 
 def load(memgpt_agent, filename):
     if filename is not None:
-        if filename[-5:] != '.json':
-            filename += '.json'
+        if filename[-5:] != ".json":
+            filename += ".json"
         try:
             memgpt_agent.load_from_json_file_inplace(filename)
             print(f"Loaded checkpoint {filename}")
@@ -75,8 +119,12 @@ def load(memgpt_agent, filename):
             print(f"Loading {filename} failed with: {e}")
     else:
         # Load the latest file
-        print(f"/load warning: no checkpoint specified, loading most recent checkpoint instead")
-        json_files = glob.glob("saved_state/*.json")  # This will list all .json files in the current directory.
+        print(
+            f"/load warning: no checkpoint specified, loading most recent checkpoint instead"
+        )
+        json_files = glob.glob(
+            "saved_state/*.json"
+        )  # This will list all .json files in the current directory.
 
         # Check if there are any json files.
         if not json_files:
@@ -91,12 +139,16 @@ def load(memgpt_agent, filename):
                 print(f"Loading {filename} failed with: {e}")
 
     # need to load persistence manager too
-    filename = filename.replace('.json', '.persistence.pickle')
+    filename = filename.replace(".json", ".persistence.pickle")
     try:
-        memgpt_agent.persistence_manager = InMemoryStateManager.load(filename)  # TODO(fixme):for different types of persistence managers that require different load/save methods
+        memgpt_agent.persistence_manager = InMemoryStateManager.load(
+            filename
+        )  # TODO(fixme):for different types of persistence managers that require different load/save methods
         print(f"Loaded persistence manager from {filename}")
     except Exception as e:
-        print(f"/load warning: loading persistence manager from {filename} failed with: {e}")
+        print(
+            f"/load warning: loading persistence manager from {filename} failed with: {e}"
+        )
 
 
 async def main():
@@ -108,39 +160,63 @@ async def main():
 
     # Azure OpenAI support
     if FLAGS.use_azure_openai:
-        azure_openai_key = os.getenv('AZURE_OPENAI_KEY')
-        azure_openai_endpoint = os.getenv('AZURE_OPENAI_ENDPOINT')
-        azure_openai_version = os.getenv('AZURE_OPENAI_VERSION')
-        azure_openai_deployment = os.getenv('AZURE_OPENAI_DEPLOYMENT')
-        if None in [azure_openai_key, azure_openai_endpoint, azure_openai_version, azure_openai_deployment]:
-            print(f"Error: missing Azure OpenAI environment variables. Please see README section on Azure.")
+        azure_openai_key = os.getenv("AZURE_OPENAI_KEY")
+        azure_openai_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+        azure_openai_version = os.getenv("AZURE_OPENAI_VERSION")
+        azure_openai_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
+        if None in [
+            azure_openai_key,
+            azure_openai_endpoint,
+            azure_openai_version,
+            azure_openai_deployment,
+        ]:
+            print(
+                f"Error: missing Azure OpenAI environment variables. Please see README section on Azure."
+            )
             return
 
         import openai
+
         openai.api_type = "azure"
         openai.api_key = azure_openai_key
         openai.api_base = azure_openai_endpoint
         openai.api_version = azure_openai_version
         # deployment gets passed into chatcompletion
     else:
-        azure_openai_deployment = os.getenv('AZURE_OPENAI_DEPLOYMENT')
+        azure_openai_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
         if azure_openai_deployment is not None:
-            print(f"Error: AZURE_OPENAI_DEPLOYMENT should not be set if --use_azure_openai is False")
+            print(
+                f"Error: AZURE_OPENAI_DEPLOYMENT should not be set if --use_azure_openai is False"
+            )
             return
 
     if FLAGS.model != constants.DEFAULT_MEMGPT_MODEL:
-      interface.important_message(f"Warning - you are running MemGPT with {FLAGS.model}, which is not officially supported (yet). Expect bugs!")
+        interface.important_message(
+            f"Warning - you are running MemGPT with {FLAGS.model}, which is not officially supported (yet). Expect bugs!"
+        )
 
     if FLAGS.archival_storage_faiss_path:
-        index, archival_database = utils.prepare_archival_index(FLAGS.archival_storage_faiss_path)
+        index, archival_database = utils.prepare_archival_index(
+            FLAGS.archival_storage_faiss_path
+        )
         persistence_manager = InMemoryStateManagerWithFaiss(index, archival_database)
     elif FLAGS.archival_storage_files:
-        archival_database = utils.prepare_archival_index_from_files(FLAGS.archival_storage_files)
+        archival_database = utils.prepare_archival_index_from_files(
+            FLAGS.archival_storage_files
+        )
         print(f"Preloaded {len(archival_database)} chunks into archival memory.")
-        persistence_manager = InMemoryStateManagerWithPreloadedArchivalMemory(archival_database)
+        persistence_manager = InMemoryStateManagerWithPreloadedArchivalMemory(
+            archival_database
+        )
     elif FLAGS.archival_storage_files_compute_embeddings:
-        faiss_save_dir = await utils.prepare_archival_index_from_files_compute_embeddings(FLAGS.archival_storage_files_compute_embeddings)
-        interface.important_message(f"To avoid computing embeddings next time, replace --archival_storage_files_compute_embeddings={FLAGS.archival_storage_files_compute_embeddings} with\n\t --archival_storage_faiss_path={faiss_save_dir} (if your files haven't changed).")
+        faiss_save_dir = (
+            await utils.prepare_archival_index_from_files_compute_embeddings(
+                FLAGS.archival_storage_files_compute_embeddings
+            )
+        )
+        interface.important_message(
+            f"To avoid computing embeddings next time, replace --archival_storage_files_compute_embeddings={FLAGS.archival_storage_files_compute_embeddings} with\n\t --archival_storage_faiss_path={faiss_save_dir} (if your files haven't changed)."
+        )
         index, archival_database = utils.prepare_archival_index(faiss_save_dir)
         persistence_manager = InMemoryStateManagerWithFaiss(index, archival_database)
     else:
@@ -148,12 +224,22 @@ async def main():
 
     # Moved defaults out of FLAGS so that we can dynamically select the default persona based on model
     chosen_human = FLAGS.human if FLAGS.human is not None else humans.DEFAULT
-    chosen_persona = FLAGS.persona if FLAGS.persona is not None else (personas.GPT35_DEFAULT if 'gpt-3.5' in FLAGS.model else personas.DEFAULT)
+    chosen_persona = (
+        FLAGS.persona
+        if FLAGS.persona is not None
+        else (personas.GPT35_DEFAULT if "gpt-3.5" in FLAGS.model else personas.DEFAULT)
+    )
 
-    memgpt_agent = presets.use_preset(presets.DEFAULT, FLAGS.model, personas.get_persona_text(chosen_persona), humans.get_human_text(chosen_human), interface, persistence_manager)
+    memgpt_agent = presets.use_preset(
+        presets.DEFAULT,
+        FLAGS.model,
+        personas.get_persona_text(chosen_persona),
+        humans.get_human_text(chosen_human),
+        interface,
+        persistence_manager,
+    )
     print_messages = interface.print_messages
     await print_messages(memgpt_agent.messages)
-
 
     counter = 0
     user_input = None
@@ -179,18 +265,19 @@ async def main():
         return
 
     if not USER_GOES_FIRST:
-        console.input('[bold cyan]Hit enter to begin (will request first MemGPT message)[/bold cyan]')
+        console.input(
+            "[bold cyan]Hit enter to begin (will request first MemGPT message)[/bold cyan]"
+        )
         clear_line()
         print()
 
     while True:
         if not skip_next_user_input and (counter > 0 or USER_GOES_FIRST):
-
             # Ask for user input
             user_input = console.input("[bold cyan]Enter your message:[/bold cyan] ")
             clear_line()
 
-            if user_input.startswith('!'):
+            if user_input.startswith("!"):
                 print(f"Commands for CLI begin with '/' not '!'")
                 continue
 
@@ -201,8 +288,7 @@ async def main():
 
             # Handle CLI commands
             # Commands to not get passed as input to MemGPT
-            if user_input.startswith('/'):
-
+            if user_input.startswith("/"):
                 if user_input == "//":
                     print("Entering multiline mode, type // when done")
                     user_input_list = []
@@ -215,7 +301,9 @@ async def main():
                             user_input_list.append(user_input)
 
                     # pass multiline inputs to MemGPT
-                    user_message = system.package_user_message("\n".join(user_input_list))
+                    user_message = system.package_user_message(
+                        "\n".join(user_input_list)
+                    )
 
                 elif user_input.lower() == "/exit":
                     # autosave
@@ -223,12 +311,14 @@ async def main():
                     break
 
                 elif user_input.lower() == "/savechat":
-                    filename = utils.get_local_time().replace(' ', '_').replace(':', '_')
+                    filename = (
+                        utils.get_local_time().replace(" ", "_").replace(":", "_")
+                    )
                     filename = f"{filename}.pkl"
                     try:
                         if not os.path.exists("saved_chats"):
                             os.makedirs("saved_chats")
-                        with open(os.path.join('saved_chats', filename), 'wb') as f:
+                        with open(os.path.join("saved_chats", filename), "wb") as f:
                             pickle.dump(memgpt_agent.messages, f)
                             print(f"Saved messages to: {filename}")
                     except Exception as e:
@@ -239,7 +329,9 @@ async def main():
                     save(memgpt_agent=memgpt_agent)
                     continue
 
-                elif user_input.lower() == "/load" or user_input.lower().startswith("/load "):
+                elif user_input.lower() == "/load" or user_input.lower().startswith(
+                    "/load "
+                ):
                     command = user_input.strip().split()
                     filename = command[1] if len(command) > 1 else None
                     load(memgpt_agent=memgpt_agent, filename=filename)
@@ -265,17 +357,23 @@ async def main():
                     continue
 
                 elif user_input.lower() == "/model":
-                    if memgpt_agent.model == 'gpt-4':
-                        memgpt_agent.model = 'gpt-3.5-turbo'
-                    elif memgpt_agent.model == 'gpt-3.5-turbo':
-                        memgpt_agent.model = 'gpt-4'
+                    if memgpt_agent.model == "gpt-4":
+                        memgpt_agent.model = "gpt-3.5-turbo"
+                    elif memgpt_agent.model == "gpt-3.5-turbo":
+                        memgpt_agent.model = "gpt-4"
                     print(f"Updated model to:\n{str(memgpt_agent.model)}")
                     continue
 
-                elif user_input.lower() == "/pop" or user_input.lower().startswith("/pop "):
+                elif user_input.lower() == "/pop" or user_input.lower().startswith(
+                    "/pop "
+                ):
                     # Check if there's an additional argument that's an integer
                     command = user_input.strip().split()
-                    amount = int(command[1]) if len(command) > 1 and command[1].isdigit() else 2
+                    amount = (
+                        int(command[1])
+                        if len(command) > 1 and command[1].isdigit()
+                        else 2
+                    )
                     print(f"Popping last {amount} messages from stack")
                     for _ in range(min(amount, len(memgpt_agent.messages))):
                         memgpt_agent.messages.pop()
@@ -304,14 +402,23 @@ async def main():
         skip_next_user_input = False
 
         with console.status("[bold cyan]Thinking...") as status:
-            new_messages, heartbeat_request, function_failed, token_warning = await memgpt_agent.step(user_message, first_message=False, skip_verify=FLAGS.no_verify)
+            (
+                new_messages,
+                heartbeat_request,
+                function_failed,
+                token_warning,
+            ) = await memgpt_agent.step(
+                user_message, first_message=False, skip_verify=FLAGS.no_verify
+            )
 
             # Skip user inputs if there's a memory warning, function execution failed, or the agent asked for control
             if token_warning:
                 user_message = system.get_token_limit_warning()
                 skip_next_user_input = True
             elif function_failed:
-                user_message = system.get_heartbeat(constants.FUNC_FAILED_HEARTBEAT_MESSAGE)
+                user_message = system.get_heartbeat(
+                    constants.FUNC_FAILED_HEARTBEAT_MESSAGE
+                )
                 skip_next_user_input = True
             elif heartbeat_request:
                 user_message = system.get_heartbeat(constants.REQ_HEARTBEAT_MESSAGE)
@@ -322,7 +429,7 @@ async def main():
     print("Finished.")
 
 
-if __name__ ==  '__main__':
+if __name__ == "__main__":
 
     def run(argv):
         loop = asyncio.get_event_loop()

--- a/main.py
+++ b/main.py
@@ -235,7 +235,11 @@ async def main():
     else:
         cfg = await Config.config_init()
 
-    print("Running... [exit by typing '/exit']")
+    interface.important_message("Running... [exit by typing '/exit']")
+    if cfg.model != constants.DEFAULT_MEMGPT_MODEL:
+        interface.warning_message(
+            f"⛔️ Warning - you are running MemGPT with {cfg.model}, which is not officially supported (yet). Expect bugs!"
+        )
 
     # Azure OpenAI support
     if FLAGS.use_azure_openai:
@@ -268,11 +272,6 @@ async def main():
                 f"Error: AZURE_OPENAI_DEPLOYMENT should not be set if --use_azure_openai is False"
             )
             return
-
-    if cfg.model != constants.DEFAULT_MEMGPT_MODEL:
-        interface.important_message(
-            f"Warning - you are running MemGPT with {cfg.model}, which is not officially supported (yet). Expect bugs!"
-        )
 
     if cfg.archival_storage_index:
         persistence_manager = InMemoryStateManagerWithFaiss(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pybars3
 pymupdf
 python-dotenv
 pytz
+questionary
 rich
 tiktoken
 timezonefinder


### PR DESCRIPTION
Addresses #11.

* runs black formatter on `main.py` (should be another PR 🤫)
* uses questionary in lieu of flags (still supports flags as a legacy)
* introduces configuration files that are saved to disk and loaded in
* asks user if they want to autoload saved agent file (if exists)
* asks user if they want to regenerate embeddings
* no longer relies on readline

![cli-overhaul](https://github.com/cpacker/MemGPT/assets/5145763/2879ee56-0e6b-4d24-b9fd-66bf03894865)