### PR TITLE
feat: added memgpt folder command

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -16,13 +16,22 @@ from memgpt.interface import CLIInterface as interface  # for printing to termin
 from memgpt.cli.cli_config import configure
 import memgpt.presets.presets as presets
 import memgpt.utils as utils
-from memgpt.utils import printd
+from memgpt.utils import printd, open_folder_in_explorer
 from memgpt.persistence_manager import LocalStateManager
 from memgpt.config import MemGPTConfig, AgentConfig
 from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX
 from memgpt.agent import Agent
 from memgpt.embeddings import embedding_model
 from memgpt.server.constants import WS_DEFAULT_PORT, REST_DEFAULT_PORT
+
+
+def open_folder():
+    """Open a folder viewer of the MemGPT home directory"""
+    try:
+        print(f"Opening home folder: {MEMGPT_DIR}")
+        open_folder_in_explorer(MEMGPT_DIR)
+    except Exception as e:
+        print(f"Failed to open folder with system viewer, error:\n{e}")
 
 
 class ServerChoice(Enum):

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -21,7 +21,7 @@ from memgpt.interface import CLIInterface as interface  # for printing to termin
 import memgpt.agent as agent
 import memgpt.system as system
 import memgpt.constants as constants
-from memgpt.cli.cli import run, attach, version, server
+from memgpt.cli.cli import run, attach, version, server, open_folder
 from memgpt.cli.cli_config import configure, list, add
 from memgpt.cli.cli_load import app as load_app
 from memgpt.connectors.storage import StorageConnector
@@ -34,6 +34,7 @@ app.command(name="configure")(configure)
 app.command(name="list")(list)
 app.command(name="add")(add)
 app.command(name="server")(server)
+app.command(name="folder")(open_folder)
 # load data commands
 app.add_typer(load_app, name="load")
 

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -2,6 +2,9 @@ from datetime import datetime
 import json
 import os
 import pickle
+import platform
+import subprocess
+
 
 import difflib
 import demjson3 as demjson
@@ -16,6 +19,32 @@ from memgpt.openai_backcompat.openai_object import OpenAIObject
 # TODO: what is this?
 # DEBUG = True
 DEBUG = False
+
+
+def open_folder_in_explorer(folder_path):
+    """
+    Opens the specified folder in the system's native file explorer.
+
+    :param folder_path: Absolute path to the folder to be opened.
+    """
+    if not os.path.exists(folder_path):
+        raise ValueError("The specified folder does not exist.")
+
+    # Determine the operating system
+    os_name = platform.system()
+
+    # Open the folder based on the operating system
+    if os_name == "Windows":
+        # Windows: use 'explorer' command
+        subprocess.run(["explorer", folder_path], check=True)
+    elif os_name == "Darwin":
+        # macOS: use 'open' command
+        subprocess.run(["open", folder_path], check=True)
+    elif os_name == "Linux":
+        # Linux: use 'xdg-open' command (works for most Linux distributions)
+        subprocess.run(["xdg-open", folder_path], check=True)
+    else:
+        raise OSError(f"Unsupported operating system {os_name}.")
 
 
 # Custom unpickler

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -28,7 +28,7 @@ def open_folder_in_explorer(folder_path):
     :param folder_path: Absolute path to the folder to be opened.
     """
     if not os.path.exists(folder_path):
-        raise ValueError("The specified folder does not exist.")
+        raise ValueError(f"The specified folder {folder_path} does not exist.")
 
     # Determine the operating system
     os_name = platform.system()


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Adds a `memgpt folder` command to allow users to easy open their home memgpt directory in a system folder browser.

This should be useful for some users as we add more settings into the home folder that people may want to manually modify.

**How to test**

Run `memgpt folder` and a folder viewer should pop up.

**Have you tested this PR?**

Yes on MacOS