### PR TITLE
Docs: updated CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ cd MemGPT
 # Optional: set up a virtual environment.
 # python3 -m venv venv
 # . venv/bin/activate
-pip install -r requirements.txt
+pip install -r docs/requirements.txt
 ```
 
 ## 2. 🛠️ Making Changes


### PR DESCRIPTION
Correcting the path for installing dependencies

solves: ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'

The requirements.txt is not inside the MemGPT.
It is inside the docs folder of MemGPT so changed the path accordingly.

**Have you tested this PR?**
Yes

Fixes #406 
