### PR TITLE
Patch JSON parsing code (regex fallback)

### DIFF
--- a/memgpt/local_llm/json_parser.py
+++ b/memgpt/local_llm/json_parser.py
@@ -62,8 +62,8 @@ def clean_and_interpret_send_message_json(json_string):
         return {
             "function": "send_message",
             "params": {
-                "inner_thoughts": inner_thoughts_match,
-                "message": message_match,
+                "inner_thoughts": inner_thoughts_match.group(1),
+                "message": message_match.group(1),
             },
         }
     else:


### PR DESCRIPTION
patched a bug where outputs of a regex extraction weren't getting cast back to string, causing an issue when the dict was then passed to json.dumps()

**Please describe the purpose of this pull request.**

One of the existing JSON parsers would fail when used/triggered in practice because it didn't cast the outputs of a regex match/search back to strings, causing a strange error message:

```
An exception ocurred when running agent.step(): 
Traceback (most recent call last):
  File "/Users/loaner/dev/MemGPT-swooders/memgpt/local_llm/chat_completion_proxy.py", line 115, in get_chat_completion
    chat_completion_result = llm_wrapper.output_to_chat_completion_response(result)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-swooders/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py", line 426, in output_to_chat_completion_response
    "arguments": json.dumps(function_parameters),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Match is not JSON serializable
```

**How to test**

N/A, tested via unit tests.