### PR TITLE
powershell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ export OPENAI_API_KEY=YOUR_API_KEY
 set OPENAI_API_KEY=YOUR_API_KEY
 ```
 
+```sh
+# on Windows (PowerShell)
+$Env:OPENAI_API_KEY = "YOUR_API_KEY"
+```
+
 To run MemGPT for as a conversation agent in CLI mode, simply run `memgpt`:
 
 ```sh


### PR DESCRIPTION
From discord:

> Update the readme on the main repo for MS Powershell (had some trouble with environment variable)
> Powershell has a different way to set the environment variables it's like $Env:OPENAI_API_KEY = 'your_api_key'
> Space is also important. Maybe add a second line for windows powershell.... Seems windows try to force users to use powershell more often. Nothing major but I needed to look it up

