### PR TITLE
setting self.agent_name so that when a client creates an agent from a…

### DIFF
--- a/memgpt/server/websocket_server.py
+++ b/memgpt/server/websocket_server.py
@@ -60,6 +60,7 @@ class WebSocketServer:
                     if data["command"] == "create_agent":
                         try:
                             self.agent = self.create_new_agent(data["config"])
+                            self.agent_name = self.agent.config.name
                             await websocket.send(protocol.server_command_response("OK: Agent initialized"))
                         except Exception as e:
                             self.agent = None


### PR DESCRIPTION
There was a bug using the websocket server.
I encountered this issue running the websocket server on a docker container.
When a client requests to create an agent, self.agent is set from the self.create_new_agent() function. self.agent_name was not being set.
I added code to set self.agent_name like is done after each self.load_agent() call in the same file.

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?
It is to fix a bug. I copied the same pattern used in the file when loading agents, just this time for the creation of new agents.

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?
I am not using the provided websocket client, but send the running websocket server the following:
{
        "type": "command",
        "command": "create_agent",
        "config": {
          "persona": "sam_pov",
          "human": "basic",
          "model": "gpt-4-1106-preview",
        },
      }
previously, self.agent_name was None for a fresh configuration of MemGPT, now it is agent_1 (or the most recent agent to be created via the above input).


**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.
I didn't write a test case for this, I'm open to direction on what I can provide on this front.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

https://github.com/cpacker/MemGPT/issues/481 may be related to the bug I found.

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length. 
No it isn't

**Additional context**
Add any other context or screenshots about the PR here.
<img width="471" alt="Screenshot 2023-11-21 at 9 45 24 PM" src="https://github.com/cpacker/MemGPT/assets/54888442/08337ce3-dde9-40e2-8d87-010eb9ea0bbc">
This is the pattern I copied 