### PR TITLE
feat: Add converter to support outbound calls to OpenAI servers that want `tool` not `function`

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -803,7 +803,7 @@ class Agent(object):
                 raise Exception("Finish reason was length (maximum context length)")
 
             # catches for soft errors
-            if response.choices[0].finish_reason not in ["stop", "function_call"]:
+            if response.choices[0].finish_reason not in ["stop", "function_call", "tool_calls"]:
                 raise Exception(f"API call finish with bad finish reason: {response}")
 
             # unpack with response.choices[0].message.content

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -1,4 +1,6 @@
 import random
+import os
+import string
 import time
 import requests
 import time
@@ -18,6 +20,111 @@ MODEL_TO_AZURE_ENGINE = {
     "gpt-3.5-turbo": "gpt-35-turbo",
     "gpt-3.5-turbo-16k": "gpt-35-turbo-16k",
 }
+
+
+def convert_from_functions_to_tools(data: dict, generate_tool_call_ids: bool = True, allow_content_in_tool_calls: bool = True) -> dict:
+    """Convert from the old style of 'functions' to 'tools'
+
+    Main differences that needs to be handled in the ChatCompletion request object:
+    (https://platform.openai.com/docs/api-reference/chat/create)
+
+    - data.function_call
+      -> data.tool_choice ("none" or "auto")
+    - data.functions (array of {description/name/parameters})
+      -> data.tools (array of (type: 'function', function: {description/name/arguments}))
+    - data.messages
+      - role == 'assistant'
+        - function_call ({arguments/name})
+          -> tool_calls (array of (id, type: 'function', function: {name/arguments}))
+      - role == 'function'
+        -> role == 'tool'
+        - name
+        -> tool_call_id
+    """
+
+    def create_tool_call_id(prefix: str = "call_", length: int = 22) -> str:
+        # Generate a random string of letters and digits
+        random_str = "".join(random.choices(string.ascii_letters + string.digits, k=length))
+        return prefix + random_str
+
+    data = data.copy()
+
+    # function_call -> tool_choice
+    # function_call = None -> tool_choice = "none"
+    if "function_call" in data:
+        data["tool_choice"] = data.pop("function_call")
+        if data["tool_choice"] is None:
+            # None = default option
+            data["tool_choice"] = "auto" if "functions" in data else "none"
+        elif data["tool_choice"] in ["none", "auto"]:
+            # !None = was manually set
+            data["tool_choice"] = data["tool_choice"]
+        else:
+            # Assume function call was set to a name
+            if isinstance(data["tool_choice"], dict) and "name" in data["tool_choice"]:
+                data["tool_choice"] = {"type": "function", "function": {"name": data["tool_choice"]["name"]}}
+            elif isinstance(data["tool_choice", str]):
+                data["tool_choice"] = {"type": "function", "function": {"name": data["tool_choice"]}}
+            else:
+                ValueError(data["tool_choice"])
+
+    # functions -> tools
+    if "functions" in data:
+        data["tools"] = [{"type": "function", "function": json_schema} for json_schema in data.pop("functions")]
+
+    # need to correct for assistant role (that calls functions)
+    # and function role (renamed to "tool" role)
+    if "messages" in data:
+        renamed_messages = []
+        for i, msg in enumerate(data["messages"]):
+            # correct the function role
+            if msg["role"] == "function":
+                msg["role"] = "tool"
+                if "name" in msg:
+                    # Use 'name' or None?
+                    if data["messages"][i - 1]["role"] == "assistant":
+                        # NOTE assumes len(tool_calls) == 1
+                        prior_message = data["messages"][i - 1]
+                        try:
+                            msg["tool_call_id"] = prior_message["tool_calls"][0]["id"]
+                        except (KeyError, IndexError, TypeError) as e:
+                            print(f"Warning: couldn't find tool_call id to match with tool result")
+                            # TODO figure out what we should do here if we can't find the relevant tool message (use 'name' or None?)
+                            # msg["tool_call_id"] = msg["name"]
+                            msg["tool_call_id"] = None
+
+                    else:
+                        # TODO figure out what we should do here if we can't find the relevant tool message (use 'name' or None?)
+                        # msg["tool_call_id"] = msg["name"]
+                        msg["tool_call_id"] = None
+
+                    # NOTE: According to the official API docs, 'tool' role shouldn't have name
+                    # However, it appears in their example docs + API throws an error when it's not included
+                    # https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models
+                    # msg.pop("name")
+
+            # correct the assistant role
+            elif msg["role"] == "assistant":
+                if "function_call" in msg:
+                    msg["tool_calls"] = [
+                        {
+                            # TODO should we use 'name' instead of None here?
+                            "id": create_tool_call_id() if generate_tool_call_ids else None,
+                            "type": "function",
+                            "function": msg.pop("function_call"),
+                        }
+                    ]
+                    if not allow_content_in_tool_calls:
+                        msg["content"] = None
+                        # TODO need backup of moving content into inner monologue parameter
+                        # (vs just deleting it)
+                        # raise NotImplementedError
+                        print(f"Warning: deleting 'content' in function call assistant message without replacement")
+
+            renamed_messages.append(msg)
+        data["messages"] = renamed_messages
+
+    return data
 
 
 def is_context_overflow_error(exception):
@@ -164,7 +271,7 @@ def azure_openai_get_model_list(url: str, api_key: Union[str, None], api_version
         raise e
 
 
-def openai_chat_completions_request(url, api_key, data):
+def openai_chat_completions_request(url, api_key, data, use_tool_naming=True):
     """https://platform.openai.com/docs/guides/text-generation?lang=curl"""
     from memgpt.utils import printd
 
@@ -175,6 +282,9 @@ def openai_chat_completions_request(url, api_key, data):
     if "functions" in data and data["functions"] is None:
         data.pop("functions")
         data.pop("function_call", None)  # extra safe,  should exist always (default="auto")
+
+    if use_tool_naming:
+        data = convert_from_functions_to_tools(data=data)
 
     printd(f"Sending request to {url}")
     try:
@@ -239,7 +349,7 @@ def openai_embeddings_request(url, api_key, data):
         raise e
 
 
-def azure_openai_chat_completions_request(resource_name, deployment_id, api_version, api_key, data):
+def azure_openai_chat_completions_request(resource_name, deployment_id, api_version, api_key, data, use_tool_naming=False):
     """https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions"""
     from memgpt.utils import printd
 
@@ -251,6 +361,10 @@ def azure_openai_chat_completions_request(resource_name, deployment_id, api_vers
     if "functions" in data and data["functions"] is None:
         data.pop("functions")
         data.pop("function_call", None)  # extra safe,  should exist always (default="auto")
+
+    if use_tool_naming:
+        # TODO azure doesn't seem to handle tool roles properly atm
+        data = convert_from_functions_to_tools(data=data)
 
     printd(f"Sending request to {url}")
     try:

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -271,7 +271,7 @@ def azure_openai_get_model_list(url: str, api_key: Union[str, None], api_version
         raise e
 
 
-def openai_chat_completions_request(url, api_key, data, use_tool_naming=False):
+def openai_chat_completions_request(url, api_key, data, use_tool_naming=True):
     """https://platform.openai.com/docs/guides/text-generation?lang=curl"""
     from memgpt.utils import printd
 
@@ -349,7 +349,7 @@ def openai_embeddings_request(url, api_key, data):
         raise e
 
 
-def azure_openai_chat_completions_request(resource_name, deployment_id, api_version, api_key, data, use_tool_naming=False):
+def azure_openai_chat_completions_request(resource_name, deployment_id, api_version, api_key, data, use_tool_naming=True):
     """https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions"""
     from memgpt.utils import printd
 

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -271,7 +271,7 @@ def azure_openai_get_model_list(url: str, api_key: Union[str, None], api_version
         raise e
 
 
-def openai_chat_completions_request(url, api_key, data, use_tool_naming=True):
+def openai_chat_completions_request(url, api_key, data, use_tool_naming=False):
     """https://platform.openai.com/docs/guides/text-generation?lang=curl"""
     from memgpt.utils import printd
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

The function naming (`function` / `function_call` / `function` role) is deprecated in OpenAI API and partially (?) deprecated in Azure OpenAI. OpenAI and Azure both still support the old naming methodology, but newer "OpenAI API-compatible" services that also allow function calling (eg Anyscale) don't support the old naming scheme and want `tool` only.

This PR adds a converter function that goes from the old format to the new one. This is done on-the-fly, ie we still store messages in the functions style but we modify it on the way out to the OpenAI API server.

@sarahwooders eventually we probably want to migrate the internal representations to the `tool_call` format, but I'm not sure how important it is for now, since unless we want to have parallel function calling support nothing really changes and these light patches work fine (AFAIK).

**How to test**

Try using MemGPT with a non-OpenAI OpenAI-compatible endpoint that has function calling, but only the `tool` version of function calling (eg Anyscale).

**Have you tested this PR?**

Yes, seems to work OK with Anyscale.