### PR TITLE
FIx #261

### DIFF
--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -6,3 +6,10 @@ class DotDict(dict):
 
     def __setattr__(self, key, value):
         self[key] = value
+
+    #following methods necessary for pickling
+    def __getstate__(self):
+        return vars(self)
+
+    def __setstate__(self, state):
+        vars(self).update(state)

--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -7,7 +7,7 @@ class DotDict(dict):
     def __setattr__(self, key, value):
         self[key] = value
 
-    #following methods necessary for pickling
+    # following methods necessary for pickling
     def __getstate__(self):
         return vars(self)
 


### PR DESCRIPTION
Closes #261

pickle.dump was crashing due to custom class DotDict. Fix was to add __getstate__ and __setstate__ methods