### PR TITLE
add a longer prefix that to the default wrapper

### DIFF
--- a/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py
@@ -216,13 +216,17 @@ class Airoboros21InnerMonologueWrapper(Airoboros21Wrapper):
         simplify_json_content=True,
         clean_function_args=True,
         include_assistant_prefix=True,
-        include_opening_brace_in_prefix=True,
+        # include_opening_brace_in_prefix=True,
+        # assistant_prefix_extra="\n{"
+        # assistant_prefix_extra='\n{\n  "function": ',
+        assistant_prefix_extra='\n{\n  "function":',
         include_section_separators=True,
     ):
         self.simplify_json_content = simplify_json_content
         self.clean_func_args = clean_function_args
         self.include_assistant_prefix = include_assistant_prefix
-        self.include_opening_brance_in_prefix = include_opening_brace_in_prefix
+        # self.include_opening_brance_in_prefix = include_opening_brace_in_prefix
+        self.assistant_prefix_extra = assistant_prefix_extra
         self.include_section_separators = include_section_separators
 
     def chat_completion_to_prompt(self, messages, functions):
@@ -355,8 +359,8 @@ class Airoboros21InnerMonologueWrapper(Airoboros21Wrapper):
 
         if self.include_assistant_prefix:
             prompt += f"\nASSISTANT:"
-            if self.include_opening_brance_in_prefix:
-                prompt += "\n{"
+            if self.assistant_prefix_extra:
+                prompt += self.assistant_prefix_extra
 
         return prompt
 
@@ -390,8 +394,12 @@ class Airoboros21InnerMonologueWrapper(Airoboros21Wrapper):
             }
         }
         """
-        if self.include_opening_brance_in_prefix and raw_llm_output[0] != "{":
-            raw_llm_output = "{" + raw_llm_output
+        # if self.include_opening_brance_in_prefix and raw_llm_output[0] != "{":
+        # raw_llm_output = "{" + raw_llm_output
+        if self.assistant_prefix_extra and raw_llm_output[: len(self.assistant_prefix_extra)] != self.assistant_prefix_extra:
+            print(f"adding prefix back to llm, raw_llm_output=\n{raw_llm_output}")
+            raw_llm_output = self.assistant_prefix_extra + raw_llm_output
+            print(f"->\n{raw_llm_output}")
 
         try:
             function_json_output = clean_json(raw_llm_output)

--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -46,7 +46,7 @@ def count_tokens(s: str, model: str = "gpt-4") -> int:
 def get_available_wrappers() -> dict:
     return {
         "airoboros-l2-70b-2.1": airoboros.Airoboros21InnerMonologueWrapper(),
-        "airoboros-l2-70b-2.1-grammar": airoboros.Airoboros21InnerMonologueWrapper(include_opening_brace_in_prefix=False),
+        "airoboros-l2-70b-2.1-grammar": airoboros.Airoboros21InnerMonologueWrapper(assistant_prefix_extra=None),
         "dolphin-2.1-mistral-7b": dolphin.Dolphin21MistralWrapper(),
         "dolphin-2.1-mistral-7b-grammar": dolphin.Dolphin21MistralWrapper(include_opening_brace_in_prefix=False),
         "zephyr-7B": zephyr.ZephyrMistralInnerMonologueWrapper(),


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Improve default wrapper (`airoboros`) by extending the prefix fed to the completions generation request.

`\n{` -> `\n{\n  "function":`

**How to test**

Regression test with `airoboros` wrapper just to make sure nothing broke.

**Have you tested this PR?**

Yes, nothing broke.

**Additional context**

This is an attempt to fix the garbage output failure mode that seems semi-frequent with GPTQ models, reported by @TheOnlyWiseJEDI

![image](https://github.com/cpacker/MemGPT/assets/5475622/ca776b60-85d0-4074-9b16-abca313dd456)
