### PR TITLE
Patch bug with loading of old agents

### DIFF
--- a/memgpt/openai_backcompat/openai_object.py
+++ b/memgpt/openai_backcompat/openai_object.py
@@ -1,0 +1,441 @@
+# https://github.com/openai/openai-python/blob/v0.27.4/openai/openai_object.py
+
+import json
+from copy import deepcopy
+from typing import Optional, Tuple, Union
+
+from enum import Enum
+
+import openai
+
+# from openai import api_requestor, util
+# from openai.openai_response import OpenAIResponse
+# from openai.util import ApiType
+
+api_requestor = None
+api_resources = None
+CompletionConfig = None
+
+OBJECT_CLASSES = {
+    # "engine": api_resources.Engine,
+    # "experimental.completion_config": CompletionConfig,
+    # "file": api_resources.File,
+    # "fine-tune": api_resources.FineTune,
+    # "model": api_resources.Model,
+    # "deployment": api_resources.Deployment,
+}
+
+
+def get_object_classes():
+    # This is here to avoid a circular dependency
+    # from openai.object_classes import OBJECT_CLASSES
+
+    return OBJECT_CLASSES
+
+
+class OpenAIResponse:
+    def __init__(self, data, headers):
+        self._headers = headers
+        self.data = data
+
+    @property
+    def request_id(self) -> Optional[str]:
+        return self._headers.get("request-id")
+
+    @property
+    def organization(self) -> Optional[str]:
+        return self._headers.get("OpenAI-Organization")
+
+    @property
+    def response_ms(self) -> Optional[int]:
+        h = self._headers.get("Openai-Processing-Ms")
+        return None if h is None else round(float(h))
+
+
+class ApiType(Enum):
+    AZURE = 1
+    OPEN_AI = 2
+    AZURE_AD = 3
+
+    @staticmethod
+    def from_str(label):
+        if label.lower() == "azure":
+            return ApiType.AZURE
+        elif label.lower() in ("azure_ad", "azuread"):
+            return ApiType.AZURE_AD
+        elif label.lower() in ("open_ai", "openai"):
+            return ApiType.OPEN_AI
+        else:
+            raise openai.error.InvalidAPIType(
+                "The API type provided in invalid. Please select one of the supported API types: 'azure', 'azure_ad', 'open_ai'"
+            )
+
+
+class OpenAIObject(dict):
+    api_base_override = None
+
+    def __init__(
+        self,
+        id=None,
+        api_key=None,
+        api_version=None,
+        api_type=None,
+        organization=None,
+        response_ms: Optional[int] = None,
+        api_base=None,
+        engine=None,
+        **params,
+    ):
+        super(OpenAIObject, self).__init__()
+
+        if response_ms is not None and not isinstance(response_ms, int):
+            raise TypeError(f"response_ms is a {type(response_ms).__name__}.")
+        self._response_ms = response_ms
+
+        self._retrieve_params = params
+
+        object.__setattr__(self, "api_key", api_key)
+        object.__setattr__(self, "api_version", api_version)
+        object.__setattr__(self, "api_type", api_type)
+        object.__setattr__(self, "organization", organization)
+        object.__setattr__(self, "api_base_override", api_base)
+        object.__setattr__(self, "engine", engine)
+
+        if id:
+            self["id"] = id
+
+    @property
+    def response_ms(self) -> Optional[int]:
+        return self._response_ms
+
+    def __setattr__(self, k, v):
+        if k[0] == "_" or k in self.__dict__:
+            return super(OpenAIObject, self).__setattr__(k, v)
+
+        self[k] = v
+        return None
+
+    def __getattr__(self, k):
+        if k[0] == "_":
+            raise AttributeError(k)
+        try:
+            return self[k]
+        except KeyError as err:
+            raise AttributeError(*err.args)
+
+    def __delattr__(self, k):
+        if k[0] == "_" or k in self.__dict__:
+            return super(OpenAIObject, self).__delattr__(k)
+        else:
+            del self[k]
+
+    def __setitem__(self, k, v):
+        if v == "":
+            raise ValueError(
+                "You cannot set %s to an empty string. "
+                "We interpret empty strings as None in requests."
+                "You may set %s.%s = None to delete the property" % (k, str(self), k)
+            )
+        super(OpenAIObject, self).__setitem__(k, v)
+
+    def __delitem__(self, k):
+        raise NotImplementedError("del is not supported")
+
+    # Custom unpickling method that uses `update` to update the dictionary
+    # without calling __setitem__, which would fail if any value is an empty
+    # string
+    def __setstate__(self, state):
+        self.update(state)
+
+    # Custom pickling method to ensure the instance is pickled as a custom
+    # class and not as a dict, otherwise __setstate__ would not be called when
+    # unpickling.
+    def __reduce__(self):
+        reduce_value = (
+            type(self),  # callable
+            (  # args
+                self.get("id", None),
+                self.api_key,
+                self.api_version,
+                self.api_type,
+                self.organization,
+            ),
+            dict(self),  # state
+        )
+        return reduce_value
+
+    @classmethod
+    def construct_from(
+        cls,
+        values,
+        api_key: Optional[str] = None,
+        api_version=None,
+        organization=None,
+        engine=None,
+        response_ms: Optional[int] = None,
+    ):
+        instance = cls(
+            values.get("id"),
+            api_key=api_key,
+            api_version=api_version,
+            organization=organization,
+            engine=engine,
+            response_ms=response_ms,
+        )
+        instance.refresh_from(
+            values,
+            api_key=api_key,
+            api_version=api_version,
+            organization=organization,
+            response_ms=response_ms,
+        )
+        return instance
+
+    def refresh_from(
+        self,
+        values,
+        api_key=None,
+        api_version=None,
+        api_type=None,
+        organization=None,
+        response_ms: Optional[int] = None,
+    ):
+        self.api_key = api_key or getattr(values, "api_key", None)
+        self.api_version = api_version or getattr(values, "api_version", None)
+        self.api_type = api_type or getattr(values, "api_type", None)
+        self.organization = organization or getattr(values, "organization", None)
+        self._response_ms = response_ms or getattr(values, "_response_ms", None)
+
+        # Wipe old state before setting new.
+        self.clear()
+        for k, v in values.items():
+            super(OpenAIObject, self).__setitem__(k, convert_to_openai_object(v, api_key, api_version, organization))
+
+        self._previous = values
+
+    @classmethod
+    def api_base(cls):
+        return None
+
+    def request(
+        self,
+        method,
+        url,
+        params=None,
+        headers=None,
+        stream=False,
+        plain_old_data=False,
+        request_id: Optional[str] = None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+    ):
+        if params is None:
+            params = self._retrieve_params
+        requestor = api_requestor.APIRequestor(
+            key=self.api_key,
+            api_base=self.api_base_override or self.api_base(),
+            api_type=self.api_type,
+            api_version=self.api_version,
+            organization=self.organization,
+        )
+        response, stream, api_key = requestor.request(
+            method,
+            url,
+            params=params,
+            stream=stream,
+            headers=headers,
+            request_id=request_id,
+            request_timeout=request_timeout,
+        )
+
+        if stream:
+            assert not isinstance(response, OpenAIResponse)  # must be an iterator
+            return (
+                convert_to_openai_object(
+                    line,
+                    api_key,
+                    self.api_version,
+                    self.organization,
+                    plain_old_data=plain_old_data,
+                )
+                for line in response
+            )
+        else:
+            return convert_to_openai_object(
+                response,
+                api_key,
+                self.api_version,
+                self.organization,
+                plain_old_data=plain_old_data,
+            )
+
+    async def arequest(
+        self,
+        method,
+        url,
+        params=None,
+        headers=None,
+        stream=False,
+        plain_old_data=False,
+        request_id: Optional[str] = None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+    ):
+        if params is None:
+            params = self._retrieve_params
+        requestor = api_requestor.APIRequestor(
+            key=self.api_key,
+            api_base=self.api_base_override or self.api_base(),
+            api_type=self.api_type,
+            api_version=self.api_version,
+            organization=self.organization,
+        )
+        response, stream, api_key = await requestor.arequest(
+            method,
+            url,
+            params=params,
+            stream=stream,
+            headers=headers,
+            request_id=request_id,
+            request_timeout=request_timeout,
+        )
+
+        if stream:
+            assert not isinstance(response, OpenAIResponse)  # must be an iterator
+            return (
+                convert_to_openai_object(
+                    line,
+                    api_key,
+                    self.api_version,
+                    self.organization,
+                    plain_old_data=plain_old_data,
+                )
+                for line in response
+            )
+        else:
+            return convert_to_openai_object(
+                response,
+                api_key,
+                self.api_version,
+                self.organization,
+                plain_old_data=plain_old_data,
+            )
+
+    def __repr__(self):
+        ident_parts = [type(self).__name__]
+
+        obj = self.get("object")
+        if isinstance(obj, str):
+            ident_parts.append(obj)
+
+        if isinstance(self.get("id"), str):
+            ident_parts.append("id=%s" % (self.get("id"),))
+
+        unicode_repr = "<%s at %s> JSON: %s" % (
+            " ".join(ident_parts),
+            hex(id(self)),
+            str(self),
+        )
+
+        return unicode_repr
+
+    def __str__(self):
+        obj = self.to_dict_recursive()
+        return json.dumps(obj, sort_keys=True, indent=2)
+
+    def to_dict(self):
+        return dict(self)
+
+    def to_dict_recursive(self):
+        d = dict(self)
+        for k, v in d.items():
+            if isinstance(v, OpenAIObject):
+                d[k] = v.to_dict_recursive()
+            elif isinstance(v, list):
+                d[k] = [e.to_dict_recursive() if isinstance(e, OpenAIObject) else e for e in v]
+        return d
+
+    @property
+    def openai_id(self):
+        return self.id
+
+    @property
+    def typed_api_type(self):
+        return ApiType.from_str(self.api_type) if self.api_type else ApiType.from_str(openai.api_type)
+
+    # This class overrides __setitem__ to throw exceptions on inputs that it
+    # doesn't like. This can cause problems when we try to copy an object
+    # wholesale because some data that's returned from the API may not be valid
+    # if it was set to be set manually. Here we override the class' copy
+    # arguments so that we can bypass these possible exceptions on __setitem__.
+    def __copy__(self):
+        copied = OpenAIObject(
+            self.get("id"),
+            self.api_key,
+            api_version=self.api_version,
+            api_type=self.api_type,
+            organization=self.organization,
+        )
+
+        copied._retrieve_params = self._retrieve_params
+
+        for k, v in self.items():
+            # Call parent's __setitem__ to avoid checks that we've added in the
+            # overridden version that can throw exceptions.
+            super(OpenAIObject, copied).__setitem__(k, v)
+
+        return copied
+
+    # This class overrides __setitem__ to throw exceptions on inputs that it
+    # doesn't like. This can cause problems when we try to copy an object
+    # wholesale because some data that's returned from the API may not be valid
+    # if it was set to be set manually. Here we override the class' copy
+    # arguments so that we can bypass these possible exceptions on __setitem__.
+    def __deepcopy__(self, memo):
+        copied = self.__copy__()
+        memo[id(self)] = copied
+
+        for k, v in self.items():
+            # Call parent's __setitem__ to avoid checks that we've added in the
+            # overridden version that can throw exceptions.
+            super(OpenAIObject, copied).__setitem__(k, deepcopy(v, memo))
+
+        return copied
+
+
+def convert_to_openai_object(
+    resp,
+    api_key=None,
+    api_version=None,
+    organization=None,
+    engine=None,
+    plain_old_data=False,
+):
+    # If we get a OpenAIResponse, we'll want to return a OpenAIObject.
+
+    response_ms: Optional[int] = None
+    if isinstance(resp, OpenAIResponse):
+        organization = resp.organization
+        response_ms = resp.response_ms
+        resp = resp.data
+
+    if plain_old_data:
+        return resp
+    elif isinstance(resp, list):
+        return [convert_to_openai_object(i, api_key, api_version, organization, engine=engine) for i in resp]
+    elif isinstance(resp, dict) and not isinstance(resp, OpenAIObject):
+        resp = resp.copy()
+        klass_name = resp.get("object")
+        if isinstance(klass_name, str):
+            klass = get_object_classes().get(klass_name, OpenAIObject)
+        else:
+            klass = OpenAIObject
+
+        return klass.construct_from(
+            resp,
+            api_key=api_key,
+            api_version=api_version,
+            organization=organization,
+            response_ms=response_ms,
+            engine=engine,
+        )
+    else:
+        return resp

--- a/memgpt/persistence_manager.py
+++ b/memgpt/persistence_manager.py
@@ -5,7 +5,7 @@ from memgpt.memory import (
     DummyRecallMemory,
     EmbeddingArchivalMemory,
 )
-from memgpt.utils import get_local_time, printd, CustomUnpickler
+from memgpt.utils import get_local_time, printd, OpenAIBackcompatUnpickler
 
 
 class PersistenceManager(ABC):
@@ -55,7 +55,7 @@ class LocalStateManager(PersistenceManager):
             # Patch for stripped openai package
             # ModuleNotFoundError: No module named 'openai.openai_object'
             with open(filename, "rb") as f:
-                unpickler = CustomUnpickler(f)
+                unpickler = OpenAIBackcompatUnpickler(f)
                 data = unpickler.load()
             # print(f"Unpickled data:\n{data.keys()}")
 

--- a/memgpt/persistence_manager.py
+++ b/memgpt/persistence_manager.py
@@ -5,7 +5,7 @@ from memgpt.memory import (
     DummyRecallMemory,
     EmbeddingArchivalMemory,
 )
-from memgpt.utils import get_local_time, printd
+from memgpt.utils import get_local_time, printd, CustomUnpickler
 
 
 class PersistenceManager(ABC):
@@ -48,8 +48,33 @@ class LocalStateManager(PersistenceManager):
     @classmethod
     def load(cls, filename, agent_config: AgentConfig):
         """ Load a LocalStateManager from a file. """ ""
-        with open(filename, "rb") as f:
-            data = pickle.load(f)
+        try:
+            with open(filename, "rb") as f:
+                data = pickle.load(f)
+        except ModuleNotFoundError as e:
+            # Patch for stripped openai package
+            # ModuleNotFoundError: No module named 'openai.openai_object'
+            with open(filename, "rb") as f:
+                unpickler = CustomUnpickler(f)
+                data = unpickler.load()
+            # print(f"Unpickled data:\n{data.keys()}")
+
+            from memgpt.openai_backcompat.openai_object import OpenAIObject
+
+            def convert_openai_objects_to_dict(obj):
+                if isinstance(obj, OpenAIObject):
+                    # Convert to dict or handle as needed
+                    # print(f"detected OpenAIObject on {obj}")
+                    return obj.to_dict_recursive()
+                elif isinstance(obj, dict):
+                    return {k: convert_openai_objects_to_dict(v) for k, v in obj.items()}
+                elif isinstance(obj, list):
+                    return [convert_openai_objects_to_dict(v) for v in obj]
+                else:
+                    return obj
+
+            data = convert_openai_objects_to_dict(data)
+            # print(f"Converted data:\n{data.keys()}")
 
         manager = cls(agent_config)
         manager.all_messages = data["all_messages"]

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -19,75 +19,10 @@ from memgpt.openai_backcompat.openai_object import OpenAIObject
 DEBUG = False
 
 
-# Assuming 'openai.openai_object' is a simple JSON object, create a substitute class
-class OpenAIObjectSubstitute:
-    def __init__(self, data):
-        self.data = data
-
-    def __getattr__(self, name):
-        # Implement any necessary methods or attributes here
-        return self.data.get(name)
-
-
-def openai_object_to_box(*args, **kwargs):
-    # Initialize a Box with default configuration
-    box_obj = Box()
-
-    # Prepare data from args and kwargs
-    data = dict(zip(["id", "api_key", "api_version", "api_type", "organization"], args))
-    data.update(kwargs)
-
-    # Update the Box object with actual data
-    box_obj.update(data)
-
-    print("BOX", box_obj)
-    print("args", args)
-    return box_obj
-
-
-# Custom function to handle openai.openai_object conversion
-def openai_object_to_dict(*args, **kwargs):
-    # Construct a dictionary from args and kwargs
-    data = {}
-    # Assuming the first argument is always the id
-    if args:
-        data["id"] = args[0]
-    data.update(kwargs)
-    return data
-
-
-class BoxSubstitute(Box):
-    def __setstate__(self, state):
-        # Check if '_box_config' is in the state, else initialize it
-        if "_box_config" not in state:
-            state["_box_config"] = Box._box_config_default.copy()
-        super().__setstate__(state)
-
-
-class OpenAIObjectMock:
-    def __init__(self, *args, **kwargs):
-        # Set attributes from args and kwargs
-        for key, value in zip(["id", "api_key", "api_version", "api_type", "organization"], args):
-            setattr(self, key, value)
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-    def __getattr__(self, name):
-        # Return None or a default value if the attribute doesn't exist
-        return getattr(self, name, None)
-
-
 # Custom unpickler
-class CustomUnpickler(pickle.Unpickler):
+class OpenAIBackcompatUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
         if module == "openai.openai_object":
-            # return OpenAIObjectSubstitute
-            # return Box
-            # return openai_object_to_box
-            # return BoxSubstitute
-            # return dict
-            # return openai_object_to_dict
-            # return OpenAIObjectMock
             return OpenAIObject
         return super().find_class(module, name)
 

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -1,16 +1,95 @@
 from datetime import datetime
+import json
+import os
+import pickle
+
+from box import Box
 import difflib
 import demjson3 as demjson
-import json
 import pytz
-import os
 import tiktoken
+
 import memgpt
 from memgpt.constants import MEMGPT_DIR, FUNCTION_RETURN_CHAR_LIMIT, CLI_WARNING_PREFIX
+
+from memgpt.openai_backcompat.openai_object import OpenAIObject
 
 # TODO: what is this?
 # DEBUG = True
 DEBUG = False
+
+
+# Assuming 'openai.openai_object' is a simple JSON object, create a substitute class
+class OpenAIObjectSubstitute:
+    def __init__(self, data):
+        self.data = data
+
+    def __getattr__(self, name):
+        # Implement any necessary methods or attributes here
+        return self.data.get(name)
+
+
+def openai_object_to_box(*args, **kwargs):
+    # Initialize a Box with default configuration
+    box_obj = Box()
+
+    # Prepare data from args and kwargs
+    data = dict(zip(["id", "api_key", "api_version", "api_type", "organization"], args))
+    data.update(kwargs)
+
+    # Update the Box object with actual data
+    box_obj.update(data)
+
+    print("BOX", box_obj)
+    print("args", args)
+    return box_obj
+
+
+# Custom function to handle openai.openai_object conversion
+def openai_object_to_dict(*args, **kwargs):
+    # Construct a dictionary from args and kwargs
+    data = {}
+    # Assuming the first argument is always the id
+    if args:
+        data["id"] = args[0]
+    data.update(kwargs)
+    return data
+
+
+class BoxSubstitute(Box):
+    def __setstate__(self, state):
+        # Check if '_box_config' is in the state, else initialize it
+        if "_box_config" not in state:
+            state["_box_config"] = Box._box_config_default.copy()
+        super().__setstate__(state)
+
+
+class OpenAIObjectMock:
+    def __init__(self, *args, **kwargs):
+        # Set attributes from args and kwargs
+        for key, value in zip(["id", "api_key", "api_version", "api_type", "organization"], args):
+            setattr(self, key, value)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __getattr__(self, name):
+        # Return None or a default value if the attribute doesn't exist
+        return getattr(self, name, None)
+
+
+# Custom unpickler
+class CustomUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == "openai.openai_object":
+            # return OpenAIObjectSubstitute
+            # return Box
+            # return openai_object_to_box
+            # return BoxSubstitute
+            # return dict
+            # return openai_object_to_dict
+            # return OpenAIObjectMock
+            return OpenAIObject
+        return super().find_class(module, name)
 
 
 def count_tokens(s: str, model: str = "gpt-4") -> int:

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -3,7 +3,6 @@ import json
 import os
 import pickle
 
-from box import Box
 import difflib
 import demjson3 as demjson
 import pytz


### PR DESCRIPTION
Closes #610

---

**Please describe the purpose of this pull request.**

When using the local state manager, message objects of type `openai.openai_object.OpenAIObject` were getting written to the persistence manager (should have been `OpenAIObject.to_dict_recursive()`). With the v1 client update, the `openai` python package no longer has an `OpenAIObject`, so existing pickles are borked.

AFAIK we have two options here:
1. Provide a converter script that installs an old version of `pymemgpt` and `openai` (< 1.0), and runs through all the pickle files and converts any `OpenAIObject`s into standard `dict`s.
2. Add a `OpenAIObjectMock` class to our own code, and use a custom unpickler that loads into the custom class that has the same interface(-ish), and writes out the mock class into a `dict` before finishing the load.

(2) results in some ugly backcompat code but it's isolate to its own file, and doesn't require the user running a split script with its own venv unlike (1).

**How to test**

@sarahwooders 

- [x] On `main`: Try loading an old agent file and you should see the error from #610.
- [x] On this PR: Try loading the same file, it should work fine.

**Have you tested this PR?**

Yes

On `main`:
```
(pymemgpt-py3.10) loaner@MacBook-Pro-5 MemGPT-2 % memgpt run
? Would you like to select an existing agent? Yes
? Select agent: corrupto
Using existing agent corrupto
Traceback (most recent call last):
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/bin/memgpt", line 6, in <module>
    sys.exit(app())
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/typer/main.py", line 328, in __call__
    raise e
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/typer/main.py", line 311, in __call__
    return get_command(self)(*args, **kwargs)
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/typer/core.py", line 778, in main
    return _main(
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/typer/core.py", line 216, in _main
    rv = self.invoke(ctx)
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/typer/main.py", line 683, in wrapper
    return callback(**use_params)  # type: ignore
  File "/Users/loaner/dev/MemGPT-2/memgpt/cli/cli.py", line 230, in run
    memgpt_agent = Agent.load_agent(interface, agent_config)
  File "/Users/loaner/dev/MemGPT-2/memgpt/agent.py", line 296, in load_agent
    persistence_manager = LocalStateManager.load(os.path.join(directory, filename), agent_config)
  File "/Users/loaner/dev/MemGPT-2/memgpt/persistence_manager.py", line 52, in load
    data = pickle.load(f)
ModuleNotFoundError: No module named 'memgpt.openai_backcompat.openai_object'
(pymemgpt-py3.10) loaner@MacBook-Pro-5 MemGPT-2 %
```

On PR:
```
(pymemgpt-py3.10) loaner@MacBook-Pro-5 MemGPT-2 % memgpt run
? Would you like to select an existing agent? Yes
? Select agent: corrupto
Using existing agent corrupto
LLM is explicitly disabled. Using MockLLM.
LLM is explicitly disabled. Using MockLLM.
Warning: skipped loading python file '/Users/loaner/.memgpt/functions/jira_cloud.py'!
'jira_cloud.py' imports 'jira', but 'jira' is not installed locally - install python package 'jira' to link functions from 'jira_cloud.py' to MemGPT.
Hit enter to begin (will request first MemGPT message)
💭 ...
> Enter your message:
```
