### PR TITLE
Patch runtime error with personas

### DIFF
--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -229,7 +229,7 @@ async def main(
         memgpt_persona = persona
         if memgpt_persona is None:
             memgpt_persona = (
-                personas.GPT35_DEFAULT if "gpt-3.5" in model else personas.DEFAULT_PRESET,
+                personas.GPT35_DEFAULT if "gpt-3.5" in model else personas.DEFAULT,
                 None,  # represents the personas dir in pymemgpt package
             )
         else:

--- a/tests/test_load_archival.py
+++ b/tests/test_load_archival.py
@@ -100,7 +100,7 @@ def test_load_database():
 
     # create agents with defaults
     agent_config = AgentConfig(
-        persona=personas.DEFAULT_PRESET,
+        persona=personas.DEFAULT,
         human=humans.DEFAULT,
         model=DEFAULT_MEMGPT_MODEL,
         data_source="tmp_hf_dataset",


### PR DESCRIPTION
Was incorrectly doing `personas.DEFAULT_PRESET`, typo should have been `personas.DEFAULT`

---

Link to comment: https://github.com/cpacker/MemGPT/discussions/67#discussioncomment-7438436

```sh
root@mx:/# memgpt --model airoboros-l2-70b-2.1
Warning: Running legacy run command. Run memgpt run instead.
? Continue with legacy CLI? Yes
⚙️ Using legacy command line arguments.
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /usr/local/lib/python3.10/site-packages/memgpt/main.py:169 in legacy_run │
│ │
│ 166 │ │ return │
│ 167 │ │
│ 168 │ loop = asyncio.get_event_loop() │
│ ❱ 169 │ loop.run_until_complete( │
│ 170 │ │ main( │
│ 171 │ │ │ persona, │
│ 172 │ │ │ human, │
│ │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │ archival_storage_faiss_path = '' │ │
│ │ archival_storage_files = '' │ │
│ │ archival_storage_files_compute_embeddings = '' │ │
│ │ archival_storage_sqldb = '' │ │
│ │ ctx = <click.core.Context object at 0x7f522181b6d0> │ │
│ │ debug = False │ │
│ │ first = False │ │
│ │ human = None │ │
│ │ loop = <_UnixSelectorEventLoop running=False │ │
│ │ closed=False debug=False> │ │
│ │ model = 'airoboros-l2-70b-2.1' │ │
│ │ no_verify = False │ │
│ │ persona = None │ │
│ │ use_azure_openai = False │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│ │
│ /usr/local/lib/python3.10/asyncio/base_events.py:649 in run_until_complete │
│ │
│ 646 │ │ if not future.done(): │
│ 647 │ │ │ raise RuntimeError('Event loop stopped before Future completed.') │
│ 648 │ │ │
│ ❱ 649 │ │ return future.result() │
│ 650 │ │
│ 651 │ def stop(self): │
│ 652 │ │ """Stop running the event loop. │
│ │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │ future = <Task finished name='Task-11' coro=<main() done, defined at │ │
│ │ /usr/local/lib/python3.10/site-packages/memgpt/main.py:186> │ │
│ │ exception=AttributeError("module 'memgpt.personas.personas' has no attribute │ │
│ │ 'DEFAULT_PRESET'")> │ │
│ │ new_task = True │ │
│ │ self = <_UnixSelectorEventLoop running=False closed=False debug=False> │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│ │
│ /usr/local/lib/python3.10/site-packages/memgpt/main.py:232 in main │
│ │
│ 229 │ │ memgpt_persona = persona │
│ 230 │ │ if memgpt_persona is None: │
│ 231 │ │ │ memgpt_persona = ( │
│ ❱ 232 │ │ │ │ personas.GPT35_DEFAULT if "gpt-3.5" in model else personas.DEFAULT_PRESE │
│ 233 │ │ │ │ None, # represents the personas dir in pymemgpt package │
│ 234 │ │ │ ) │
│ 235 │ │ else: │
│ │
│ ╭────────────────────────────── locals ──────────────────────────────╮ │
│ │ archival_storage_faiss_path = '' │ │
│ │ archival_storage_files = '' │ │
│ │ archival_storage_files_compute_embeddings = '' │ │
│ │ archival_storage_sqldb = '' │ │
│ │ azure_vars = [] │ │
│ │ debug = False │ │
│ │ first = False │ │
│ │ human = None │ │
│ │ memgpt_persona = None │ │
│ │ model = 'airoboros-l2-70b-2.1' │ │
│ │ no_verify = False │ │
│ │ persona = None │ │
│ │ use_azure_openai = False │ │
│ ╰────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: module 'memgpt.personas.personas' has no attribute 'DEFAULT_PRESET'


```