### PR TITLE
Remove usage of `BACKEND_TYPE`

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -60,9 +60,6 @@ def configure_llm_endpoint(config: MemGPTConfig):
         if config.model_endpoint_type in backend_options:
             # set from previous config
             default_model_endpoint_type = config.model_endpoint_type
-        if os.getenv("BACKEND_TYPE") and os.getenv("BACKEND_TYPE") in backend_options:
-            # set form env variable (ok if none)
-            default_model_endpoint_type = os.getenv("BACKEND_TYPE")
         model_endpoint_type = questionary.select(
             "Select LLM backend (select 'openai' if you have an OpenAI compatible proxy):",
             backend_options,

--- a/memgpt/embeddings.py
+++ b/memgpt/embeddings.py
@@ -121,14 +121,9 @@ def embedding_model():
         return embed_model
     else:
         # default to hugging face model running local
+        # warning: this is a terrible model
         from llama_index.embeddings import HuggingFaceEmbedding
 
         os.environ["TOKENIZERS_PARALLELISM"] = "False"
         model = "BAAI/bge-small-en-v1.5"
         return HuggingFaceEmbedding(model_name=model)
-
-    # TODO: add back if we decide to support custom embedding endpoints
-    # else:
-    #    # use env variable OPENAI_API_BASE
-    #    model = OpenAIEmbedding()
-    #    return model

--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -19,8 +19,6 @@ from memgpt.local_llm.utils import get_available_wrappers
 from memgpt.prompts.gpt_summarize import SYSTEM as SUMMARIZE_SYSTEM_MESSAGE
 from memgpt.errors import LocalLLMConnectionError, LocalLLMError
 
-endpoint = os.getenv("OPENAI_API_BASE")
-endpoint_type = os.getenv("BACKEND_TYPE")  # default None == ChatCompletion
 DEBUG = False
 # DEBUG = True
 
@@ -103,7 +101,7 @@ def get_chat_completion(
             result = get_vllm_completion(endpoint, model, prompt, context_window, user)
         else:
             raise LocalLLMError(
-                f"BACKEND_TYPE is not set, please set variable depending on your backend (webui, lmstudio, llamacpp, koboldcpp)"
+                f"Invalid endpoint type {endpoint_type}, please set variable depending on your backend (webui, lmstudio, llamacpp, koboldcpp)"
             )
     except requests.exceptions.ConnectionError as e:
         raise LocalLLMConnectionError(f"Unable to connect to endpoint {endpoint}")

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -10,10 +10,6 @@ from box import Box
 
 from memgpt.local_llm.chat_completion_proxy import get_chat_completion
 
-HOST = os.getenv("OPENAI_API_BASE")
-HOST_TYPE = os.getenv("BACKEND_TYPE")  # default None == ChatCompletion
-R = TypeVar("R")
-
 
 def is_context_overflow_error(exception):
     from memgpt.utils import printd


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
MemGPT's config file specifies the backend type and configuration, so this removes dead code using environment variables (does not update docs). 
