### PR TITLE
Gracefully catch errors when running agent.step()

### DIFF
--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -534,9 +534,9 @@ async def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, legacy=
                         user_message = system.get_heartbeat(constants.REQ_HEARTBEAT_MESSAGE)
                         skip_next_user_input = True
             except Exception as e:
-                print("An exception ocurred when running step(): ")
+                print("An exception ocurred when running agent.step(): ")
                 traceback.print_exc()
-                retry = await questionary.confirm("Retry step()?").ask_async()
+                retry = await questionary.confirm("Retry agent.step()?").ask_async()
                 if not retry:
                     break
 


### PR DESCRIPTION
We don't want exceptions from agent.step() to cause the CLI to exit and irrevocably lose conversation history. 

- Asks user if they want to retry upon failed step()
- If user answers no, they are sent back to providing user input
<img width="1217" alt="image" src="https://github.com/cpacker/MemGPT/assets/5145763/a857dbbf-1523-4627-9ed9-727a79dc226d">
