### PR TITLE
[hotfix] extra arg being passed causing a runtime error

### DIFF
--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -130,7 +130,7 @@ def summarize_messages(
         trunc_ratio = (MESSAGE_SUMMARY_WARNING_FRAC * context_window / summary_input_tkns) * 0.8  # For good measure...
         cutoff = int(len(message_sequence_to_summarize) * trunc_ratio)
         summary_input = str(
-            [summarize_messages(agent_config, context_window, message_sequence_to_summarize[:cutoff])]
+            [summarize_messages(agent_config=agent_config, message_sequence_to_summarize=message_sequence_to_summarize[:cutoff])]
             + message_sequence_to_summarize[cutoff:]
         )
     message_sequence = [


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Fixing bug reported by @TheOnlyWiseJEDI

![image](https://github.com/cpacker/MemGPT/assets/5475622/3f34400f-0125-409a-95bb-872343ba77a0)

This bug should not happen during regular summarization, but can be triggered if context limit in the config is set lower than the native context window (triggering a nested summarization when the `summarize_messages_inplace` call is triggered.