### PR TITLE
feat: metadata in archival memory

### DIFF
--- a/memgpt/functions/function_sets/base.py
+++ b/memgpt/functions/function_sets/base.py
@@ -181,6 +181,6 @@ def archival_memory_search(self, query: str, page: Optional[int] = 0) -> Optiona
         results_str = f"No results found."
     else:
         results_pref = f"Showing {len(results)} of {total} results (page {page}/{num_pages}):"
-        results_formatted = [f"timestamp: {d['timestamp']}, memory: {d['content']}" for d in results]
+        results_formatted = [f"timestamp: {d['timestamp']}, memory: {d['content']}, metadata: {d['metadata']}" for d in results]
         results_str = f"{results_pref} {json.dumps(results_formatted, ensure_ascii=JSON_ENSURE_ASCII)}"
     return results_str

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -443,7 +443,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
             end = min(count + start, len(self.cache[query_string]))
 
             results = self.cache[query_string][start:end]
-            results = [{"timestamp": get_local_time(), "content": node.text} for node in results]
+            results = [{"timestamp": get_local_time(), "content": node.text, "metadata": node.metadata} for node in results]
             return results, len(results)
         except Exception as e:
             print("Archival search error", e)

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -379,7 +379,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
         # TODO: have some mechanism for cleanup otherwise will lead to OOM
         self.cache = {}
 
-    def create_passage(self, text, embedding):
+    def create_passage(self, text, embedding, metadata={}):
         return Passage(
             user_id=self.agent_state.user_id,
             agent_id=self.agent_state.id,
@@ -387,6 +387,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
             embedding=embedding,
             embedding_dim=self.agent_state.embedding_config.embedding_dim,
             embedding_model=self.agent_state.embedding_config.embedding_model,
+            metadata=metadata
         )
 
     def save(self):
@@ -418,7 +419,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
                         raise TypeError(
                             f"Got back an unexpected payload from text embedding function, type={type(embedding)}, value={embedding}"
                         )
-                passages.append(self.create_passage(node.text, embedding))
+                passages.append(self.create_passage(node.text, embedding, node.metadata))
 
             # insert passages
             self.storage.insert_many(passages)


### PR DESCRIPTION
Adds metadata as an option in archival memory. This means that if the connected store that provides the archival memory stores metadata then MemGPT can use it.

As none of the built-in storage options provide metadata (as far as I know), this shouldn't make any difference to existing storage options. I am using a custom storage connector using Milvus and MongoDB that provides document info as metadata, allowing MemGPT to make use of things like the document title, last updated date etc.

Let me know your thoughts!