### PR TITLE
Fix crash from bad key access into response_message

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -433,7 +433,8 @@ class Agent(object):
             printd(f"First message didn't include function call: {response_message}")
             return False
 
-        function_name = response_message["function_call"]["name"]
+        function_call = response_message.get("function_call")
+        function_name = function_call.get("name") if function_call is not None else ""
         if require_send_message and function_name != "send_message" and function_name != "archival_memory_search":
             printd(f"First message function call wasn't send_message or archival_memory_search: {response_message}")
             return False


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Hello,

While playing around with the code I ran into a crash condition in `verify_first_message_correctness`. When calling this function with `require_send_message` set to `False`, the function can try to access the value stored under the `function_call` key in the `response` parameter. It is possible for this key to not be present in the dictionary, causing a crash.

**How to test**
Try to pass a dictionary without a `function_call` entry into `verify_first_message_correctness`, while also passing `require_send_message=False`. Easy to do with some models and bad prompting :)

**Have you tested this PR?**
No crashes after the changes

**Related issues or PRs**
I couldn't find any

**Is your PR over 500 lines of code?**
Thankfully not!

**Additional context**
Nothing more to provide :)
