### PR TITLE
fix doc typo autogem to autogen

### DIFF
--- a/docs/autogen.md
+++ b/docs/autogen.md
@@ -68,9 +68,9 @@ WebUI exposes a lot of parameters that can dramatically change LLM outputs, to c
 ⁉️ If you have problems getting WebUI setup, please use the [official web UI repo for support](https://github.com/oobabooga/text-generation-webui)! There will be more answered questions about web UI there vs here on the MemGPT repo.
 
 ### Example groupchat
-Going back to the example we first mentioned, [examples/agent_groupchat.py](https://github.com/cpacker/MemGPT/blob/main/memgpt/autogem/examples/agent_groupchat.py) contains an example of a groupchat where one of the agents is powered by MemGPT.
+Going back to the example we first mentioned, [examples/agent_groupchat.py](https://github.com/cpacker/MemGPT/blob/main/memgpt/autogen/examples/agent_groupchat.py) contains an example of a groupchat where one of the agents is powered by MemGPT.
 
-In order to run this example on a local LLM, go to lines 32-55 in [examples/agent_groupchat.py](https://github.com/cpacker/MemGPT/blob/main/memgpt/autogem/examples/agent_groupchat.py) and fill in the config files with your local LLM's deployment details. For example, if you are using webui, it will look something like this:
+In order to run this example on a local LLM, go to lines 32-55 in [examples/agent_groupchat.py](https://github.com/cpacker/MemGPT/blob/main/memgpt/autogen/examples/agent_groupchat.py) and fill in the config files with your local LLM's deployment details. For example, if you are using webui, it will look something like this:
 
 ```
 config_list = [


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fix a doc bug -> a link is broken in autogen doc due to a typo 

**How to test**
Click on the readme link and check we reach the good file

**Have you tested this PR?**
I've clicked ;) 



**Is your PR over 500 lines of code?**
No

**Additional context**
Not the biggest contribution... Will eventually expend this PR with other minor typo fixes
