### PR TITLE
Allow MemGPT to read/write text files + make HTTP requests

### DIFF
--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -445,7 +445,7 @@ async def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, legacy=
                     continue
 
                 elif user_input.lower() == "/dump":
-                    await print_messages(memgpt_agent.messages)
+                    await memgpt.interface.print_messages(memgpt_agent.messages)
                     continue
 
                 elif user_input.lower() == "/dumpraw":
@@ -453,7 +453,7 @@ async def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, legacy=
                     continue
 
                 elif user_input.lower() == "/dump1":
-                    await print_messages(memgpt_agent.messages[-1])
+                    await memgpt.interface.print_messages(memgpt_agent.messages[-1])
                     continue
 
                 elif user_input.lower() == "/memory":

--- a/memgpt/presets.py
+++ b/memgpt/presets.py
@@ -45,7 +45,7 @@ def use_preset(preset_name, agent_config, model, persona, human, interface, pers
             first_message_verify_mono=True if "gpt-4" in model else False,
         )
 
-    if preset_name == "memgpt_chat_sync":  # TODO: remove me after we move the CLI to AgentSync
+    elif preset_name == "memgpt_chat_sync":  # TODO: remove me after we move the CLI to AgentSync
         functions = [
             "send_message",
             "pause_heartbeats",

--- a/memgpt/presets.py
+++ b/memgpt/presets.py
@@ -77,5 +77,41 @@ def use_preset(preset_name, agent_config, model, persona, human, interface, pers
             first_message_verify_mono=True if "gpt-4" in model else False,
         )
 
+    elif preset_name == "memgpt_extras":
+        functions = [
+            "send_message",
+            "pause_heartbeats",
+            "core_memory_append",
+            "core_memory_replace",
+            "conversation_search",
+            "conversation_search_date",
+            "archival_memory_insert",
+            "archival_memory_search",
+            # extra for read/write to files
+            "read_from_text_file",
+            "append_to_text_file",
+            # internet access
+            "http_request",
+        ]
+        available_functions = [v for k, v in gpt_functions.FUNCTIONS_CHAINING.items() if k in functions]
+        printd(f"Available functions:\n", [x["name"] for x in available_functions])
+        assert len(functions) == len(available_functions)
+
+        if "gpt-3.5" in model:
+            # use a different system message for gpt-3.5
+            preset_name = "memgpt_gpt35_extralong"
+
+        return AgentAsync(
+            model=model,
+            system=gpt_system.get_system_text("memgpt_chat"),
+            functions=available_functions,
+            interface=interface,
+            persistence_manager=persistence_manager,
+            persona_notes=persona,
+            human_notes=human,
+            # gpt-3.5-turbo tends to omit inner monologue, relax this requirement for now
+            first_message_verify_mono=True if "gpt-4" in model else False,
+        )
+
     else:
         raise ValueError(preset_name)

--- a/memgpt/prompts/gpt_functions.py
+++ b/memgpt/prompts/gpt_functions.py
@@ -235,4 +235,74 @@ FUNCTIONS_CHAINING = {
             "required": ["name", "query", "page", "request_heartbeat"],
         },
     },
+    "read_from_text_file": {
+        "name": "read_from_text_file",
+        "description": "Read lines from a text file.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "The name of the file to read.",
+                },
+                "line_start": {
+                    "type": "integer",
+                    "description": "Line to start reading from.",
+                },
+                "num_lines": {
+                    "type": "integer",
+                    "description": "How many lines to read (defaults to 1).",
+                },
+                "request_heartbeat": {
+                    "type": "boolean",
+                    "description": FUNCTION_PARAM_DESCRIPTION_REQ_HEARTBEAT,
+                },
+            },
+            "required": ["filename", "line_start", "request_heartbeat"],
+        },
+    },
+    "append_to_text_file": {
+        "name": "append_to_text_file",
+        "description": "Append to a text file.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "The name of the file to read.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to append to the file.",
+                },
+                "request_heartbeat": {
+                    "type": "boolean",
+                    "description": FUNCTION_PARAM_DESCRIPTION_REQ_HEARTBEAT,
+                },
+            },
+            "required": ["filename", "content", "request_heartbeat"],
+        },
+    },
+    "archival_memory_search": {
+        "name": "archival_memory_search",
+        "description": "Search archival memory using semantic (embedding-based) search.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "String to search for.",
+                },
+                "page": {
+                    "type": "integer",
+                    "description": "Allows you to page through results. Only use on a follow-up query. Defaults to 0 (first page).",
+                },
+                "request_heartbeat": {
+                    "type": "boolean",
+                    "description": FUNCTION_PARAM_DESCRIPTION_REQ_HEARTBEAT,
+                },
+            },
+            "required": ["name", "query", "page", "request_heartbeat"],
+        },
+    },
 }

--- a/memgpt/prompts/gpt_functions.py
+++ b/memgpt/prompts/gpt_functions.py
@@ -283,26 +283,30 @@ FUNCTIONS_CHAINING = {
             "required": ["filename", "content", "request_heartbeat"],
         },
     },
-    "archival_memory_search": {
-        "name": "archival_memory_search",
-        "description": "Search archival memory using semantic (embedding-based) search.",
+    "http_request": {
+        "name": "http_request",
+        "description": "Generates an HTTP request and returns the response.",
         "parameters": {
             "type": "object",
             "properties": {
-                "query": {
+                "method": {
                     "type": "string",
-                    "description": "String to search for.",
+                    "description": "The HTTP method (e.g., 'GET', 'POST').",
                 },
-                "page": {
-                    "type": "integer",
-                    "description": "Allows you to page through results. Only use on a follow-up query. Defaults to 0 (first page).",
+                "url": {
+                    "type": "string",
+                    "description": "The URL for the request",
+                },
+                "payload": {
+                    "type": "string",
+                    "description": "A JSON string representing the request payload.",
                 },
                 "request_heartbeat": {
                     "type": "boolean",
                     "description": FUNCTION_PARAM_DESCRIPTION_REQ_HEARTBEAT,
                 },
             },
-            "required": ["name", "query", "page", "request_heartbeat"],
+            "required": ["method", "url", "request_heartbeat"],
         },
     },
 }

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -154,7 +154,7 @@ def chunk_file(file, tkns_per_chunk=300, model="gpt-4"):
     encoding = tiktoken.encoding_for_model(model)
 
     if file.endswith(".db"):
-        return # can't read the sqlite db this way, will get handled in main.py
+        return  # can't read the sqlite db this way, will get handled in main.py
 
     with open(file, "r") as f:
         if file.endswith(".pdf"):


### PR DESCRIPTION
Addresses #26 

---

TODO

- [x] Allow toggling of preset from CLI (right now it's hardcoded)

---

## Example with MemGPT launching HTTP requests

<img width="1019" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/b386eee2-5fc8-43ba-b915-4547d132336c">

---

## Example with MemGPT reading / writing from a shared .txt file

<img width="1017" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/76224591-22a3-4ffd-973e-277cb1da4f88">

```sh
$ cat notes.txt
I will tell you a secret
```

Modify the file, then check if MemGPT can read the updated file:

```sh
$ echo "I like dogs" >> notes.txt
$ cat notes.txt
I will tell you a secret
I like dogs
```

MemGPT can successfully read from the updated file (after some prodding to read more lines):

<img width="1017" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/5730045d-6181-45e0-bd99-4d3935e50b32">

---
