### PR TITLE
Add error handling during linking imports

### DIFF
--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -49,7 +49,7 @@ def load_all_function_sets(merge=True):
     user_module_files = [f for f in os.listdir(user_scripts_dir) if f.endswith(".py") and f != "__init__.py"]
 
     # combine them both (pull from both examples and user-provided)
-    all_module_files = example_module_files + user_module_files
+    # all_module_files = example_module_files + user_module_files
 
     # Add user_scripts_dir to sys.path
     if user_scripts_dir not in sys.path:

--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -30,7 +30,7 @@ def load_function_set(module):
             }
 
     if len(function_dict) == 0:
-        raise ValueError(f"No functions found in module {module_name}")
+        raise ValueError(f"No functions found in module {module}")
     return function_dict
 
 
@@ -69,17 +69,18 @@ def load_all_function_sets(merge=True):
                 except ModuleNotFoundError as e:
                     # Handle missing module imports
                     missing_package = str(e).split("'")[1]  # Extract the name of the missing package
+                    print(f"Warning: skipped loading python file '{module_full_path}'!")
                     print(
-                        f"Skipped loading python file '{file}' because of ModuleNotFoundError - install python package '{missing_package}' to link functions from '{file}' to MemGPT."
+                        f"'{file}' imports '{missing_package}', but '{missing_package}' is not installed locally - install python package '{missing_package}' to link functions from '{file}' to MemGPT."
                     )
                     continue
                 except SyntaxError as e:
                     # Handle syntax errors in the module
-                    print(f"Skipped loading python file '{file}' due to a syntax error: {e}")
+                    print(f"Warning: skipped loading python file '{file}' due to a syntax error: {e}")
                     continue
                 except Exception as e:
                     # Handle other general exceptions
-                    print(f"An error occurred while loading python file '{file}': {e}")
+                    print(f"Warning: skipped loading python file '{file}': {e}")
                     continue
             else:
                 # For built-in scripts, use the existing method
@@ -88,7 +89,7 @@ def load_all_function_sets(merge=True):
                     module = importlib.import_module(full_module_name)
                 except Exception as e:
                     # Handle other general exceptions
-                    print(f"An error occurred while loading python module '{full_module_name}': {e}")
+                    print(f"Warning: skipped loading python module '{full_module_name}': {e}")
                     continue
 
             try:


### PR DESCRIPTION
Closes #489

**Please describe the purpose of this pull request.**

Patch bug from #489

**How to test**

1. [Reproducing the bug] On the latest `main`: make sure `jira` is uninstalled (`pip uninstall jira`). Then run `memgpt run`, you should get this error:

```
...
  File "/Users/loaner/dev/MemGPT-2/memgpt/presets/presets.py", line 23, in use_preset
    available_functions = load_all_function_sets()
  File "/Users/loaner/dev/MemGPT-2/memgpt/functions/functions.py", line 67, in load_all_function_sets
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/loaner/.memgpt/functions/jira_cloud.py", line 3, in <module>
    from jira import JIRA
ModuleNotFoundError: No module named 'jira'
```

2. [Test the fix] Do the same thing, but in this PR branch, you should see a nice message instead + no runtime error:

```
 % memgpt run
? Would you like to select an existing agent? No
Creating new agent...
Created new agent agent_118.
Skipped loading python file '/Users/loaner/.memgpt/functions/jira_cloud.py': 'jira_cloud.py' imports 'jira', but it is not installed locally (install Python package 'jira' to link functions from 'jira_cloud.py' to MemGPT).
Hit enter to begin (will request first MemGPT message)
```

**Have you tested this PR?**

Yes, see above 