### PR TITLE
fix: LocalArchivalMemory prints ref_doc_info on if not using EmptyIndex

### DIFF
--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -736,5 +736,8 @@ class LocalArchivalMemory(ArchivalMemory):
         return self.search(query_string, count, start)
 
     def __repr__(self) -> str:
-        print(self.index.ref_doc_info)
-        return ""
+        if isinstance(self.index, EmptyIndex):
+            memory_str = "<empty>"
+        else:
+            memory_str = self.index.ref_doc_info
+        return f"\n### ARCHIVAL MEMORY ###" + f"\n{memory_str}"


### PR DESCRIPTION
Currently, if you run the /memory command the application breaks if the LocalArchivalMemory has no existing archival storage and defaults to the EmptyIndex. This is caused by EmptyIndex not having a ref_doc_info implementation and throwing an Exception when that is used to print the memory information to the console. This hot fix simply makes sure that we do not try to use the function if using EmptyIndex and instead prints a message to the console indicating an EmptyIndex is used.

This is just a hot fix and I feel like there's definitely ways to improve this, but this might be "good enough" for now to run the `/memory` command successfully again.

I am pretty new to the python game so please feel free to adjust this PR as needed.

Happy to learn more about LLamaIndex if you guys have any recommended resources for me to check out that would be awesome!