### PR TITLE
sort agents by directory-last-modified time

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -259,6 +259,9 @@ class Agent(object):
         timestamp = get_local_time().replace(" ", "_").replace(":", "_")
         agent_name = self.config.name  # TODO: fix
 
+        # save config
+        self.config.save()
+
         # save agent state
         filename = f"{timestamp}.json"
         os.makedirs(self.config.save_state_dir(), exist_ok=True)

--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -284,8 +284,6 @@ class AgentConfig:
         self.agent_config_path = (
             os.path.join(MEMGPT_DIR, "agents", self.name, "config.json") if agent_config_path is None else agent_config_path
         )
-        # assert not os.path.exists(self.agent_config_path), f"Agent config file already exists at {self.agent_config_path}"
-        self.save()
 
     def generate_agent_id(self, length=6):
         ## random character based

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -88,11 +88,25 @@ def parse_json(string):
         raise e
 
 
-def list_agent_config_files():
+def list_agent_config_files(sort="last_modified"):
     """List all agent config files, ignoring dotfiles."""
-    files = os.listdir(os.path.join(MEMGPT_DIR, "agents"))
-    #  remove dotfiles like .DS_Store
-    return [file for file in files if not file.startswith(".")]
+    agent_dir = os.path.join(MEMGPT_DIR, "agents")
+    files = os.listdir(agent_dir)
+
+    # Remove dotfiles like .DS_Store
+    files = [file for file in files if not file.startswith(".")]
+
+    # Remove anything that's not a directory
+    files = [file for file in files if os.path.isdir(os.path.join(agent_dir, file))]
+
+    if sort is not None:
+        if sort == "last_modified":
+            # Sort the directories by last modified (most recent first)
+            files.sort(key=lambda x: os.path.getmtime(os.path.join(agent_dir, x)), reverse=True)
+        else:
+            raise ValueError(f"Unrecognized sorting option {sort}")
+
+    return files
 
 
 def list_human_files():


### PR DESCRIPTION
Closes #567

---

**Please describe the purpose of this pull request.**

When the user asks to choose from an existing agent, sort them reverse chronological by the last modify time (on the save directory).

**How to test**

Try `memgpt run`, check the sorting.

**Have you tested this PR?**

Yes, on MacOS.