### PR TITLE
Fix #487 (summarize call uses OpenAI even with local LLM config)

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -716,9 +716,7 @@ class Agent(object):
                 if (self.model is not None and self.model in LLM_MAX_TOKENS)
                 else str(LLM_MAX_TOKENS["DEFAULT"])
             )
-        summary = summarize_messages(
-            model=self.model, context_window=int(self.config.context_window), message_sequence_to_summarize=message_sequence_to_summarize
-        )
+        summary = summarize_messages(agent_config=self.config, message_sequence_to_summarize=message_sequence_to_summarize)
         printd(f"Got summary: {summary}")
 
         # Metadata that's useful for the agent to see

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -85,6 +85,11 @@ def chat_completion_with_backoff(agent_config, **kwargs):
     from memgpt.utils import printd
     from memgpt.config import AgentConfig, MemGPTConfig
 
+    # both "model" and "messages" are required for base OpenAI calls
+    # also required for local LLM Ollama, but not others
+    if "model" not in kwargs:
+        kwargs["model"] = agent_config.model
+
     printd(f"Using model {agent_config.model_endpoint_type}, endpoint: {agent_config.model_endpoint}")
     if agent_config.model_endpoint_type == "openai":
         # openai


### PR DESCRIPTION
Closes #487

**How to test**

Set the context length of a local model (eg in LM Studio) intentionally low (~3-3.5k tokens) to trigger the summarize:

- [x] (Reproduce bug) Do this on `main` without `OPENAI_API_KEY` set
- [x] (Test fix) Do this on PR branch, should now be fixed

**Have you tested this PR?**

Yes