### PR TITLE
fix: import PostgresStorageConnector only if postgres is selected as …

### DIFF
--- a/memgpt/connectors/storage.py
+++ b/memgpt/connectors/storage.py
@@ -36,14 +36,18 @@ class Passage:
 class StorageConnector:
     @staticmethod
     def get_storage_connector(name: Optional[str] = None, agent_config: Optional[AgentConfig] = None):
-        from memgpt.connectors.db import PostgresStorageConnector
-        from memgpt.connectors.local import LocalStorageConnector
-
         storage_type = MemGPTConfig.load().archival_storage_type
+
         if storage_type == "local":
+            from memgpt.connectors.local import LocalStorageConnector
+
             return LocalStorageConnector(name=name, agent_config=agent_config)
+
         elif storage_type == "postgres":
+            from memgpt.connectors.db import PostgresStorageConnector
+
             return PostgresStorageConnector(name=name, agent_config=agent_config)
+
         else:
             raise NotImplementedError(f"Storage type {storage_type} not implemented")
 


### PR DESCRIPTION
…storage type

currently there is a requirements issue that makes memgpt crash if the necessary postgres libraries are missing. This change lets people select local as storage type to continue to use memgpt locally without postgres and not run into these issues.

This allows us to fix the requirements necessary for using Postgres as a backend while local memgpt usage is still possible