### PR TITLE
Remove .DS_Store from agents list

### DIFF
--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -373,7 +373,7 @@ def estimate_openai_cost(docs):
 def list_agent_config_files():
     """List all agent config files, ignoring dotfiles."""
     files = os.listdir(os.path.join(MEMGPT_DIR, "agents"))
-    # remove dotfiles like .DS_Store
+    #  remove dotfiles like .DS_Store
     return [file for file in files if not file.startswith('.')]
 
 

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -371,8 +371,10 @@ def estimate_openai_cost(docs):
 
 
 def list_agent_config_files():
-    """List all agents config files"""
-    return os.listdir(os.path.join(MEMGPT_DIR, "agents"))
+    """List all agent config files, ignoring dotfiles."""
+    files = os.listdir(os.path.join(MEMGPT_DIR, "agents"))
+    # remove dotfiles like .DS_Store
+    return [file for file in files if not file.startswith('.')]
 
 
 def list_human_files():

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -374,7 +374,7 @@ def list_agent_config_files():
     """List all agent config files, ignoring dotfiles."""
     files = os.listdir(os.path.join(MEMGPT_DIR, "agents"))
     #  remove dotfiles like .DS_Store
-    return [file for file in files if not file.startswith('.')]
+    return [file for file in files if not file.startswith(".")]
 
 
 def list_human_files():


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Fix bug described here: https://discord.com/channels/1161736243340640419/1162177332350558339/1175581958856781904

> I keep needing to do rm -Rf /Users/richpav/.memgpt/agents/.DS_Store because MacOS finder keeps making it and python isn't ignoring it.

```
❯ memgpt run

[snip]

"/Users/richpav/Documents/MemGPT/memgpt/cli/cli.py", line 96, in run
    agents = [AgentConfig.load(f).name for f in agent_files]
  File "/Users/richpav/Documents/MemGPT/memgpt/cli/cli.py", line 96, in <listcomp>
    agents = [AgentConfig.load(f).name for f in agent_files]
  File "/Users/richpav/Documents/MemGPT/memgpt/config.py", line 360, in load
    assert os.path.exists(agent_config_path), f"Agent config file does not exist at {agent_config_path}"
AssertionError: Agent config file does not exist at /Users/richpav/.memgpt/agents/.DS_Store/config.json
```

**How to test**

Run `memgpt run` and make sure agents are listed properly. Try inserting a `.DS_Store` file.

**Have you tested this PR?**

Not yet.