### PR TITLE
Retry acompletions_with_backoff for local LLMs

### DIFF
--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -108,13 +108,13 @@ def aretry_with_exponential_backoff(
 async def acompletions_with_backoff(**kwargs):
     # Local model
     if HOST_TYPE is not None:
-        retry_count = 5 # Retry up to five times
-        for i in range(1, retry_count):
+        retry_count = 5  # Retry up to five times
+        for i in range(1, retry_count + 1):
             try:
                 return await get_chat_completion(**kwargs)
             except Exception as e:
                 print(f"Failed to get a valid response on attempt: {i}\n{str(e)}")
-                if i <= retry_count:
+                if i < retry_count:
                     pass
                 else:
                     raise e

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -108,7 +108,11 @@ def aretry_with_exponential_backoff(
 async def acompletions_with_backoff(**kwargs):
     # Local model
     if HOST_TYPE is not None:
-        return await get_chat_completion(**kwargs)
+        for i in range(5):  # Retry up to five times
+            try:
+                return await get_chat_completion(**kwargs)
+            except Exception as e:
+                raise e
 
     # OpenAI / Azure model
     else:

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -108,11 +108,16 @@ def aretry_with_exponential_backoff(
 async def acompletions_with_backoff(**kwargs):
     # Local model
     if HOST_TYPE is not None:
-        for i in range(5):  # Retry up to five times
+        retry_count = 5 # Retry up to five times
+        for i in range(1, retry_count):
             try:
                 return await get_chat_completion(**kwargs)
             except Exception as e:
-                raise e
+                print(f"Failed to get a valid response on attempt: {i}\n{str(e)}")
+                if i <= retry_count:
+                    pass
+                else:
+                    raise e
 
     # OpenAI / Azure model
     else:


### PR DESCRIPTION
Retry the acompletions_with_backoff method when the local LLM raises an exception. For example get_chat_completion often fails to produce a valid JSON response. Since models aren't very deterministic for a random seed, even a suboptimal model/configuration will typically generate a passable response within a few retries. Otherwise, we re-raise the error. This change results in a more user-friendly experience using local LLMs and provides an opportunity to get more debugging info while the application is running