### PR TITLE
Fix class names used in persistence manager logging

### DIFF
--- a/memgpt/persistence_manager.py
+++ b/memgpt/persistence_manager.py
@@ -146,7 +146,7 @@ class LocalStateManager(PersistenceManager):
             printd(f"Saved state to {fh}")
 
     def init(self, agent):
-        printd(f"Initializing InMemoryStateManager with agent object")
+        printd(f"Initializing LocalStateManager with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
@@ -199,7 +199,7 @@ class InMemoryStateManagerWithPreloadedArchivalMemory(InMemoryStateManager):
         self.archival_memory_db = archival_memory_db
 
     def init(self, agent):
-        print(f"Initializing InMemoryStateManager with agent object")
+        print(f"Initializing InMemoryStateManagerWithPreloadedArchivalMemory with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
@@ -228,7 +228,7 @@ class InMemoryStateManagerWithFaiss(InMemoryStateManager):
         raise NotImplementedError
 
     def init(self, agent):
-        print(f"Initializing InMemoryStateManager with agent object")
+        print(f"Initializing InMemoryStateManagerWithFaiss with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory

--- a/memgpt/persistence_manager.py
+++ b/memgpt/persistence_manager.py
@@ -57,7 +57,7 @@ class InMemoryStateManager(PersistenceManager):
             pickle.dump(self, fh, protocol=pickle.HIGHEST_PROTOCOL)
 
     def init(self, agent):
-        printd(f"Initializing InMemoryStateManager with agent object")
+        printd(f"Initializing {self.__class__.__name__} with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
@@ -77,7 +77,7 @@ class InMemoryStateManager(PersistenceManager):
         # first tag with timestamps
         added_messages = [{"timestamp": get_local_time(), "message": msg} for msg in added_messages]
 
-        printd(f"InMemoryStateManager.prepend_to_message")
+        printd(f"{self.__class__.__name__}.prepend_to_message")
         self.messages = [self.messages[0]] + added_messages + self.messages[1:]
         self.all_messages.extend(added_messages)
 
@@ -85,7 +85,7 @@ class InMemoryStateManager(PersistenceManager):
         # first tag with timestamps
         added_messages = [{"timestamp": get_local_time(), "message": msg} for msg in added_messages]
 
-        printd(f"InMemoryStateManager.append_to_messages")
+        printd(f"{self.__class__.__name__}.append_to_messages")
         self.messages = self.messages + added_messages
         self.all_messages.extend(added_messages)
 
@@ -93,12 +93,12 @@ class InMemoryStateManager(PersistenceManager):
         # first tag with timestamps
         new_system_message = {"timestamp": get_local_time(), "message": new_system_message}
 
-        printd(f"InMemoryStateManager.swap_system_message")
+        printd(f"{self.__class__.__name__}.swap_system_message")
         self.messages[0] = new_system_message
         self.all_messages.append(new_system_message)
 
     def update_memory(self, new_memory):
-        printd(f"InMemoryStateManager.update_memory")
+        printd(f"{self.__class__.__name__}.update_memory")
         self.memory = new_memory
 
 
@@ -146,12 +146,12 @@ class LocalStateManager(PersistenceManager):
             printd(f"Saved state to {fh}")
 
     def init(self, agent):
-        printd(f"Initializing LocalStateManager with agent object")
+        printd(f"Initializing {self.__class__.__name__} with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
-        printd(f"InMemoryStateManager.all_messages.len = {len(self.all_messages)}")
-        printd(f"InMemoryStateManager.messages.len = {len(self.messages)}")
+        printd(f"{self.__class__.__name__}.all_messages.len = {len(self.all_messages)}")
+        printd(f"{self.__class__.__name__}.messages.len = {len(self.messages)}")
 
         # Persistence manager also handles DB-related state
         self.recall_memory = self.recall_memory_cls(message_database=self.all_messages)
@@ -166,7 +166,7 @@ class LocalStateManager(PersistenceManager):
         # first tag with timestamps
         added_messages = [{"timestamp": get_local_time(), "message": msg} for msg in added_messages]
 
-        printd(f"InMemoryStateManager.prepend_to_message")
+        printd(f"{self.__class__.__name__}.prepend_to_message")
         self.messages = [self.messages[0]] + added_messages + self.messages[1:]
         self.all_messages.extend(added_messages)
 
@@ -174,7 +174,7 @@ class LocalStateManager(PersistenceManager):
         # first tag with timestamps
         added_messages = [{"timestamp": get_local_time(), "message": msg} for msg in added_messages]
 
-        printd(f"InMemoryStateManager.append_to_messages")
+        printd(f"{self.__class__.__name__}.append_to_messages")
         self.messages = self.messages + added_messages
         self.all_messages.extend(added_messages)
 
@@ -182,12 +182,12 @@ class LocalStateManager(PersistenceManager):
         # first tag with timestamps
         new_system_message = {"timestamp": get_local_time(), "message": new_system_message}
 
-        printd(f"InMemoryStateManager.swap_system_message")
+        printd(f"{self.__class__.__name__}.swap_system_message")
         self.messages[0] = new_system_message
         self.all_messages.append(new_system_message)
 
     def update_memory(self, new_memory):
-        printd(f"InMemoryStateManager.update_memory")
+        printd(f"{self.__class__.__name__}.update_memory")
         self.memory = new_memory
 
 
@@ -199,12 +199,12 @@ class InMemoryStateManagerWithPreloadedArchivalMemory(InMemoryStateManager):
         self.archival_memory_db = archival_memory_db
 
     def init(self, agent):
-        print(f"Initializing InMemoryStateManagerWithPreloadedArchivalMemory with agent object")
+        print(f"Initializing {self.__class__.__name__} with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
-        print(f"InMemoryStateManager.all_messages.len = {len(self.all_messages)}")
-        print(f"InMemoryStateManager.messages.len = {len(self.messages)}")
+        print(f"{self.__class__.__name__}.all_messages.len = {len(self.all_messages)}")
+        print(f"{self.__class__.__name__}.messages.len = {len(self.messages)}")
         self.recall_memory = self.recall_memory_cls(message_database=self.all_messages)
         self.archival_memory = self.archival_memory_cls(archival_memory_database=self.archival_memory_db)
 
@@ -228,12 +228,12 @@ class InMemoryStateManagerWithFaiss(InMemoryStateManager):
         raise NotImplementedError
 
     def init(self, agent):
-        print(f"Initializing InMemoryStateManagerWithFaiss with agent object")
+        print(f"Initializing {self.__class__.__name__} with agent object")
         self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
-        print(f"InMemoryStateManager.all_messages.len = {len(self.all_messages)}")
-        print(f"InMemoryStateManager.messages.len = {len(self.messages)}")
+        print(f"{self.__class__.__name__}.all_messages.len = {len(self.all_messages)}")
+        print(f"{self.__class__.__name__}.messages.len = {len(self.messages)}")
 
         # Persistence manager also handles DB-related state
         self.recall_memory = self.recall_memory_cls(message_database=self.all_messages)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
All of the print statements used at creation time of the different persistence managers use the same name for each class. This PR changes the names to actually match the classes they are being used in

**How to test**
Run MemGPT with different persistence managers

**Have you tested this PR?**
```
Created new agent agent_111.
Available functions:
 ['send_message', 'pause_heartbeats', 'core_memory_append', 'core_memory_replace', 'conversation_search', 'conversation_search_date', 'archival_memory_insert', 'archival_memory_search']
AgentAsync initialized, self.messages_total=3
Initializing LoadStateManager with agent object
InMemoryStateManager.all_messages.len = 4
InMemoryStateManager.messages.len = 4
💭 *inner thoughts* Ah, the user has logged in for the first time. How exciting! I should introduce myself and make them feel welcome.
```
