### PR TITLE
patch bug where `function_args.copy()` throws runtime error

### DIFF
--- a/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/airoboros.py
@@ -158,7 +158,7 @@ class Airoboros21Wrapper(LLMChatCompletionWrapper):
     def clean_function_args(self, function_name, function_args):
         """Some basic MemGPT-specific cleaning of function args"""
         cleaned_function_name = function_name
-        cleaned_function_args = function_args.copy()
+        cleaned_function_args = function_args.copy() if function_args is not None else {}
 
         if function_name == "send_message":
             # strip request_heartbeat
@@ -379,7 +379,7 @@ class Airoboros21InnerMonologueWrapper(Airoboros21Wrapper):
     def clean_function_args(self, function_name, function_args):
         """Some basic MemGPT-specific cleaning of function args"""
         cleaned_function_name = function_name
-        cleaned_function_args = function_args.copy()
+        cleaned_function_args = function_args.copy() if function_args is not None else {}
 
         if function_name == "send_message":
             # strip request_heartbeat

--- a/memgpt/local_llm/llm_chat_completion_wrappers/dolphin.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/dolphin.py
@@ -193,7 +193,7 @@ class Dolphin21MistralWrapper(LLMChatCompletionWrapper):
     def clean_function_args(self, function_name, function_args):
         """Some basic MemGPT-specific cleaning of function args"""
         cleaned_function_name = function_name
-        cleaned_function_args = function_args.copy()
+        cleaned_function_args = function_args.copy() if function_args is not None else {}
 
         if function_name == "send_message":
             # strip request_heartbeat

--- a/memgpt/local_llm/llm_chat_completion_wrappers/zephyr.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/zephyr.py
@@ -124,7 +124,7 @@ class ZephyrMistralWrapper(LLMChatCompletionWrapper):
     def clean_function_args(self, function_name, function_args):
         """Some basic MemGPT-specific cleaning of function args"""
         cleaned_function_name = function_name
-        cleaned_function_args = function_args.copy()
+        cleaned_function_args = function_args.copy() if function_args is not None else {}
 
         if function_name == "send_message":
             # strip request_heartbeat
@@ -283,7 +283,7 @@ class ZephyrMistralInnerMonologueWrapper(ZephyrMistralWrapper):
     def clean_function_args(self, function_name, function_args):
         """Some basic MemGPT-specific cleaning of function args"""
         cleaned_function_name = function_name
-        cleaned_function_args = function_args.copy()
+        cleaned_function_args = function_args.copy() if function_args is not None else {}
 
         if function_name == "send_message":
             # strip request_heartbeat


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Patch bug where if function args is None, `function_args.copy()` throws runtime error.


