### PR TITLE
When default_mode_endpoint has a value, it needs to become model_endp…

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -89,6 +89,8 @@ def configure_llm_endpoint(config: MemGPTConfig):
                     if "http://" not in model_endpoint and "https://" not in model_endpoint:
                         typer.secho(f"Endpoint must be a valid address", fg=typer.colors.YELLOW)
                         model_endpoint = None
+        else:
+            model_endpoint = default_model_endpoint
         assert model_endpoint, f"Environment variable OPENAI_API_BASE must be set."
 
     return model_endpoint_type, model_endpoint


### PR DESCRIPTION
When trying to use MemGPT with a litellm container trying to run 'memgpt configure' was hitting an assert complaining that model_endpoint was unset, the reason was that the default_model_endpoint was set and there was no branch of the final if block before the assert to handle this, so model_endpoint never got set.
