### PR TITLE
strip '/' and use osp.join (Windows support)

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -369,7 +369,7 @@ class Agent(object):
 
         # load state
         directory = agent_config.save_state_dir()
-        json_files = glob.glob(f"{directory}/*.json")  # This will list all .json files in the current directory.
+        json_files = glob.glob(os.path.join(directory, "*.json"))  # This will list all .json files in the current directory.
         if not json_files:
             print(f"/load error: no .json checkpoint files found")
             raise ValueError(f"Cannot load {agent_name}")

--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -37,7 +37,7 @@ model_choices = [
 
 @dataclass
 class MemGPTConfig:
-    config_path: str = f"{MEMGPT_DIR}/config"
+    config_path: str = os.path.join(MEMGPT_DIR, "config")
     anon_clientid: str = None
 
     # preset

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -99,9 +99,9 @@ def load(memgpt_agent, filename):
             print(f"Loading {filename} failed with: {e}")
     else:
         # Load the latest file
-        save_path = f"{constants.MEMGPT_DIR}/saved_state"
+        save_path = os.path.join(constants.MEMGPT_DIR, "saved_state")
         print(f"/load warning: no checkpoint specified, loading most recent checkpoint from {save_path} instead")
-        json_files = glob.glob(f"{save_path}/*.json")  # This will list all .json files in the current directory.
+        json_files = glob.glob(os.path.join(save_path, "*.json"))  # This will list all .json files in the current directory.
 
         # Check if there are any json files.
         if not json_files:

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -663,7 +663,7 @@ class LocalArchivalMemory(ArchivalMemory):
 
         # locate saved index
         if self.agent_config.data_source is not None:  # connected data source
-            directory = f"{MEMGPT_DIR}/archival/{self.agent_config.data_source}"
+            directory = os.path.join(MEMGPT_DIR, "archival", self.agent_config.data_source)
             assert os.path.exists(directory), f"Archival memory database {self.agent_config.data_source} does not exist"
         elif self.agent_config.name is not None:
             directory = agent_config.save_agent_index_dir()

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -376,7 +376,7 @@ def get_index(name, docs):
     print("Warning: get_index(docs) only supported for OpenAI")
 
     # check if directory exists
-    dir = f"{MEMGPT_DIR}/archival/{name}"
+    dir = os.path.join(MEMGPT_DIR, "archival", name)
     if os.path.exists(dir):
         confirm = typer.confirm(typer.style(f"Index with name {name} already exists -- re-index?", fg="yellow"), default=False)
         if not confirm:
@@ -435,7 +435,7 @@ def save_index(index, name):
     # TODO: load directory from config
     # TODO: save to vectordb/local depending on config
 
-    dir = f"{MEMGPT_DIR}/archival/{name}"
+    dir = os.pathjoin(MEMGPT_DIR, "archival", name)
 
     ## Avoid overwriting
     ## check if directory exists

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -435,7 +435,7 @@ def save_index(index, name):
     # TODO: load directory from config
     # TODO: save to vectordb/local depending on config
 
-    dir = os.pathjoin(MEMGPT_DIR, "archival", name)
+    dir = os.path.join(MEMGPT_DIR, "archival", name)
 
     ## Avoid overwriting
     ## check if directory exists

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -200,7 +200,7 @@ def chunk_files(files, tkns_per_chunk=300, model="gpt-4"):
     for file in files:
         timestamp = os.path.getmtime(file)
         formatted_time = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %I:%M:%S %p %Z%z")
-        file_stem = file.split("/")[-1]
+        file_stem = file.split(os.sep)[-1]
         chunks = [c for c in chunk_file(file, tkns_per_chunk, model)]
         for i, chunk in enumerate(chunks):
             archival_database.append(
@@ -215,7 +215,7 @@ def chunk_files(files, tkns_per_chunk=300, model="gpt-4"):
 def chunk_files_for_jsonl(files, tkns_per_chunk=300, model="gpt-4"):
     ret = []
     for file in files:
-        file_stem = file.split("/")[-1]
+        file_stem = file.split(os.sep)[-1]
         curr_file = []
         for chunk in chunk_file(file, tkns_per_chunk, model):
             curr_file.append(


### PR DESCRIPTION
Fixes bad path issues, from Discord:

> It looks like the os.sep is not being used in the path. 
> persistence.pickle failed with: [Errno 2] No such file or directory: 'C:\Users\xxx\.memgpt/saved_state\2023-11-03_04_57_10_AM_PDT-0700.persistence.pickle
> As you can see there is an error due to the forward slash being used instead of the back slash right after .memgpt directory


