### PR TITLE
patch load_save test

### DIFF
--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -7,6 +7,8 @@ from memgpt.constants import MESSAGE_SUMMARY_WARNING_FRAC
 from memgpt.utils import get_local_time, printd, count_tokens
 from memgpt.prompts.gpt_summarize import SYSTEM as SUMMARY_PROMPT_SYSTEM
 from memgpt.openai_tools import create
+from memgpt.config import MemGPTConfig
+from memgpt.embeddings import embedding_model
 from llama_index import Document
 from llama_index.node_parser import SimpleNodeParser
 from llama_index.node_parser import SimpleNodeParser


### PR DESCRIPTION
Runtime error on `memgpt run` caused by refactor in `memory.py` 