### PR TITLE
Bug fix grammar_name not being defined causes a crash

### DIFF
--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -29,6 +29,7 @@ def get_chat_completion(
 ):
     global has_shown_warning
     grammar = None
+    grammar_name = None
 
     if HOST is None:
         raise ValueError(f"The OPENAI_API_BASE environment variable is not defined. Please set it in your environment.")


### PR DESCRIPTION
grammar_name has to be defined, if not there's an issue with line 92.
Without that, when starting local llm with webui and model e.g. airoboros-l2-70b-2.1 it will crash.
