### PR TITLE
Allow recursive blobs

### DIFF
--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -137,13 +137,13 @@ def read_in_rows_csv(file_object, chunk_size):
 
 def prepare_archival_index_from_files(glob_pattern, tkns_per_chunk=300, model="gpt-4"):
     encoding = tiktoken.encoding_for_model(model)
-    files = glob.glob(glob_pattern)
+    files = glob.glob(glob_pattern, recursive=True)
     return chunk_files(files, tkns_per_chunk, model)
 
 
 def total_bytes(pattern):
     total = 0
-    for filename in glob.glob(pattern):
+    for filename in glob.glob(pattern, recursive=True):
         if os.path.isfile(filename):  # ensure it's a file and not a directory
             total += os.path.getsize(filename)
     return total

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -260,7 +260,7 @@ async def prepare_archival_index_from_files_compute_embeddings(
     model="gpt-4",
     embeddings_model="text-embedding-ada-002",
 ):
-    files = sorted(glob.glob(glob_pattern))
+    files = sorted(glob.glob(glob_pattern, recursive=True))
     save_dir = os.path.join(
         MEMGPT_DIR,
         "archival_index_from_files_" + get_local_time().replace(" ", "_").replace(":", "_"),


### PR DESCRIPTION
This should allow searching for file types instead of having to flatten things like repositories before embedding files types. This should be useful for things like creating embeddings for all markdown or all python files in a repository. 

Previous behavior:
```
MemGPT % python main.py --archival_storage_files_compute_embeddings="**/*.py" --persona=memgpt_doc --human=basic
⚙️ Using legacy command line arguments.
memgpt_doc gpt-4 ('memgpt_doc', 'memgpt/personas/examples')
gpt-4
('memgpt_doc', 'memgpt/personas/examples')
('basic', 'memgpt/humans/examples')
Computing embeddings over 15 files. This will cost ~$0.01. Continue? [y/n] 
```
New behavior:
```
MemGPT % python main.py --archival_storage_files_compute_embeddings="**/*.py" --persona=memgpt_doc --human=basic
⚙️ Using legacy command line arguments.
memgpt_doc gpt-4 ('memgpt_doc', 'memgpt/personas/examples')
gpt-4
('memgpt_doc', 'memgpt/personas/examples')
('basic', 'memgpt/humans/examples')
Computing embeddings over 45 files. This will cost ~$0.01. Continue? [y/n]```