### PR TITLE
always cast `config.context_window` to `int` before use

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -605,7 +605,7 @@ class Agent(object):
                         model=self.model,
                         message_sequence=input_message_sequence,
                         functions=self.functions,
-                        context_window=self.config.context_window,
+                        context_window=int(self.config.context_window),
                     )
                     if self.verify_first_message_correctness(response, require_monologue=self.first_message_verify_mono):
                         break
@@ -619,7 +619,7 @@ class Agent(object):
                     model=self.model,
                     message_sequence=input_message_sequence,
                     functions=self.functions,
-                    context_window=self.config.context_window,
+                    context_window=int(self.config.context_window),
                 )
 
             # Step 2: check if LLM wanted to call a function
@@ -649,16 +649,18 @@ class Agent(object):
             # Check the memory pressure and potentially issue a memory pressure warning
             current_total_tokens = response["usage"]["total_tokens"]
             active_memory_warning = False
-            if current_total_tokens > MESSAGE_SUMMARY_WARNING_FRAC * self.config.context_window:
+            if current_total_tokens > MESSAGE_SUMMARY_WARNING_FRAC * int(self.config.context_window):
                 printd(
-                    f"WARNING: last response total_tokens ({current_total_tokens}) > {MESSAGE_SUMMARY_WARNING_FRAC * self.config.context_window}"
+                    f"WARNING: last response total_tokens ({current_total_tokens}) > {MESSAGE_SUMMARY_WARNING_FRAC * int(self.config.context_window)}"
                 )
                 # Only deliver the alert if we haven't already (this period)
                 if not self.agent_alerted_about_memory_pressure:
                     active_memory_warning = True
                     self.agent_alerted_about_memory_pressure = True  # it's up to the outer loop to handle this
             else:
-                printd(f"last response total_tokens ({current_total_tokens}) < {MESSAGE_SUMMARY_WARNING_FRAC * self.config.context_window}")
+                printd(
+                    f"last response total_tokens ({current_total_tokens}) < {MESSAGE_SUMMARY_WARNING_FRAC * int(self.config.context_window)}"
+                )
 
             self.append_to_messages(all_new_messages)
             return all_new_messages, heartbeat_request, function_failed, active_memory_warning
@@ -730,7 +732,7 @@ class Agent(object):
         printd(f"Attempting to summarize {len(message_sequence_to_summarize)} messages [1:{cutoff}] of {len(self.messages)}")
 
         summary = summarize_messages(
-            model=self.model, context_window=self.config.context_window, message_sequence_to_summarize=message_sequence_to_summarize
+            model=self.model, context_window=int(self.config.context_window), message_sequence_to_summarize=message_sequence_to_summarize
         )
         printd(f"Got summary: {summary}")
 

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -100,9 +100,9 @@ def run(
     sys.stdout = original_stdout
 
     # overwrite the context_window if specified
-    if context_window is not None and int(context_window) != config.context_window:
+    if context_window is not None and int(context_window) != int(config.context_window):
         typer.secho(f"Warning: Overriding existing context window {config.context_window} with {context_window}", fg=typer.colors.YELLOW)
-        config.context_window = context_window
+        config.context_window = str(context_window)
 
     # create agent config
     if agent and AgentConfig.exists(agent):  # use existing agent


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

```
An exception ocurred when running agent.step():
Traceback (most recent call last):
  File "C:\Users\cherr\AppData\Local\Programs\Python\Python311\Lib\site-packages\memgpt\main.py", line 608, in run_agent_loop
    new_messages, user_message, skip_next_user_input = process_agent_step(user_message, no_verify)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\cherr\AppData\Local\Programs\Python\Python311\Lib\site-packages\memgpt\main.py", line 584, in process_agent_step
    new_messages, heartbeat_request, function_failed, token_warning = memgpt_agent.step(
                                                                      ^^^^^^^^^^^^^^^^^^
  File "C:\Users\cherr\AppData\Local\Programs\Python\Python311\Lib\site-packages\memgpt\agent.py", line 657, in step
    raise e
  File "C:\Users\cherr\AppData\Local\Programs\Python\Python311\Lib\site-packages\memgpt\agent.py", line 631, in step
    if current_total_tokens > MESSAGE_SUMMARY_WARNING_FRAC * self.config.context_window:
                              ~~~~~~~^~~~~~
TypeError: can't multiply sequence by non-int of type 'float'
```

Preventative measure to try and avoid type errors with `agent.config.context_window`

**How to test**

Just basic regression testing

**Have you tested this PR?**

Not yet