### PR TITLE
fix cannot import name 'EmptyIndex' from 'llama_index'

### DIFF
--- a/memgpt/connectors/local.py
+++ b/memgpt/connectors/local.py
@@ -8,7 +8,8 @@ import os
 
 from typing import List, Optional
 
-from llama_index import VectorStoreIndex, EmptyIndex, ServiceContext, set_global_service_context
+from llama_index import VectorStoreIndex, ServiceContext, set_global_service_context
+from llama_index.indices.empty.base import EmptyIndex
 from llama_index.retrievers import VectorIndexRetriever
 from llama_index.schema import TextNode
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Patch #556

```
ImportError: cannot import name 'EmptyIndex' from 'llama_index' (/.../lib/python3.10/site-packages/llama_index/__init__.py)
```