### PR TITLE
Adding max_new_tokens fixed the problem with partial JSON

### DIFF
--- a/memgpt/local_llm/webui/settings.py
+++ b/memgpt/local_llm/webui/settings.py
@@ -9,5 +9,6 @@ SIMPLE = {
         # '\n#',
         # '\n\n\n',
     ],
-    "truncation_length": 4096,  # assuming llama2 models
+    "truncation_length": 4096,  # assuming llama2 models,
+    "max_new_tokens": 1000
 }


### PR DESCRIPTION
After setting the max_new_tokes double as high as the default, I did not experience more partial JSON replies from "dolphin-2.1-mistral-7b". I did get one that had line feeds in it, but could not reproduce that. I guess it would be enough actually remove all line feeds in the answer (as JSON should work without them)