### PR TITLE
Add safety check to pop

### DIFF
--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -157,7 +157,7 @@ def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, strip_ui=Fals
                     MIN_MESSAGES = 2
                     if n_messages <= MIN_MESSAGES:
                         print(f"Agent only has {n_messages} messages in stack, none left to pop")
-                    elif n_messages - pop_amount <= MIN_MESSAGES:
+                    elif n_messages - pop_amount < MIN_MESSAGES:
                         print(f"Agent only has {n_messages} messages in stack, cannot pop more than {n_messages - MIN_MESSAGES}")
                     else:
                         print(f"Popping last {pop_amount} messages from stack")

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -152,10 +152,17 @@ def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, strip_ui=Fals
                 elif user_input.lower() == "/pop" or user_input.lower().startswith("/pop "):
                     # Check if there's an additional argument that's an integer
                     command = user_input.strip().split()
-                    amount = int(command[1]) if len(command) > 1 and command[1].isdigit() else 3
-                    print(f"Popping last {amount} messages from stack")
-                    for _ in range(min(amount, len(memgpt_agent.messages))):
-                        memgpt_agent.messages.pop()
+                    pop_amount = int(command[1]) if len(command) > 1 and command[1].isdigit() else 3
+                    n_messages = len(memgpt_agent.messages)
+                    MIN_MESSAGES = 2
+                    if n_messages <= MIN_MESSAGES:
+                        print(f"Agent only has {n_messages} messages in stack, none left to pop")
+                    elif n_messages - pop_amount <= MIN_MESSAGES:
+                        print(f"Agent only has {n_messages} messages in stack, cannot pop more than {n_messages - MIN_MESSAGES}")
+                    else:
+                        print(f"Popping last {pop_amount} messages from stack")
+                        for _ in range(min(pop_amount, len(memgpt_agent.messages))):
+                            memgpt_agent.messages.pop()
                     continue
 
                 elif user_input.lower() == "/retry":


### PR DESCRIPTION
Closes #561

---

**Please describe the purpose of this pull request.**

Users can `pop` the system message off, need to add a safety check: https://github.com/cpacker/MemGPT/blob/main/memgpt/main.py#L152-L159

See [Discord discussion](https://discord.com/channels/1161736243340640419/1162177332350558339/1180767443065516072)

**How to test**

On `main`, you can pop all the way to an empty system message, which bricks the agent (`/dump` returns an empty list):
<img width="916" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/72a603af-6f30-4d81-b2ee-93b8151e38cb">

With this PR, you can't pop past the minimum of 2 messages:
<img width="1213" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/81b00eee-ff9f-4239-8647-2c8f80c15b66">
<img width="546" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/e6d19418-a2c9-4c2c-ab88-ee392395ea4d">

**Have you tested this PR?**

Yes, see above.