### PR TITLE
hotfix for broken sync agent code

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -1,3 +1,5 @@
+import asyncio
+import inspect
 import datetime
 import pickle
 import math
@@ -152,6 +154,14 @@ async def get_ai_reply_async(
 
     except Exception as e:
         raise e
+
+
+# Assuming function_to_call is either sync or async
+async def call_function(function_to_call, **function_args):
+    if inspect.iscoroutinefunction(function_to_call):
+        return await function_to_call(**function_args)
+    else:
+        return function_to_call(**function_args)
 
 
 class Agent(object):
@@ -814,7 +824,7 @@ class AgentAsync(Agent):
             # Failure case 3: function failed during execution
             await self.interface.function_message(f"Running {function_name}({function_args})")
             try:
-                function_response_string = await function_to_call(**function_args)
+                function_response_string = await call_function(function_to_call, **function_args)
                 function_response = package_function_response(True, function_response_string)
                 function_failed = False
             except Exception as e:


### PR DESCRIPTION
Fix for bug introduced in #156 that broke all sync function calling in the AsyncAgent (see https://github.com/cpacker/MemGPT/issues/162#issue-1966587329).

Fix is pretty broad, basically checks in real-time if the function to run is async or not. Might want to revert to something cleaner later.