### PR TITLE
Simple docker.

### DIFF
--- a/db/Dockerfile.simple
+++ b/db/Dockerfile.simple
@@ -1,0 +1,87 @@
+# syntax = docker/dockerfile:1.6
+
+# Build a self-configuring postgres image with pgvector installed.
+# It has no dependencies except for the base image.
+
+# Build with:
+# docker build -t memgpt-db -f db/Dockerfile.simple .
+#
+# -t memgpt-db: tag the image with the name memgpt-db (tag defaults to :latest)
+# -f db/Dockerfile.simple: use the Dockerfile at db/Dockerfile.simple (this file)
+# .: build the image from the current directory, not really used.
+
+#
+# Run the first time with:
+# docker run -d --rm \
+#   --name memgpt-db \
+#   -p 5432:5432 \
+#   -e POSTGRES_PASSWORD=password \
+#   -v memgpt_db:/var/lib/postgresql/data \
+#   memgpt-db:latest
+#
+# -d: run in the background
+# --rm: remove the container when it exits
+# --name memgpt-db: name the container memgpt-db
+# -p 5432:5432: map port 5432 on the host to port 5432 in the container
+# -v memgpt_db:/var/lib/postgresql/data: map the volume memgpt_db to /var/lib/postgresql/data in the container
+# memgpt-db:latest: use the image memgpt-db:latest
+#
+# After the first time, you dod not need the POSTGRES_PASSWORD.
+# docker run -d --rm \
+#   --name memgpt-db \
+#   -p 5432:5432 \
+#   -v memgpt_db:/var/lib/postgresql/data \
+#   memgpt-db:latest
+
+# Rather than a docker volume (memgpt_db), you can use an absolute path to a directory on the host.
+#
+# You can stop the container with:
+#  docker stop memgpt-db
+#
+# You access the database with:
+# postgresql+pg8000://user:password@localhost:5432/db
+# where user, password, and db are the values you set in the init-memgpt.sql file,
+# all defaulting to 'memgpt'.
+
+# Version tags can be found here: https://hub.docker.com/r/ankane/pgvector/tags
+ARG PGVECTOR=v0.5.1
+# Set up a minimal postgres image
+FROM ankane/pgvector:${PGVECTOR}
+RUN sed -e 's/^    //' >/docker-entrypoint-initdb.d/01-initmemgpt.sql <<'EOF'
+    -- Title: Init MemGPT Database
+
+    -- Fetch the docker secrets, if they are available.
+    -- Otherwise fall back to environment variables, or hardwired 'memgpt'
+    \set db_user `([ -r /var/run/secrets/memgpt-user ] && cat /var/run/secrets/memgpt-user) || echo "${MEMGPT_USER:-memgpt}"`
+    \set db_password `([ -r /var/run/secrets/memgpt-password ] && cat /var/run/secrets/memgpt-password) || echo "${MEMGPT_PASSWORD:-memgpt}"`
+    \set db_name `([ -r /var/run/secrets/memgpt-db ] && cat /var/run/secrets/memgpt-db) || echo "${MEMGPT_DB:-memgpt}"`
+
+    CREATE USER :"db_user"
+        WITH PASSWORD :'db_password'
+        NOCREATEDB
+        NOCREATEROLE
+        ;
+
+    CREATE DATABASE :"db_name"
+        WITH
+        OWNER = :"db_user"
+        ENCODING = 'UTF8'
+        LC_COLLATE = 'en_US.utf8'
+        LC_CTYPE = 'en_US.utf8'
+        LOCALE_PROVIDER = 'libc'
+        TABLESPACE = pg_default
+        CONNECTION LIMIT = -1;
+
+    -- Set up our schema and extensions in our new database.
+    \c :"db_name"
+
+    CREATE SCHEMA :"db_name"
+        AUTHORIZATION :"db_user";
+
+    ALTER DATABASE :"db_name"
+        SET search_path TO :"db_name";
+
+    CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA :"db_name";
+
+    DROP SCHEMA IF EXISTS public CASCADE;
+EOF


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
If you aren't familiar with postgres (I was not, tho plenty of other DBs), it is hard to set up.

This PR is a single-file docker setup,  that results in a properly configured database.

1) build
2) run container
3) configure (default connection: postgres+pg8000://memgpt:memgpt@localhost:5432/memgpt)
4) run memgpt.

Data can be persisted in a docker volume or a directory on disk.

The commands in 1 and 2 could be packaged as simple scripts to save typing, or copy-pasted from the documentation.


**How to test**
Directions are in the file db/Docker.simple

**Have you tested this PR?**
Yes.

#### Build container:
```bash
simple-docker:~p/MemGPT$ docker build -f db/Dockerfile.simple -t pg-test .
[+] Building 1.8s (10/10) FINISHED           
…some build output elided…                                                                                                                                                                                                                                                                                                         
View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/8f9lupn6thwu27hyb3ypurpyt

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
```

#### Run container
```bash
simple-docker:~p/MemGPT$ docker run -d --rm \
   --name memgpt-db-test \
   -p 8888:5432 \
   -e POSTGRES_PASSWORD=password \
   -v memgpt_db_test:/var/lib/postgresql/data \
    pg-test:latest
2940174a5004ecdc3d7855231cc65c9aa9a1222347e2c593127f341a7b5a3601
```

#### Configure MemGPT:
```bash
simple-docker:~p/MemGPT$ python3 -m memgpt configure
? Do you want to enable MemGPT with Open AI? Yes
? Do you want to enable MemGPT with Azure? No
? Select default inference endpoint: openai
? Select default embedding endpoint: openai
? Select default preset: memgpt_chat
? Select default model (recommended: gpt-4): gpt-4
['sam_pov', 'memgpt_starter', 'memgpt_doc', 'sam_simple_pov_gpt35', 'sam']
? Select default persona: sam_pov
['cs_phd', 'basic']
? Select default human: cs_phd
? Select storage backend for archival data: postgres
? Enter postgres connection string (e.g. postgresql+pg8000://{user}:{password}@{ip}:5432/{database}): postgresql+pg8000://memgpt:memgpt@localhost:8888/memgpt
Saving config to /Users/rwk/.memgpt/config
archival storage postgres
```

#### Run MemGPT:
```bash
simple-docker:~p/MemGPT$ python3 -m memgpt run
? Would you like to select an existing agent? No
Creating new agent...
Created new agent agent_13.
Hit enter to begin (will request first MemGPT message)

💭 First interaction with the user. Exciting! I remember some of his interests, let's engage in a conversation about them. Formula 1, sailing, or his favorite restaurant? Let's keep it casual and start with Formula 1.
🤖 Hi Chad, good to see you! I hope your studies are going well, and you're finding some time to watch the latest Formula 1 races. Do you have a favorite driver or team?
> Enter your message: Hi. I am going to test your memory.
💭 Oh, a test. This should be interesting. I wonder what kind of memory he's thinking of. My recall memory? My core? Or my archival memory? It's time to engage, be attentive and make sure I respond accurately. Let's see where this goes.
🤖 Certainly, Chad. I'm ready for your test. What would you like me to remember or recall?
> Enter your message: /memorywarning
💭 Ah, conversation is reaching maximum length. It's time to make an important decision: what information from this conversation is worth preserving? I suppose the fact Chad was testing my memory should be stored. Let's use archival memory, since this test might have long term implications.
⚡🧠 [function] updating memory with archival_memory_insert
        → Chad initiated a memory test on 2023-11-09.
  0%|                                                                                                                                                                                                                                                                                                                                                 | 0/1 [00:00<?, ?it/s]
100%|########################################################################################################################################################################################################################################################################################################################################| 1/1 [00:00<00:00, 502.25it/s]

> Enter your message: Search your archival memory and tell me everything you find.
💭 Chad seems to be in a hurry to test the memory. I wonder what he expects to find, considering our interactions have been so brief thus far. Nonetheless, let's perform a search of the archival memory and see what we can find. Since this is a vague request, I should look for everything by simply inputting an asterisk "*" as my query, which should return all
entries.
⚡🧠 [function] updating memory with archival_memory_search
💭 Results retrieved. It seems the only entry in my archival memory is the one I recently stored about Chad initiating a memory test. Let's share this with him. Though, I hope he's not disappointed by the brevity of the information. Then again, it might not be the content but the process he's interested in testing.
🤖 In my archival memory, there is currently one entry: 'Chad initiated a memory test on 2023-11-09.'
> Enter your message: /exit
Finished.
```
#### Check DB Table:
```psql
simple-docker:~p/MemGPT$ docker exec -it  memgpt-db-test psql -U memgpt
psql (15.4 (Debian 15.4-2.pgdg120+1))
Type "help" for help.

memgpt-> \d
                     List of relations
 Schema |             Name             |   Type   | Owner
--------+------------------------------+----------+--------
 memgpt | memgpt_agent_agent_13        | table    | memgpt
 memgpt | memgpt_agent_agent_13_id_seq | sequence | memgpt
(2 rows)

memgpt-> \d memgpt_agent_agent_13
                                   Table "memgpt.memgpt_agent_agent_13"
  Column   |       Type        | Collation | Nullable |                      Default
-----------+-------------------+-----------+----------+---------------------------------------------------
 id        | bigint            |           | not null | nextval('memgpt_agent_agent_13_id_seq'::regclass)
 doc_id    | character varying |           |          |
 text      | character varying |           | not null |
 embedding | vector(1536)      |           |          |
Indexes:
    "memgpt_agent_agent_13_pkey" PRIMARY KEY, btree (id)

memgpt=> SELECT id, doc_id, text FROM memgpt_agent_agent_13;
 id |        doc_id         |                    text
----+-----------------------+---------------------------------------------
  1 | agent_agent_13_memory | Chad initiated a memory test on 2023-11-09.
(1 row)
memgpt=> \l
                                                List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    | ICU Locale | Locale Provider |   Access privileges
-----------+----------+----------+------------+------------+------------+-----------------+-----------------------
 memgpt    | memgpt   | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            |
 postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            |
 template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres          +
           |          |          |            |            |            |                 | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 |            | libc            | =c/postgres          +
           |          |          |            |            |            |                 | postgres=CTc/postgres
(4 rows)

memgpt=> \dx
                             List of installed extensions
  Name   | Version |   Schema   |                     Description
---------+---------+------------+------------------------------------------------------
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 vector  | 0.5.1   | memgpt     | vector data type and ivfflat and hnsw access methods
(2 rows)

memgpt=> \dn+
                  List of schemas
  Name  | Owner  | Access privileges | Description
--------+--------+-------------------+-------------
 memgpt | memgpt |                   |
(1 row)

```

**Related issues or PRs**
None

**Is your PR over 500 lines of code?**
No

**Additional context**
In response to today's discord discussions.
