### PR TITLE
add back dotdict for backcompat

### DIFF
--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -6,6 +6,24 @@ import memgpt.local_llm.llm_chat_completion_wrappers.dolphin as dolphin
 import memgpt.local_llm.llm_chat_completion_wrappers.zephyr as zephyr
 
 
+# deprecated for Box
+class DotDict(dict):
+    """Allow dot access on properties similar to OpenAI response object"""
+
+    def __getattr__(self, attr):
+        return self.get(attr)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    # following methods necessary for pickling
+    def __getstate__(self):
+        return vars(self)
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+
+
 def load_grammar_file(grammar):
     # Set grammar
     grammar_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "grammars", f"{grammar}.gbnf")


### PR DESCRIPTION
Closes #562

**Please describe the purpose of this pull request.**

On loads of old agents that used LocalLLMs, `DotDict` is present in the pickle file (even though we deprecated `DotDict` for `Box`):

```
  File "/.../lib/python3.11/site-packages/memgpt/persistence_manager.py", line 52, in load
    data = pickle.load(f)
           ^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'DotDict' on <module 'memgpt.local_llm.utils' from '/.../lib/python3.11/site-packages/memgpt/local_llm/utils.py'>
```

Solution: add back `DotDict` to `utils.py` for backcompat.

**How to test**

Try loading old (>1 week old) agents on `main` - should break, whereas with this patch they should run fine.

**Have you tested this PR?**

Yes