### PR TITLE
Patch for #434 (context window value not used by `memgpt run`)

### DIFF
--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -178,6 +178,7 @@ class MemGPTConfig:
         # CLI defaults
         config.add_section("defaults")
         config.set("defaults", "model", self.model)
+        config.set("defaults", "context_window", str(self.context_window))
         config.set("defaults", "preset", self.preset)
         assert self.model_endpoint is not None, "Endpoint must be set"
         config.set("defaults", "model_endpoint", self.model_endpoint)


### PR DESCRIPTION
Closes #434

---

Important note: if an agent config is missing `context_window`, it will get set to the model dict default (`LLM_MAX_TOKENS["DEFAULT"]`) (8k if local) instead of the config default (from `~/.memgpt/config`)

---

**Please describe the purpose of this pull request.**

See #434 (tl;dr - the context window set in `memgpt configure` would have no effect, it would just pull defaults)

**How to test**

## Running the same test from #434, but showing that it's now fixed

Run `memgpt configure` and set context window = 4096:
```
 % memgpt configure
? Do you want to enable MemGPT with OpenAI? No
? Do you want to enable MemGPT with Azure? No
? Select default inference endpoint: http://localhost:1234
? Select default embedding endpoint: local
? Select default preset: memgpt_chat
? Select your model's context window (for Mistral 7B models, this is probably 8k / 8192): 4096
? Select default persona: sam_pov
? Select default human: cs_phd
? Select storage backend for archival data: local
Saving config to /Users/loaner/.memgpt/config
```

Check that it got updated in the defaults (previously it wouldn't be stored here):
```
 % cat ~/.memgpt/config 
[defaults]
model = local
context_window = 4096
preset = memgpt_chat
model_endpoint = http://localhost:1234
persona = sam_pov
human = cs_phd

[embedding]
model = local
dim = 384
chunk_size = 300

[archival_storage]
type = local

[client]
anon_clientid = 000000000000000...
```

Create a new agent with `memgpt run`:
```
% memgpt run
? Would you like to select an existing agent? No
Creating new agent...
Created new agent agent_34.
Hit enter to begin (will request first MemGPT message)^C
Aborted.
```

Check that the agent's context window is set correctly in `config.json`:
```
% cat ~/.memgpt/agents/agent_34/config.json 
{
    "name": "agent_34",
    "persona": "sam_pov",
    "human": "cs_phd",
    "model": "local",
    "context_window": "4096",
    "preset": "memgpt_chat",
    "data_sources": [],
    "create_time": "2023-11-12 04:37:44 PM ",
    "data_source": null,
    "agent_config_path": "/Users/loaner/.memgpt/agents/agent_34/config.json"
}%                                            
```

## Extra tests

Check that we can override the context-window with a flag passed to `memgpt run`:
```
 % memgpt run --context_window 8000                           
? Would you like to select an existing agent? No
Warning: Overriding existing context window 4096 with 8000
Creating new agent...
Created new agent agent_35.
Hit enter to begin (will request first MemGPT message)^C
Aborted.
```

Default config is **unchanged** (as expected):
```
% cat ~/.memgpt/config                                       
[defaults]
model = local
context_window = 4096
preset = memgpt_chat
model_endpoint = http://localhost:1234
persona = sam_pov
human = cs_phd

[embedding]
model = local
dim = 384
chunk_size = 300

[archival_storage]
type = local

[client]
anon_clientid = 00000000000000...
```

New agent has config with updated `context_window`:
```
% cat ~/.memgpt/agents/agent_35/config.json                 
{
    "name": "agent_35",
    "persona": "sam_pov",
    "human": "cs_phd",
    "model": "local",
    "context_window": 8000,
    "preset": "memgpt_chat",
    "data_sources": [],
    "create_time": "2023-11-12 04:41:41 PM ",
    "data_source": null,
    "agent_config_path": "/Users/loaner/.memgpt/agents/agent_35/config.json"
}%                                                        
```