### PR TITLE
I added some json repairs that helped me with malformed messages

### DIFF
--- a/memgpt/local_llm/json_parser.py
+++ b/memgpt/local_llm/json_parser.py
@@ -138,8 +138,8 @@ def clean_json(raw_llm_output, messages=None, functions=None):
                 data = json.loads(raw_llm_output + "}}")
             except json.JSONDecodeError:
                 try:
-                    printd("trying adding \"}}")
-                    data = json.loads(raw_llm_output + "\"}}")
+                    printd('trying adding "}}')
+                    data = json.loads(raw_llm_output + '"}}')
                 except json.JSONDecodeError:
                     try:
                         repaired = repair_json_string(raw_llm_output)

--- a/memgpt/local_llm/json_parser.py
+++ b/memgpt/local_llm/json_parser.py
@@ -122,27 +122,29 @@ def repair_even_worse_json(json_string):
 
 
 def clean_json(raw_llm_output, messages=None, functions=None):
+    from memgpt.utils import printd
+
     """Try a bunch of hacks to parse the data coming out of the LLM"""
     try:
-        print("clean json runs:", raw_llm_output)
+        # printd("clean json runs:", raw_llm_output)
         data = json.loads(raw_llm_output)
     except json.JSONDecodeError:
         try:
-            print("trying adding }")
+            printd("trying adding }")
             data = json.loads(raw_llm_output + "}")
         except json.JSONDecodeError:
             try:
                 repaired = repair_json_string(raw_llm_output)
-                print("trying my repair json:", repaired)
+                printd("trying my repair json:", repaired)
                 data = json.loads(repaired)
             except json.JSONDecodeError:
                 try:
                     repaired = repair_json_string(raw_llm_output)
-                    print("trying my repair json:", repaired)
+                    printd("trying my repair json:", repaired)
                     data = json.loads(repaired)
                 except json.JSONDecodeError:
                     try:
-                        print("trying first_json")
+                        printd("trying first_json")
                         data = extract_first_json(raw_llm_output + "}")
                     except:
                         raise

--- a/memgpt/local_llm/json_parser.py
+++ b/memgpt/local_llm/json_parser.py
@@ -134,18 +134,26 @@ def clean_json(raw_llm_output, messages=None, functions=None):
             data = json.loads(raw_llm_output + "}")
         except json.JSONDecodeError:
             try:
-                repaired = repair_json_string(raw_llm_output)
-                printd("trying my repair json:", repaired)
-                data = json.loads(repaired)
+                printd("trying adding }}")
+                data = json.loads(raw_llm_output + "}}")
             except json.JSONDecodeError:
                 try:
-                    repaired = repair_json_string(raw_llm_output)
-                    printd("trying my repair json:", repaired)
-                    data = json.loads(repaired)
+                    printd("trying adding \"}}")
+                    data = json.loads(raw_llm_output + "\"}}")
                 except json.JSONDecodeError:
                     try:
-                        printd("trying first_json")
-                        data = extract_first_json(raw_llm_output + "}")
-                    except:
-                        raise
+                        repaired = repair_json_string(raw_llm_output)
+                        printd("trying repair_json_string:", repaired)
+                        data = json.loads(repaired)
+                    except json.JSONDecodeError:
+                        try:
+                            repaired = repair_even_worse_json(raw_llm_output)
+                            printd("trying repair_even_worse_json:", repaired)
+                            data = json.loads(repaired)
+                        except json.JSONDecodeError:
+                            try:
+                                printd("trying first_json")
+                                data = extract_first_json(raw_llm_output + "}")
+                            except:
+                                raise
     return data

--- a/memgpt/local_llm/json_parser.py
+++ b/memgpt/local_llm/json_parser.py
@@ -153,7 +153,7 @@ def clean_json(raw_llm_output, messages=None, functions=None):
                         except json.JSONDecodeError:
                             try:
                                 printd("trying first_json")
-                                data = extract_first_json(raw_llm_output + "}")
+                                data = extract_first_json(raw_llm_output + "}}")
                             except:
                                 raise
     return data

--- a/tests/test_json_parsers.py
+++ b/tests/test_json_parsers.py
@@ -1,0 +1,64 @@
+import json
+
+import memgpt.local_llm.json_parser as json_parser
+
+
+EXAMPLE_MISSING_CLOSING_BRACE = """{
+  "function": "send_message",
+  "params": {
+    "inner_thoughts": "Oops, I got their name wrong! I should apologize and correct myself.",
+    "message": "Sorry about that! I assumed you were Chad. Welcome, Brad! "
+  }
+"""
+
+EXAMPLE_BAD_TOKEN_END = """{
+  "function": "send_message",
+  "params": {
+    "inner_thoughts": "Oops, I got their name wrong! I should apologize and correct myself.",
+    "message": "Sorry about that! I assumed you were Chad. Welcome, Brad! "
+  }
+}<|>"""
+
+EXAMPLE_DOUBLE_JSON = """{
+  "function": "core_memory_append",
+  "params": {
+    "name": "human",
+    "content": "Brad, 42 years old, from Germany."
+  }
+}
+{
+  "function": "send_message",
+  "params": {
+    "message": "Got it! Your age and nationality are now saved in my memory."
+  }
+}
+"""
+
+EXAMPLE_HARD_LINE_FEEDS = """{
+  "function": "send_message",
+  "params": {
+    "message": "Let's create a list:
+- First, we can do X
+- Then, we can do Y!
+- Lastly, we can do Z :)"
+  }
+}
+"""
+
+
+def test_json_parsers():
+    """Try various broken JSON and check that the parsers can fix it"""
+
+    test_strings = [EXAMPLE_MISSING_CLOSING_BRACE, EXAMPLE_BAD_TOKEN_END, EXAMPLE_DOUBLE_JSON, EXAMPLE_HARD_LINE_FEEDS]
+
+    for string in test_strings:
+        try:
+            json.loads(string)
+            assert False, f"Test JSON string should have failed basic JSON parsing:\n{string}"
+        except:
+            print("String failed (expectedly)")
+            try:
+                json_parser.clean_json(string)
+            except:
+                f"Failed to repair test JSON string:\n{string}"
+                raise


### PR DESCRIPTION
There are two of them: The first will remove hard line feeds that appear in the message part because the model added those instead of escaped line feeds. This happens a lot in my experiments and that actually fixes them.

The second one is less tested and should handle the case that the model answers with multiple blocks of strings in quotes or even uses unescaped quotes. It should grab everything betwenn the message: " and the ending curly braces, escape them and makes it propper json that way.

Disclaimer: Both function were written with the help of ChatGPT-4 (I can't write much Python). I think the first one is quite solid but doubt that the second one is fully working. Maybe somebody with more Python skills than me (or with more time) has a better idea for this type of malformed replies.