### PR TITLE
Clean memory error messages

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -520,7 +520,9 @@ class Agent(object):
                 function_failed = False
             except Exception as e:
                 function_args.pop("self", None)
-                error_msg = f"Error calling function {function_name} with args {function_args}: {str(e)}"
+                # error_msg = f"Error calling function {function_name} with args {function_args}: {str(e)}"
+                # Less detailed - don't provide full args, idea is that it should be in recent context so no need (just adds noise)
+                error_msg = f"Error calling function {function_name}: {str(e)}"
                 error_msg_user = f"{error_msg}\n{traceback.format_exc()}"
                 printd(error_msg_user)
                 function_response = package_function_response(False, error_msg)

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -515,9 +515,11 @@ class Agent(object):
             try:
                 function_args["self"] = self  # need to attach self to arg since it's dynamically linked
                 function_response_string = function_to_call(**function_args)
+                function_args.pop("self", None)
                 function_response = package_function_response(True, function_response_string)
                 function_failed = False
             except Exception as e:
+                function_args.pop("self", None)
                 error_msg = f"Error calling function {function_name} with args {function_args}: {str(e)}"
                 error_msg_user = f"{error_msg}\n{traceback.format_exc()}"
                 printd(error_msg_user)

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -86,7 +86,7 @@ class CoreMemory(object):
         elif field == "human":
             return self.edit_human(content)
         else:
-            raise KeyError
+            raise KeyError(f'No memory section named {field} (must be either "persona" or "human")')
 
     def edit_append(self, field, content, sep="\n"):
         if field == "persona":
@@ -96,7 +96,7 @@ class CoreMemory(object):
             new_content = self.human + sep + content
             return self.edit_human(new_content)
         else:
-            raise KeyError
+            raise KeyError(f'No memory section named {field} (must be either "persona" or "human")')
 
     def edit_replace(self, field, old_content, new_content):
         if field == "persona":
@@ -112,7 +112,7 @@ class CoreMemory(object):
             else:
                 raise ValueError("Content not found in human (make sure to use exact string)")
         else:
-            raise KeyError
+            raise KeyError(f'No memory section named {field} (must be either "persona" or "human")')
 
 
 def summarize_messages(


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Clean up error messages from bad function calls sent to LLM processor.

Previously, error messages would (1) have 'self' polluting the message, (2) specifically for `core_memory_*`, key errors were generic and didn't provide hints to what should be changed:

![image](https://github.com/cpacker/MemGPT/assets/5475622/b88ca8c7-7236-4bc9-8a42-ef685390307c)

Now (outdated, see below):

<img width="1393" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/05ffdbfb-3395-4416-8362-ff4da0dfb1e0">

After https://github.com/cpacker/MemGPT/pull/523/commits/ef8c046812df72240b534c69c299c7ff8436ba25:

<img width="1114" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/fe807421-1b7a-4576-b4be-4bcce189252a">

---

**How to test**

Basic regression test - just mimic the bottom screenshot.

**Have you tested this PR?**

Yes, see bottom screenshot.