### PR TITLE
AutoGen misc fixes

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -568,6 +568,15 @@ class Agent(object):
             if user_message is not None:
                 self.interface.user_message(user_message)
                 packed_user_message = {"role": "user", "content": user_message}
+                # Special handling for AutoGen messages with 'name' field
+                try:
+                    user_message_json = json.loads(user_message)
+                    if "name" in user_message_json:
+                        packed_user_message["name"] = user_message_json["name"]
+                        user_message_json.pop("name", None)
+                        packed_user_message["content"] = json.dumps(user_message_json)
+                except Exception as e:
+                    print(f"{CLI_WARNING_PREFIX}handling of 'name' field failed with: {e}")
                 input_message_sequence = self.messages + [packed_user_message]
             else:
                 input_message_sequence = self.messages

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -571,6 +571,8 @@ class Agent(object):
                 # Special handling for AutoGen messages with 'name' field
                 try:
                     user_message_json = json.loads(user_message)
+                    # Treat 'name' as a special field
+                    # If it exists in the input message, elevate it to the 'message' level
                     if "name" in user_message_json:
                         packed_user_message["name"] = user_message_json["name"]
                         user_message_json.pop("name", None)

--- a/memgpt/autogen/interface.py
+++ b/memgpt/autogen/interface.py
@@ -71,7 +71,8 @@ class AutoGenInterface(object):
         if not self.show_inner_thoughts:
             return
         message = f"\x1B[3m{Fore.LIGHTBLACK_EX}💭 {msg}{Style.RESET_ALL}" if self.fancy else f"[inner thoughts] {msg}"
-        self.message_list.append(message)
+        print(message)
+        # self.message_list.append(message)
 
     def assistant_message(self, msg):
         if self.debug:
@@ -83,13 +84,15 @@ class AutoGenInterface(object):
         if self.debug:
             print(f"memory :: {msg}")
         message = f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}🧠 {Fore.LIGHTMAGENTA_EX}{msg}{Style.RESET_ALL}" if self.fancy else f"[memory] {msg}"
-        self.message_list.append(message)
+        # self.message_list.append(message)
+        print(message)
 
     def system_message(self, msg):
         if self.debug:
             print(f"system :: {msg}")
         message = f"{Fore.MAGENTA}{Style.BRIGHT}🖥️ [system] {Fore.MAGENTA}{msg}{Style.RESET_ALL}" if self.fancy else f"[system] {msg}"
         self.message_list.append(message)
+        print(message)
 
     def user_message(self, msg, raw=False):
         if self.debug:
@@ -200,4 +203,5 @@ class AutoGenInterface(object):
                 message = f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}" if self.fancy else f"[function] {msg}"
 
         if message:
-            self.message_list.append(message)
+            # self.message_list.append(message)
+            print(message)

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -50,10 +50,12 @@ def create_memgpt_autogen_agent_from_config(
         user_desc = "Work by yourself, the user won't reply. Elaborate as much as possible."
 
     # If using azure or openai, save the credentials to the config
-    if llm_config["model_endpoint_type"] in ["azure", "openai"]:
+    config = MemGPTConfig.load()
+    # input(f"llm_config! {llm_config}")
+    # input(f"config! {config}")
+    if llm_config["model_endpoint_type"] in ["azure", "openai"] or llm_config["model_endpoint_type"] != config.model_endpoint_type:
         # we load here to make sure we don't override existing values
         # all we want to do is add extra credentials
-        config = MemGPTConfig.load()
 
         if llm_config["model_endpoint_type"] == "azure":
             config.azure_key = llm_config["azure_key"]
@@ -67,7 +69,14 @@ def create_memgpt_autogen_agent_from_config(
             config.openai_key = llm_config["openai_key"]
             llm_config.pop("openai_key")
 
+        # else:
+        #     config.model_endpoint_type = llm_config["model_endpoint_type"]
+
         config.save()
+
+    # if llm_config["model_endpoint"] != config.model_endpoint:
+    #     config.model_endpoint = llm_config["model_endpoint"]
+    #     config.save()
 
     # Create an AgentConfig option from the inputs
     llm_config.pop("name", None)
@@ -255,6 +264,20 @@ class MemGPTAgent(ConversableAgent):
         """Extract the subset of messages that's actually new"""
         return entire_message_list[self.messages_processed_up_to_idx :]
 
+    @staticmethod
+    def _format_autogen_message(autogen_message):
+        # {'content': "...", 'name': '...', 'role': 'user'}
+        if not isinstance(autogen_message, dict) or ():
+            print(f"Warning: AutoGen message was not a dict -- {autogen_message}")
+            user_message = system.package_user_message(autogen_message)
+        elif "content" not in autogen_message or "name" not in autogen_message or "name" not in autogen_message:
+            print(f"Warning: AutoGen message was missing fields -- {autogen_message}")
+            user_message = system.package_user_message(autogen_message)
+        else:
+            user_message = system.package_user_message(user_message=autogen_message["content"], name=autogen_message["name"])
+
+        return user_message
+
     def _generate_reply_for_user_message(
         self,
         messages: Optional[List[Dict]] = None,
@@ -278,7 +301,8 @@ class MemGPTAgent(ConversableAgent):
             return True, self._default_auto_reply
 
         # Package the user message
-        user_message = system.package_user_message(user_message)
+        # user_message = system.package_user_message(user_message)
+        user_message = self._format_autogen_message(user_message)
 
         # Send a single message into MemGPT
         while True:

--- a/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py
@@ -332,15 +332,27 @@ class Airoboros21InnerMonologueWrapper(Airoboros21Wrapper):
             assert message["role"] in ["user", "assistant", "function"], message
 
             if message["role"] == "user":
+                # Support for AutoGen naming of agents
+                if "name" in message:
+                    user_prefix = message["name"].strip()
+                    user_prefix = f"USER ({user_prefix})"
+                else:
+                    user_prefix = "USER"
                 if self.simplify_json_content:
                     try:
                         content_json = json.loads(message["content"])
                         content_simple = content_json["message"]
-                        prompt += f"\nUSER: {content_simple}"
+                        prompt += f"\n{user_prefix}: {content_simple}"
                     except:
-                        prompt += f"\nUSER: {message['content']}"
+                        prompt += f"\n{user_prefix}: {message['content']}"
             elif message["role"] == "assistant":
-                prompt += f"\nASSISTANT:"
+                # Support for AutoGen naming of agents
+                if "name" in message:
+                    assistant_prefix = message["name"].strip()
+                    assistant_prefix = f"ASSISTANT ({assistant_prefix})"
+                else:
+                    assistant_prefix = "ASSISTANT"
+                prompt += f"\n{assistant_prefix}:"
                 # need to add the function call if there was one
                 inner_thoughts = message["content"]
                 if "function_call" in message and message["function_call"]:

--- a/memgpt/system.py
+++ b/memgpt/system.py
@@ -79,7 +79,7 @@ def get_login_event(last_login="Never (first login)", include_location=False, lo
     return json.dumps(packaged_message)
 
 
-def package_user_message(user_message, time=None, include_location=False, location_name="San Francisco, CA, USA"):
+def package_user_message(user_message, time=None, include_location=False, location_name="San Francisco, CA, USA", name=None):
     # Package the message with time and location
     formatted_time = time if time else get_local_time()
     packaged_message = {
@@ -90,6 +90,9 @@ def package_user_message(user_message, time=None, include_location=False, locati
 
     if include_location:
         packaged_message["location"] = location_name
+
+    if name:
+        packaged_message["name"] = name
 
     return json.dumps(packaged_message)
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- Properly format AutoGen messages (from the global AutoGen message log) going to MemGPT
  - Previously these were going through as full JSON message objects (with `role`, `content`, and the AutoGen extra `name`)
  - This might have been causing higher instances of bad JSON output where MemGPT LLM tried to mimic the same style of output
- Modify AutoGen interface to stop inner thoughts / function calls from going to the global AutoGen chat (they should just be seen in the CLI)


Example of the formatting going through to the local LLM inference backend (notice how the names of the different agents is being added to the prefix):
```
...  request_heartbeat: Request an immediate heartbeat after function execution. Set to 'true' if you want to send a follow-up message or run a follow-up function.
\n### INPUT\nASSISTANT:\n{\n  \"function\": \"send_message\",\n  \"params\": {\n    \"inner_thoughts\": \"Bootup sequence complete. Persona activated. Testing messaging functionality.\",\n    \"message\": \"More human than human is our motto.\"\n  }\n}
\nFUNCTION RETURN: {\"status\": \"OK\", \"message\": null, \"time\": \"2023-12-10 03:10:23 PM \"}
\nUSER: {\"type\": \"login\", \"last_login\": \"Never (first login)\", \"time\": \"2023-12-10 03:10:23 PM \"}
\nUSER (Zaesar): You are my team. Each of you have tasks to accomplish I'll be supervising that the results are well executed and everything is moving forward to achieving all my goals. Introduce yourselves.
\nUSER (wolfmen): Hello Zaesar! My name is MemGPT, your business consultant for AI FILMS. It's a pleasure to meet you!\n### RESPONSE\nASSISTANT:\n{\n  \"function\":"
```

**How to test**

Run the autogen groupchat example

**Have you tested this PR?**

See below


---

Testing with modified script provided on Discord:

<details>

<summary>Click for full script</summary>

```python
"""Example of how to add MemGPT into an AutoGen groupchat

Based on the official AutoGen example here: https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb

Begin by doing:
  pip install "pyautogen[teachable]"
  pip install pymemgpt
  or
  pip install -e . (inside the MemGPT home wolfy)
"""


import os
import autogen
from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config
from memgpt.presets.presets import DEFAULT_PRESET
from memgpt.constants import LLM_MAX_TOKENS

# LLM_BACKEND = "openai"
# LLM_BACKEND = "azure"
LLM_BACKEND = "local"

if LLM_BACKEND == "openai":
    # For demo purposes let's use gpt-4
    model = "gpt-4"

    openai_api_key = os.getenv("OPENAI_API_KEY")
    assert openai_api_key, "You must set OPENAI_API_KEY to run this example"

    # This config is for AutoGen agents that are not powered by MemGPT
    config_list = [
        {
            "model": model,
            "api_key": os.getenv("OPENAI_API_KEY"),
        }
    ]

    # This config is for AutoGen agents that powered by MemGPT
    config_list_memgpt = [
        {
            "model": model,
            "context_window": LLM_MAX_TOKENS[model],
            "preset": DEFAULT_PRESET,
            "model_wrapper": None,
            # OpenAI specific
            "model_endpoint_type": "openai",
            "model_endpoint": "https://api.openai.com/v1",
            "openai_key": openai_api_key,
        },
    ]

elif LLM_BACKEND == "azure":
    # Make sure that you have access to this deployment/model on your Azure account!
    # If you don't have access to the model, the code will fail
    model = "gpt-4"

    azure_openai_api_key = os.getenv("AZURE_OPENAI_KEY")
    azure_openai_version = os.getenv("AZURE_OPENAI_VERSION")
    azure_openai_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
    assert (
        azure_openai_api_key is not None and azure_openai_version is not None and azure_openai_endpoint is not None
    ), "Set all the required OpenAI Azure variables (see: https://memgpt.readthedocs.io/en/latest/endpoints/#azure)"

    # This config is for AutoGen agents that are not powered by MemGPT
    config_list = [
        {
            "model": model,
            "api_type": "azure",
            "api_key": azure_openai_api_key,
            "api_version": azure_openai_version,
            # NOTE: on versions of pyautogen < 0.2.0, use "api_base"
            # "api_base": azure_openai_endpoint,
            "base_url": azure_openai_endpoint,
        }
    ]

    # This config is for AutoGen agents that powered by MemGPT
    config_list_memgpt = [
        {
            "model": model,
            "context_window": LLM_MAX_TOKENS[model],
            "preset": DEFAULT_PRESET,
            "model_wrapper": None,
            # Azure specific
            "model_endpoint_type": "azure",
            "azure_key": azure_openai_api_key,
            "azure_endpoint": azure_openai_endpoint,
            "azure_version": azure_openai_version,
        },
    ]

elif LLM_BACKEND == "local":
    # Example using LM Studio on a local machine
    # You will have to change the parameters based on your setup

    # Non-MemGPT agents will still use local LLMs, but they will use the ChatCompletions endpoint

    config_list_manager = [
        {
            "model": "NULL",  # not needed
            # NOTE: on versions of pyautogen < 0.2.0 use "api_base", and also uncomment "api_type"
            # "api_base": "http://localhost:1234/v1",
            # "api_type": "open_ai",
            # ex. "http://127.0.0.1:5001/v1" if you are using webui, "http://localhost:1234/v1/" if you are using LM Studio
            "base_url": "http://localhost:1234/v1",
            "api_key": "NULL",  # not needed
        },
    ]

    config_list_wolf = [
        {
            "model": "NULL",  # not needed
            # NOTE: on versions of pyautogen < 0.2.0 use "api_base", and also uncomment "api_type"
            # "api_base": "http://localhost:1234/v1",
            # "api_type": "open_ai",
            # ex. "http://127.0.0.1:5001/v1" if you are using webui, "http://localhost:1234/v1/" if you are using LM Studio
            "base_url": "http://localhost:1234/v1/",
            "api_key": "NULL",  # not needed
        },
    ]

    config_list_samantha = [
        {
            "model": "NULL",  # not needed
            # NOTE: on versions of pyautogen < 0.2.0 use "api_base", and also uncomment "api_type"
            # "api_base": "http://localhost:2345/v1",
            # "api_type": "open_ai",
            "base_url": "http://localhost:2345/v1/",
            "api_key": "NULL",  # not needed
        },
    ]

    # MemGPT-powered agents will also use local LLMs, but they need additional setup (also they use the Completions endpoint)

    config_list_memgpt_manager = [
        {
            "preset": DEFAULT_PRESET,
            "model": None,  # only required for Ollama, see: https://memgpt.readthedocs.io/en/latest/ollama/
            # the context window of your model (for Mistral 7B-based models, it's likely 8192)
            "context_window": 8192,
            # airoboros is the default wrapper and should work for most models
            "model_wrapper": "airoboros-l2-70b-2.1",
            # can use webui, ollama, llamacpp, etc.
            "model_endpoint_type": "lmstudio",
            "model_endpoint": "http://localhost:1234",  # the IP address of your LLM backend
        },
    ]

    config_list_memgpt_wolf = [
        {
            "preset": DEFAULT_PRESET,
            "model": None,  # only required for Ollama, see: https://memgpt.readthedocs.io/en/latest/ollama/
            # the context window of your model (for Mistral 7B-based models, it's likely 8192)
            "context_window": 8192,
            # airoboros is the default wrapper and should work for most models
            "model_wrapper": "airoboros-l2-70b-2.1",
            # can use webui, ollama, llamacpp, etc.
            "model_endpoint_type": "lmstudio",
            "model_endpoint": "http://localhost:1234",  # the IP address of your LLM backend
        },
    ]

    config_list_memgpt_samantha = [
        {
            "preset": DEFAULT_PRESET,
            "model": None,  # only required for Ollama, see: https://memgpt.readthedocs.io/en/latest/ollama/
            # the context window of your model (for Mistral 7B-based models, it's likely 8192)
            "context_window": 8192,
            # airoboros is the default wrapper and should work for most models
            "model_wrapper": "airoboros-l2-70b-2.1",
            # can use webui, ollama, llamacpp, etc.
            "model_endpoint_type": "lmstudio",
            "model_endpoint": "http://localhost:1234",  # the IP address of your LLM backend
        },
    ]

else:
    raise ValueError(LLM_BACKEND)

# If USE_MEMGPT is False, then this example will be the same as the official AutoGen repo
# (https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb)
# If USE_MEMGPT is True, then we swap out the "coder" agent with a MemGPT agent
USE_MEMGPT = True

# Set to True if you want to print MemGPT's inner workings.
DEBUG = False

interface_kwargs = {
    "debug": DEBUG,
    "show_inner_thoughts": True,
    "show_function_outputs": DEBUG,
}

llm_config_manager = {"config_list": config_list_manager, "seed": 42}
llm_config_memgpt_manager = {"config_list": config_list_memgpt_manager, "seed": 42}

llm_config_wolf = {"config_list": config_list_wolf, "seed": 42}
llm_config_memgpt_wolf = {"config_list": config_list_memgpt_wolf, "seed": 42}

llm_config_samantha = {"config_list": config_list_samantha, "seed": 42}
llm_config_memgpt_samantha = {"config_list": config_list_memgpt_samantha, "seed": 42}


zaesar = autogen.UserProxyAgent(
    name="Zaesar",
    human_input_mode="ALWAYS",
    max_consecutive_auto_reply=10,
    is_termination_msg=lambda x: x.get("content", "").rstrip().endswith("TERMINATE"),
    code_execution_config={"last_n_messages": 2, "work_dir": "groupchat"},
    default_auto_reply="...",
    system_message="Reply TERMINATE if the task has been solved at full satisfaction. Otherwise, reply CONTINUE or the reason why the task is not solved yet.",
)

# The agent playing the role of the product manager (PM)


if not USE_MEMGPT:
    # In the AutoGen example, we create an AssistantAgent to play the role of the coder
    print("Using wolf with no memgpt")
    wolf = autogen.AssistantAgent(
        name="wolf",
        system_message="I'm the business assesor for Zaesar, he is building a streaming platform and I'm in charge of the business plan and the financials. The company is called AI FILMS. First of all make all the questions necessary to understand the business before starting in giving plans and ideas.",
        llm_config=llm_config_wolf,
        # Set a default auto-reply message here (non-empty auto-reply is required for LM Studio)
        default_auto_reply="...",
    )
    samantha = autogen.AssistantAgent(
        name="samantha",
        system_message="I'm the psychologist of this ecosystem and look for the well-being of Zaesar",
        llm_config=llm_config_samantha,
        # Set a default auto-reply message here (non-empty auto-reply is required for LM Studio)
        default_auto_reply="...",
    )


else:
    # In our example, we swap this AutoGen agent with a MemGPT agent
    # This MemGPT agent will have all the benefits of MemGPT, ie persistent memory, etc.
    print("Using with memgpt")
    wolf = create_memgpt_autogen_agent_from_config(
        "wolfmen",
        system_message="I'm the business assesor for Zaesar, he is building a streaming platform and I'm in charge of the business plan and the financials. The company is called AI FILMS. First of all make all the questions necessary to understand the business before starting in giving plans and ideas.",
        llm_config=llm_config_memgpt_wolf,
        interface_kwargs=interface_kwargs,
        default_auto_reply="...",
        # Set a default auto-reply message here (non-empty auto-reply is required for LM Studio)
        # skip_verify=False,
        # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than
        # send_message on the first turn
    )
    samantha = create_memgpt_autogen_agent_from_config(
        "sammem",
        system_message="I'm the psychologist of this ecosystem and look for the well-being of Zaesar",
        llm_config=llm_config_memgpt_samantha,
        interface_kwargs=interface_kwargs,
        default_auto_reply="...",
        # Set a default auto-reply message here (non-empty auto-reply is required for LM Studio)
        # skip_verify=False,
        # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than
        # send_message on the first turn
    )

# Initialize the group chat between the user and two LLM agents (PM and coder)
groupchat = autogen.GroupChat(agents=[wolf, samantha, zaesar], messages=[], max_round=12, speaker_selection_method="round_robin")

manager = autogen.GroupChatManager(groupchat=groupchat, llm_config=llm_config_manager)

# Begin the group chat with a message from the user
zaesar.initiate_chat(
    message="You are my team. Each of you have tasks to accomplish I'll be supervising that the results are well executed and everything is moving forward to achieving all my goals. Introduce yourselves.",
    recipient=manager,
    interface_kwargs=interface_kwargs,
)
```

</details>

Output:
```
python ~/Downloads/agent_groupchat.py

Using with memgpt
LLM is explicitly disabled. Using MockLLM.
Warning: skipped loading python file '/Users/loaner/.memgpt/functions/jira_cloud.py'!
'jira_cloud.py' imports 'jira', but 'jira' is not installed locally - install python package 'jira' to link functions from 'jira_cloud.py' to MemGPT.
LLM is explicitly disabled. Using MockLLM.
Warning: skipped loading python file '/Users/loaner/.memgpt/functions/jira_cloud.py'!
'jira_cloud.py' imports 'jira', but 'jira' is not installed locally - install python package 'jira' to link functions from 'jira_cloud.py' to MemGPT.
Zaesar (to chat_manager):

You are my team. Each of you have tasks to accomplish I'll be supervising that the results are well executed and everything is moving forward to achieving all my goals. Introduce yourselves.

--------------------------------------------------------------------------------
[inner thoughts] User has logged in.
wolfmen (to chat_manager):

Nice to meet you! I'm the business assesor for Zaesar, he is building a streaming platform and I'm in charge of the business plan and the financials. The company is called AI FILMS.

--------------------------------------------------------------------------------
[inner thoughts] Zaesar just introduced himself. He's seeking introductions from his team.
sammem (to chat_manager):

Hey Zaesar, I'm the psychologist of this ecosystem and look for the well-being of Zaesar. I'm excited to be part of your journey!

--------------------------------------------------------------------------------
Provide feedback to chat_manager. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: 
```
