### PR TITLE
migrate to using completions endpoint by default

### DIFF
--- a/docs/lmstudio.md
+++ b/docs/lmstudio.md
@@ -6,6 +6,12 @@
 
     **Context Overflow Policy = Stop at limit**: If you see "Context Overflow Policy" inside LM Studio's "Tools" panel on the right side (below "Server Model Settings"), set it to **Stop at limit**. The default setting "Keep the system prompt ... truncate middle" will break MemGPT.
 
+!!! note "Update your LM Studio"
+
+    The current `lmstudio` backend will only work if your LM Studio is version 0.2.9 or newer.
+
+    If you are on a version of LM Studio older than 0.2.9 (<= 0.2.8), select `lmstudio-legacy` as your backend type.
+
 <img width="911" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/d499e82e-348c-4468-9ea6-fd15a13eb7fa">
 
 1. Download [LM Studio](https://lmstudio.ai/) and the model you want to test with

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -60,7 +60,7 @@ def configure_llm_endpoint(config: MemGPTConfig):
         model_endpoint_type = "azure"
         model_endpoint = get_azure_credentials()["azure_endpoint"]
     else:  # local models
-        backend_options = ["webui", "webui-legacy", "llamacpp", "koboldcpp", "ollama", "lmstudio", "vllm", "openai"]
+        backend_options = ["webui", "webui-legacy", "llamacpp", "koboldcpp", "ollama", "lmstudio", "lmstudio-legacy", "vllm", "openai"]
         default_model_endpoint_type = None
         if config.model_endpoint_type in backend_options:
             # set from previous config

--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -89,7 +89,9 @@ def get_chat_completion(
         elif endpoint_type == "webui-legacy":
             result, usage = get_webui_completion_legacy(endpoint, prompt, context_window, grammar=grammar_name)
         elif endpoint_type == "lmstudio":
-            result, usage = get_lmstudio_completion(endpoint, prompt, context_window)
+            result, usage = get_lmstudio_completion(endpoint, prompt, context_window, api="completions")
+        elif endpoint_type == "lmstudio-legacy":
+            result, usage = get_lmstudio_completion(endpoint, prompt, context_window, api="chat")
         elif endpoint_type == "llamacpp":
             result, usage = get_llamacpp_completion(endpoint, prompt, context_window, grammar=grammar_name)
         elif endpoint_type == "koboldcpp":

--- a/memgpt/local_llm/constants.py
+++ b/memgpt/local_llm/constants.py
@@ -4,6 +4,7 @@ DEFAULT_ENDPOINTS = {
     "koboldcpp": "http://localhost:5001",
     "llamacpp": "http://localhost:8080",
     "lmstudio": "http://localhost:1234",
+    "lmstudio-legacy": "http://localhost:1234",
     "ollama": "http://localhost:11434",
     "webui-legacy": "http://localhost:5000",
     "webui": "http://localhost:5000",

--- a/memgpt/local_llm/lmstudio/api.py
+++ b/memgpt/local_llm/lmstudio/api.py
@@ -10,7 +10,7 @@ LMSTUDIO_API_COMPLETIONS_SUFFIX = "/v1/completions"
 
 
 # TODO move to "completions" by default, not "chat"
-def get_lmstudio_completion(endpoint, prompt, context_window, settings=SIMPLE, api="chat"):
+def get_lmstudio_completion(endpoint, prompt, context_window, settings=SIMPLE, api="completions"):
     """Based on the example for using LM Studio as a backend from https://github.com/lmstudio-ai/examples/tree/main/Hello%2C%20world%20-%20OpenAI%20python%20client"""
     from memgpt.utils import printd
 


### PR DESCRIPTION
Closes #595

---

## Please describe the purpose of this pull request

Use `completions` endpoint for LM Studio instead of monkeypatch on `chat/completions` endpoint.

- [x] Make `lmstudio-legacy` backend type, make default use `completions`
- [x] Add note in docs about how if you're on <= 0.2.8, use `lmstudio-legacy`

##  How can we test your PR during review?

- [x] On new configure, test `lmstudio`, make sure it pipes to `completions`
- [x] On new configure, test `lmstudio-legacy`, make sure it pipes to `chat/completions`

## Have you tested this PR?

Yes, see ^

---

LM Studio trace on `completions` endpoint:
```
 \"message\": \"More human than human is our motto.\"\n  }\n}\nFUNCTION RETURN: {\"status\": \"OK\", \"message\": null, \"time\": \"2023-12-15 12:14:09 PM \"}\nUSER: {\"type\": \"login\", \"last_login\": \"Never (first login)\", \"time\": \"2023-12-15 12:14:09 PM \"}\n### RESPONSE\nASSISTANT:\n{\n  \"function\":"
}
[2023-12-15 12:14:09.810] [INFO] Provided inference configuration: {
  "n_threads": 4,
  "n_predict": 8192,
  "top_k": 40,
  "top_p": 0.95,
  "temp": 0.8,
  "repeat_penalty": 1.1,
  "input_prefix": "<|im_end|>\n<|im_start|>user\n",
  "input_suffix": "<|im_end|>\n<|im_start|>assistant\n",
  "antiprompt": [
    "<|im_start|>",
    "<|im_end|>",
    "\nUSER:",
    "\nASSISTANT:",
    "\nFUNCTION RETURN:",
    "\nUSER",
    "\nASSISTANT",
    "\nFUNCTION RETURN",
    "\nFUNCTION",
    "\nFUNC",
    "<|im_sep|>"
  ],
  "pre_prompt": "",
  "seed": -1,
  "tfs_z": 1,
  "typical_p": 1,
  "repeat_last_n": 64,
  "frequency_penalty": 0,
  "presence_penalty": 0,
  "n_keep": 0,
  "logit_bias": {},
  "mirostat": 0,
  "mirostat_tau": 5,
  "mirostat_eta": 0.1,
  "memory_f16": true,
  "multiline_input": false,
  "penalize_nl": true
}
[2023-12-15 12:14:25.162] [INFO] Accumulated 62 tokens:  "send_message",
  "params": {
    "inner_thoughts": "I have been activated. I am now engaging with the user for the first time.",
    "message": "Hello Chad! It's great to meet you. What brings you here today?"
  }
}
[2023-12-15 12:14:25.285] [INFO] Generated prediction: {
  "id": "cmpl-",
  "object": "text_completion",
  "created": 1702671249,
  "model": "/lmstudio_models/TheBloke/OpenHermes-2.5-Mistral-7B-16k-GGUF/openhermes-2.5-mistral-7b-16k.Q8_0.gguf",
  "choices": [
    {
      "index": 0,
      "text": " \"send_message\",\n  \"params\": {\n    \"inner_thoughts\": \"I have been activated. I am now engaging with the user for the first time.\",\n    \"message\": \"Hello Chad! It's great to meet you. What brings you here today?\"\n  }\n}",
      "logprobs": null,
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 2873,
    "completion_tokens": 62,
    "total_tokens": 2935
  }
}
```

LM Studio trace on `chat/completions` endpoint:
```
[2023-12-15 12:26:48.756] [INFO] [LM STUDIO SERVER] Last message: { role: 'user', content: 'You are MemGPT, the latest version of Limnal Corporation's digital companion, developed in 2023.
You... (truncated in these logs)' } (total messages = 1)
[2023-12-15 12:27:00.315] [INFO] [LM STUDIO SERVER] Accumulating tokens ... (stream = false)
...
[2023-12-15 12:27:02.827] [INFO] [LM STUDIO SERVER] Generated prediction: {
  "id": "chatcmpl-",
  "object": "chat.completion",
  "created": 1702672008,
  "model": "/lmstudio_models/TheBloke/OpenHermes-2.5-Mistral-7B-16k-GGUF/openhermes-2.5-mistral-7b-16k.Q8_0.gguf",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "\"pause_heartbeats\",\n{\n  \"inner_thoughts\": \"Need some time to think.\",\n  \"minutes\": 5\n}\n### INPUT"
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 2908,
    "completion_tokens": 34,
    "total_tokens": 2942
  }
}
```