### PR TITLE
Aligned code with README for using Azure embeddings to load documents

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -43,7 +43,7 @@ def configure():
         azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
         azure_version = os.getenv("AZURE_OPENAI_VERSION")
         azure_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
-        azure_embedding_deployment = os.getenv("AZURE_OPENAI_EMBEDDING_DEPLOYMENT")
+        azure_embedding_deployment = os.getenv("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT")
 
         if all([azure_key, azure_endpoint, azure_version]):
             print(f"Using Microsoft endpoint {azure_endpoint}.")


### PR DESCRIPTION
As mentioned in [issue 259](https://github.com/cpacker/MemGPT/issues/259), Azure embeddings were throwing an error. I believe the issue was that the README variable was `AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT` whereas code had `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` (note the 'S'). I corrected the code as I felt the plural was perhaps more factually correct, but the converse would too of course.

I tested memgpt in general, but to test the Azure embeddings I did the following ...

1. Set these environment variables ...

```
AZURE_OPENAI_KEY=<KEY>
AZURE_OPENAI_ENDPOINT=<ENDPOINT>
AZURE_OPENAI_VERSION=2023-07-01-preview
AZURE_OPENAI_DEPLOYMENT=gpt-4
AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT=text-embedding-ada-002
OPENAI_API_KEY=<KEY>
```

Note: I had to set `OPENAI_API_KEY` for loading documents to work. Will raise a separate issue for that shortly.

2. Put a text document in subfolder `./data`
3. Ran the loader with `memgpt load directory --name hdx_dictionaries --input-dir ./data/dictionaries --recursive`. Note, the `--recursive` is a temporary workaround being fixed under PR [246](https://github.com/cpacker/MemGPT/pull/246).

Load now works successfully ...

```
loading data
done loading data
LLM is explicitly disabled. Using MockLLM.
LLM is explicitly disabled. Using MockLLM.
Parsing documents into nodes: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 81.62it/s]
Generating embeddings: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:01<00:00,  9.36it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 107797.53it/s]
Saved local /Users/matthewharris/.memgpt/archival/hdx_dictionaries/nodes.pkl
```

