### PR TITLE
Upgrade workflows to Python 3.11

### DIFF
--- a/.github/workflows/poetry-publish-nightly.yml
+++ b/.github/workflows/poetry-publish-nightly.yml
@@ -42,7 +42,7 @@ jobs:
           # Extract the version number from pyproject.toml using awk
           CURRENT_VERSION=$(awk -F '"' '/version =/ { print $2 }' pyproject.toml | head -n 1)
           # Export the CURRENT_VERSION with the .dev and current date suffix
-          NIGHTLY_VERSION="${CURRENT_VERSION}.dev$(date +%Y%m%d-%H%M%S)"
+          NIGHTLY_VERSION="${CURRENT_VERSION}.dev$(date +%Y%m%d%H%M%S)"
           # Overwrite pyproject.toml with nightly config
           sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NIGHTLY_VERSION}\"/" pyproject.toml
           sed -i 's/name = "pymemgpt"/name = "pymemgpt-nightly"/g' pyproject.toml

--- a/.github/workflows/poetry-publish-nightly.yml
+++ b/.github/workflows/poetry-publish-nightly.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
@@ -42,7 +42,7 @@ jobs:
           # Extract the version number from pyproject.toml using awk
           CURRENT_VERSION=$(awk -F '"' '/version =/ { print $2 }' pyproject.toml | head -n 1)
           # Export the CURRENT_VERSION with the .dev and current date suffix
-          NIGHTLY_VERSION="${CURRENT_VERSION}.dev$(date +%Y%m%d)"
+          NIGHTLY_VERSION="${CURRENT_VERSION}.dev$(date +%Y%m%d-%H%M%S)"
           # Overwrite pyproject.toml with nightly config
           sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NIGHTLY_VERSION}\"/" pyproject.toml
           sed -i 's/name = "pymemgpt"/name = "pymemgpt-nightly"/g' pyproject.toml

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install poetry
       run: pip install poetry


### PR DESCRIPTION
We didn't catch errors in 3.11 since we were testing with Python 3.9/3.10

Tests

- [x] Test deployed `pymemgt-nightly` 

- [x] Test pass for 3.11 after #440: https://github.com/cpacker/MemGPT/actions/runs/6858147084/job/18648436868