### PR TITLE
Add load and load_and_attach functions to memgpt autogen agent.

### DIFF
--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -177,15 +177,15 @@ class MemGPTAgent(ConversableAgent):
         # call load function based on type
         match type:
             case "directory":
-                load_directory(name, **kwargs)
+                load_directory(name=name, **kwargs)
             case "webpage":
-                load_webpage(name, **kwargs)
+                load_webpage(name=name, **kwargs)
             case "index":
-                load_index(name, **kwargs)
+                load_index(name=name, **kwargs)
             case "database":
-                load_database(name, **kwargs)
+                load_database(name=name, **kwargs)
             case "vector_database":
-                load_vector_database(name, **kwargs)
+                load_vector_database(name=name, **kwargs)
             case _:
                 raise ValueError(f"Invalid data source type {type}")
 
@@ -199,12 +199,14 @@ class MemGPTAgent(ConversableAgent):
         # reload agent with new data source
         self.agent.persistence_manager.archival_memory.storage = StorageConnector.get_storage_connector(agent_config=self.agent.config)
 
-    def load_and_attach(self, name: str, type: str, **kwargs):
-        # load data
-        self.load(name, type, **kwargs)
-
-        # attach data
-        self.attach(name)
+    def load_and_attach(self, name: str, type: str, force=False, **kwargs):
+        # check if data source already exists
+        if name in StorageConnector.list_loaded_data() and not force:
+            print(f"Data source {name} already exists. Use force=True to overwrite.")
+            self.attach(name)
+        else:
+            self.load(name, type, **kwargs)
+            self.attach(name)
 
     def format_other_agent_message(self, msg):
         if "name" in msg:

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -12,6 +12,7 @@ from memgpt.personas import personas
 from memgpt.humans import humans
 from memgpt.config import AgentConfig
 from memgpt.cli.cli import attach
+from memgpt.cli.cli_load import load_directory, load_webpage, load_index, load_database, load_vector_database
 from memgpt.connectors.storage import StorageConnector
 
 
@@ -172,6 +173,22 @@ class MemGPTAgent(ConversableAgent):
 
         self._is_termination_msg = is_termination_msg if is_termination_msg is not None else (lambda x: x == "TERMINATE")
 
+    def load(self, name: str, type: str, **kwargs):
+        # call load function based on type
+        match type:
+            case "directory":
+                load_directory(name, **kwargs)
+            case "webpage":
+                load_webpage(name, **kwargs)
+            case "index":
+                load_index(name, **kwargs)
+            case "database":
+                load_database(name, **kwargs)
+            case "vector_database":
+                load_vector_database(name, **kwargs)
+            case _:
+                raise ValueError(f"Invalid data source type {type}")
+
     def attach(self, data_source: str):
         # attach new data
         attach(self.agent.config.name, data_source)
@@ -181,6 +198,13 @@ class MemGPTAgent(ConversableAgent):
 
         # reload agent with new data source
         self.agent.persistence_manager.archival_memory.storage = StorageConnector.get_storage_connector(agent_config=self.agent.config)
+
+    def load_and_attach(self, name: str, type: str, **kwargs):
+        # load data
+        self.load(name, type, **kwargs)
+
+        # attach data
+        self.attach(name)
 
     def format_other_agent_message(self, msg):
         if "name" in msg:

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -203,7 +203,7 @@ def attach(
     generator = source_storage.get_all_paginated(page_size=page_size)  # yields List[Passage]
     for i in tqdm(range(0, size, page_size)):
         passages = next(generator)
-        dest_storage.insert_many(passages, show_progress=False)
+        dest_storage.insert_many(passages)
 
     # save destination storage
     dest_storage.save()

--- a/memgpt/cli/cli_load.py
+++ b/memgpt/cli/cli_load.py
@@ -93,7 +93,6 @@ def load_directory(
         assert input_dir is not None, "Must provide input directory if recursive is True."
 
     if input_dir is not None:
-        assert len(input_files) == 0, "Either load in a list of files OR a directory."
         reader = SimpleDirectoryReader(
             input_dir=input_dir,
             recursive=recursive,


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This is to allow loading storage when defining an autogen agent instead of needing to use the CLI and then pass in a loaded directory by name via `attach()`

**How to test**
This should function in two ways: either run `load(<storage name>, <type of storage matching directory, webpage, index, database, vector_database>, <kwargs for underlying load function>)`. After that, run `attach()` as you would in the existing examples. You can also run `agent.load_and_attach()` with the same arguments and skip running `attach()`. 

**Have you tested this PR?**
In progress. 

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Additional context**
Discussed here https://discord.com/channels/1161736243340640419/1161736244074659893/1173122858222899263
