### PR TITLE
Updated documentation for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ Now, you should be able to run `memgpt` from the command-line using the download
 
 If you are having dependency issues using `pip install -e .`, we recommend you install the package using Poetry (see below). Installing MemGPT from source using Poetry will ensure that you are using exact package versions that have been tested for the production build.
 
-## Installing from source (using Poetry)
+<details>
+ <summary>
+  <strong>Installing from source (using Poetry)</strong>
+ </summary>
 
 First, install Poetry using [the official instructions here](https://python-poetry.org/docs/#installing-with-the-official-installer).
 
@@ -123,6 +126,7 @@ git clone git@github.com:cpacker/MemGPT.git
 poetry shell
 poetry install
 ```
+</details>
 
 ## Support
 For issues and feature requests, please [open a GitHub issue](https://github.com/cpacker/MemGPT/issues) or message us on our `#support` channel on [Discord](https://discord.gg/9GEQrxmVyE)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See full documentation at: https://memgpt.readthedocs.io/
 
 ## Installing from source
 
-To install MemGPT from source, you can simply clone the repo:
+To install MemGPT from source, start by cloning the repo:
 ```sh
 git clone git@github.com:cpacker/MemGPT.git
 ```
@@ -109,7 +109,7 @@ Then navigate to the main `MemGPT` directory, and do:
 pip install -e .
 ```
 
-Now, you should be able to run `memgpt` from that command-line (using the downloaded source code).
+Now, you should be able to run `memgpt` from the command-line using the downloaded source code.
 
 If you are having dependency issues using `pip install -e .`, we recommend you install the package using Poetry (see below). Installing MemGPT from source using Poetry will ensure that you are using exact package versions that have been tested for the production build.
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,35 @@ You can run the following commands in the MemGPT CLI prompt:
 
 Once you exit the CLI with `/exit`, you can resume chatting with the same agent by specifying the agent name in `memgpt run --agent <NAME>`.
 
-## Documentation 
+## Documentation
 See full documentation at: https://memgpt.readthedocs.io/
+
+## Installing from source
+
+To install MemGPT from source, you can simply clone the repo:
+```sh
+git clone git@github.com:cpacker/MemGPT.git
+```
+
+Then navigate to the main `MemGPT` directory, and do:
+```sh
+pip install -e .
+```
+
+Now, you should be able to run `memgpt` from that command-line (using the downloaded source code).
+
+If you are having dependency issues using `pip install -e .`, we recommend you install the package using Poetry (see below). Installing MemGPT from source using Poetry will ensure that you are using exact package versions that have been tested for the production build.
+
+## Installing from source (using Poetry)
+
+First, install Poetry using [the official instructions here](https://python-poetry.org/docs/#installing-with-the-official-installer).
+
+Then, you can install MemGPT from source with:
+```sh
+git clone git@github.com:cpacker/MemGPT.git
+poetry shell
+poetry install
+```
 
 ## Support
 For issues and feature requests, please [open a GitHub issue](https://github.com/cpacker/MemGPT/issues) or message us on our `#support` channel on [Discord](https://discord.gg/9GEQrxmVyE)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,23 @@
 # Contributing
 
 ## Installing from source
+
+To install MemGPT from source, you can simply clone the repo:
+```sh
+git clone git@github.com:cpacker/MemGPT.git
+```
+
+Then navigate to the main `MemGPT` directory, and do:
+```sh
+pip install -e .
+```
+
+Now, you should be able to run `memgpt` from that command-line (using the downloaded source code).
+
+If you are having dependency issues using `pip install -e .`, we recommend you install the package using Poetry (see below). Installing MemGPT from source using Poetry will ensure that you are using exact package versions that have been tested for the production build.
+
+## Installing from source (using Poetry)
+
 First, install Poetry using [the official instructions here](https://python-poetry.org/docs/#installing-with-the-official-installer).
 
 Then, you can install MemGPT from source with:
@@ -9,15 +26,17 @@ git clone git@github.com:cpacker/MemGPT.git
 poetry shell
 poetry install
 ```
+
+### Formatting
+
+We welcome pull requests! Please run the formatter before submitting a pull request:
+```sh
+poetry run black . -l 140
+```
+
 We recommend installing pre-commit to ensure proper formatting during development:
 ```sh
 pip install pre-commit
 pre-commit install
 pre-commit run --all-files
-```
-
-### Formatting
-We welcome pull requests! Please run the formatter before submitting a pull request:
-```sh
-poetry run black . -l 140
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 ## Installing from source
 
-To install MemGPT from source, you can simply clone the repo:
+To install MemGPT from source, start by cloning the repo:
 ```sh
 git clone git@github.com:cpacker/MemGPT.git
 ```
@@ -12,7 +12,7 @@ Then navigate to the main `MemGPT` directory, and do:
 pip install -e .
 ```
 
-Now, you should be able to run `memgpt` from that command-line (using the downloaded source code).
+Now, you should be able to run `memgpt` from the command-line using the downloaded source code.
 
 If you are having dependency issues using `pip install -e .`, we recommend you install the package using Poetry (see below). Installing MemGPT from source using Poetry will ensure that you are using exact package versions that have been tested for the production build.
 


### PR DESCRIPTION
Linked to #358

---

- Make the recommended workflow clearly `pip install -e .` for building from source
  - (poetry install is the backup for when people have dependency issues)
- Add this recommendation to both the docs and a section in the main README