### PR TITLE
I am unhappy to be forced to "your" timezone and AM/PM.

### DIFF
--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -132,6 +132,7 @@ def legacy_run(
     persona: str = typer.Option(None, help="Specify persona"),
     human: str = typer.Option(None, help="Specify human"),
     model: str = typer.Option(constants.DEFAULT_MEMGPT_MODEL, help="Specify the LLM model"),
+    timezone: str = typer.Option("", help="Sets the timezone (useful if the host is not in your local time)"),
     first: bool = typer.Option(False, "--first", help="Use --first to send the first message in the sequence"),
     debug: bool = typer.Option(False, "--debug", help="Use --debug to enable debugging output"),
     no_verify: bool = typer.Option(False, "--no_verify", help="Bypass message verification"),
@@ -167,6 +168,9 @@ def legacy_run(
     typer.secho("Warning: Running legacy run command. Run `memgpt run` instead.", fg=typer.colors.RED, bold=True)
     if not questionary.confirm("Continue with legacy CLI?", default=False).ask():
         return
+
+    if timezone != "":
+        os.environ["TZ"] = timezone
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -28,6 +28,7 @@ def count_tokens(s: str, model: str = "gpt-4") -> int:
 
 # DEBUG = True
 DEBUG = False
+AMPM = False
 
 
 def printd(*args, **kwargs):
@@ -46,32 +47,8 @@ def united_diff(str1, str2):
     return "".join(diff)
 
 
-def get_local_time_military():
-    # Get the current time in UTC
-    current_time_utc = datetime.now(pytz.utc)
-
-    # Convert to San Francisco's time zone (PST/PDT)
-    sf_time_zone = pytz.timezone("America/Los_Angeles")
-    local_time = current_time_utc.astimezone(sf_time_zone)
-
-    # You may format it as you desire
-    formatted_time = local_time.strftime("%Y-%m-%d %H:%M:%S %Z%z")
-
-    return formatted_time
-
-
 def get_local_time():
-    # Get the current time in UTC
-    current_time_utc = datetime.now(pytz.utc)
-
-    # Convert to San Francisco's time zone (PST/PDT)
-    sf_time_zone = pytz.timezone("America/Los_Angeles")
-    local_time = current_time_utc.astimezone(sf_time_zone)
-
-    # You may format it as you desire, including AM/PM
-    formatted_time = local_time.strftime("%Y-%m-%d %I:%M:%S %p %Z%z")
-
-    return formatted_time
+    return datetime.now().astimezone().isoformat("T", timespec="seconds")
 
 
 def parse_json(string):


### PR DESCRIPTION
- Timezone is now an argument (use --timezone="America/Los_Angeles" for the old behaviour.
- The time format is RFC3999 (without microseconds) which is a good format for "the world". I think it is better to not push the AM/PM system to the rest of the world.