### PR TITLE
patch `getargspec` error

### DIFF
--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -342,7 +342,11 @@ class AgentConfig:
             agent_config = json.load(f)
 
         # allow compatibility accross versions
-        class_args = inspect.getargspec(cls.__init__).args
+        try:
+            class_args = inspect.getargspec(cls.__init__).args
+        except AttributeError:
+            # https://github.com/pytorch/pytorch/issues/15344
+            class_args = inspect.getfullargspec(cls.__init__).args
         agent_fields = list(agent_config.keys())
         for key in agent_fields:
             if key not in class_args:


### PR DESCRIPTION
## Problem

`inspect.getargspec` does not work with Python 3.11, leading to the following crash:

```sh
$ python --version
Python 3.11.6
```
```sh
$ memgpt run
```
```
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-JHpOih47-py3.11/lib/python3.11/site-packages/typer/main.py", line 683, in wrapper
    return callback(**use_params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-public/MemGPT/memgpt/cli/cli.py", line 86, in run
    agents = [AgentConfig.load(f).name for f in agent_files]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-public/MemGPT/memgpt/cli/cli.py", line 86, in <listcomp>
    agents = [AgentConfig.load(f).name for f in agent_files]
              ^^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-public/MemGPT/memgpt/config.py", line 345, in load
    class_args = inspect.getargspec(cls.__init__).args
                 ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```

## Solution:

- [x] Add fallback for Python 3.11 (should we actually do this? unclear @sarahwooders )
- [ ] Update `pyproject.toml` to force Python 3.11

---

**Please describe the purpose of this pull request.**

Patching bug.

**How to test**

Try doing `poetry shell` -> `poetry install`, see what Python you get (does it resolve to 3.11?)

Then try `memgpt run`, see if it crashes.