### PR TITLE
feat: Add `memgpt quickstart` command

### DIFF
--- a/configs/memgpt_hosted.json
+++ b/configs/memgpt_hosted.json
@@ -1,0 +1,12 @@
+{
+    "context_window": 32768,
+    "model": "ehartford/dolphin-2.5-mixtral-8x7b",
+    "model_endpoint_type": "vllm",
+    "model_endpoint": "http://api.memgpt.ai",
+    "model_wrapper": "airoboros-l2-70b-2.1",
+    "embedding_endpoint_type": "hugging-face",
+    "embedding_endpoint": "http://embeddings.memgpt.ai",
+    "embedding_model": "BAAI/bge-large-en-v1.5",
+    "embedding_dim": 1536,
+    "embedding_chunk_size": 300
+}

--- a/configs/openai.json
+++ b/configs/openai.json
@@ -1,0 +1,12 @@
+{
+    "context_window": 8192,
+    "model": "gpt-4",
+    "model_endpoint_type": "openai",
+    "model_endpoint": "https://api.openai.com/v1",
+    "model_wrapper": null,
+    "embedding_endpoint_type": "openai",
+    "embedding_endpoint": "https://api.openai.com/v1",
+    "embedding_model": null,
+    "embedding_dim": 1536,
+    "embedding_chunk_size": 300
+}

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -70,8 +70,7 @@ def quickstart(
         # fallback to using local
         if latest:
             # Download the latest memgpt hosted config
-            # url = "https://raw.githubusercontent.com/cpacker/MemGPT/main/configs/memgpt_hosted.json"
-            url = "https://raw.githubusercontent.com/cpacker/MemGPT/quickstart-command/configs/memgpt_hosted.json"
+            url = "https://raw.githubusercontent.com/cpacker/MemGPT/main/configs/memgpt_hosted.json"
             response = requests.get(url)
 
             # Check if the request was successful
@@ -116,7 +115,7 @@ def quickstart(
                 # Ask for API key as input
                 api_key = questionary.text("Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):").ask()
 
-            url = "https://raw.githubusercontent.com/cpacker/MemGPT/quickstart-command/configs/openai.json"
+            url = "https://raw.githubusercontent.com/cpacker/MemGPT/main/configs/openai.json"
             response = requests.get(url)
 
             # Check if the request was successful

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -27,7 +27,7 @@ from memgpt.server.constants import WS_DEFAULT_PORT, REST_DEFAULT_PORT
 
 
 class QuickstartChoice(Enum):
-    # openai = "openai"
+    openai = "openai"
     # azure = "azure"
     memgpt_hosted = "memgpt"
 
@@ -78,6 +78,50 @@ def quickstart(
             set_config_with_dict(config)
         else:
             print(f"Failed to download config from {url}. Status code:", response.status_code)
+
+            # Load the file from the relative path
+            script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
+            backup_config_path = os.path.join(script_dir, "..", "..", "configs", "memgpt_hosted.json")
+            try:
+                with open(backup_config_path, "r") as file:
+                    backup_config = json.load(file)
+                print("Loaded backup config file successfully.")
+                set_config_with_dict(backup_config)
+            except FileNotFoundError:
+                print(f"Backup config file not found at {backup_config_path}")
+
+    elif type == QuickstartChoice.openai:
+        # Make sure we have an API key
+        api_key = os.getenv("OPENAI_API_KEY")
+        while api_key is None or len(api_key) == 0:
+            # Ask for API key as input
+            api_key = questionary.text("Enter your OpenAI API key (starts with 'sk..'):").ask()
+
+        url = "https://raw.githubusercontent.com/cpacker/MemGPT/quickstart-command/configs/openai.json"
+        response = requests.get(url)
+
+        # Check if the request was successful
+        if response.status_code == 200:
+            # Parse the response content as JSON
+            config = response.json()
+            # Output a success message and the first few items in the dictionary as a sample
+            print("JSON config file downloaded successfully.")
+            # Add the API key
+            config["openai_key"] = api_key
+            set_config_with_dict(config)
+        else:
+            print(f"Failed to download config from {url}. Status code:", response.status_code)
+
+            # Load the file from the relative path
+            script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
+            backup_config_path = os.path.join(script_dir, "..", "..", "configs", "openai.json")
+            try:
+                with open(backup_config_path, "r") as file:
+                    backup_config = json.load(file)
+                print("Loaded backup config file successfully.")
+                set_config_with_dict(backup_config)
+            except FileNotFoundError:
+                print(f"Backup config file not found at {backup_config_path}")
 
     else:
         raise NotImplementedError(type)

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -44,11 +44,12 @@ def set_config_with_dict(new_config: dict):
                 printd(f"Replacing config {k}: {v} -> {new_config[k]}")
                 modified = True
                 # old_config[k] = new_config[k]
-                setattr(old_config, k, v)  # Set the new value using dot notation
+                setattr(old_config, k, new_config[k])  # Set the new value using dot notation
             else:
                 printd(f"Skipping new config {k}: {v} == {new_config[k]}")
 
     if modified:
+        printd(f"Saving new config file.")
         old_config.save()
 
 

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -96,7 +96,7 @@ def quickstart(
         api_key = os.getenv("OPENAI_API_KEY")
         while api_key is None or len(api_key) == 0:
             # Ask for API key as input
-            api_key = questionary.text("Enter your OpenAI API key (starts with 'sk..'):").ask()
+            api_key = questionary.text("Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):").ask()
 
         url = "https://raw.githubusercontent.com/cpacker/MemGPT/quickstart-command/configs/openai.json"
         response = requests.get(url)

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -1,5 +1,6 @@
 import typer
 import json
+import requests
 import sys
 import io
 import logging
@@ -23,6 +24,34 @@ from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX
 from memgpt.agent import Agent
 from memgpt.embeddings import embedding_model
 from memgpt.server.constants import WS_DEFAULT_PORT, REST_DEFAULT_PORT
+
+
+class QuickstartChoice(Enum):
+    # openai = "openai"
+    # azure = "azure"
+    memgpt_hosted = "memgpt"
+
+
+def quickstart(
+    type: QuickstartChoice = typer.Option("memgpt", help="Quickstart setup type"),
+):
+    """Set the base config file with a single command"""
+    if type == QuickstartChoice.memgpt_hosted:
+        # Download the latest memgpt hosted config
+        url = "https://raw.githubusercontent.com/cpacker/MemGPT/main/configs/memgpt_hosted.json"
+        response = requests.get(url)
+
+        # Check if the request was successful
+        if response.status_code == 200:
+            # Parse the response content as JSON
+            config = response.json()
+            # Output a success message and the first few items in the dictionary as a sample
+            print("JSON file downloaded and loaded into a dictionary successfully.")
+        else:
+            print(f"Failed to download config from {url}. Status code:", response.status_code)
+
+    else:
+        raise NotImplementedError(type)
 
 
 def open_folder():

--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -54,7 +54,7 @@ def get_chat_completion(
         # Warn the user that we're using the fallback
         if not has_shown_warning:
             print(
-                f"{CLI_WARNING_PREFIX}no wrapper specified for local LLM, using the default wrapper (you can remove this warning by specifying the wrapper with --wrapper)"
+                f"{CLI_WARNING_PREFIX}no wrapper specified for local LLM, using the default wrapper (you can remove this warning by specifying the wrapper with --model-wrapper)"
             )
             has_shown_warning = True
         if endpoint_type in ["koboldcpp", "llamacpp", "webui"]:

--- a/memgpt/local_llm/vllm/api.py
+++ b/memgpt/local_llm/vllm/api.py
@@ -18,7 +18,7 @@ def get_vllm_completion(endpoint, model, prompt, context_window, user, settings=
     # Settings for the generation, includes the prompt + stop tokens, max length, etc
     request = settings
     request["prompt"] = prompt
-    request["max_tokens"] = int(context_window - prompt_tokens)
+    request["max_tokens"] = 3000  # int(context_window - prompt_tokens)
     request["stream"] = False
     request["user"] = user
 

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -21,7 +21,7 @@ from memgpt.interface import CLIInterface as interface  # for printing to termin
 import memgpt.agent as agent
 import memgpt.system as system
 import memgpt.constants as constants
-from memgpt.cli.cli import run, attach, version, server, open_folder
+from memgpt.cli.cli import run, attach, version, server, open_folder, quickstart
 from memgpt.cli.cli_config import configure, list, add
 from memgpt.cli.cli_load import app as load_app
 from memgpt.connectors.storage import StorageConnector
@@ -35,6 +35,7 @@ app.command(name="list")(list)
 app.command(name="add")(add)
 app.command(name="server")(server)
 app.command(name="folder")(open_folder)
+app.command(name="quickstart")(quickstart)
 # load data commands
 app.add_typer(load_app, name="load")
 


### PR DESCRIPTION
## Please describe the purpose of this pull request

Add `memgpt quickstart` to allow users to immediately start using the hosted endpoint (or openai/azure) w/o copy-paste.

I've set things up so that the quickstart configs (`.json`) files are actually pulled from the internet (the repo `main`), that way we can update eg the memgpt hosted endpoint details on-the-fly with commits to `main`.

## How to test

- `memgpt quickstart`
  - Simple, should just pull from remote url
- `memgpt quickstart --type openai`
  - To make this a true "one-click", we should check for the existence of `OPENAI_API_KEY` and throw a nice error here
- `memgpt quickstart --type azure`
  - Similarly, we should check for the existence of all the necessary Azure variables and throw a nice error

## Have you tested this PR?

Yes, see examples below.

- [x] `memgpt quickstart`
- [x] `memgpt quickstart --type openai`
~~- [ ] `memgpt quickstart azure`~~

Note: Azure is a little complicated, should put in separate PR.

## Outstanding questions

- [x] Should we pull configs from GitHub? Can also put the configs inside the gh-pages assets directory, so the `wget` goes to `memgpt.ai/...` instead of a GitHub link
- [x] Should we store configs in `memgpt/configs`? Naming? (`memgpt/example_configs`?)
- [x] Should we store JSON? YAML?
- [x] Change command convention? eg `memgpt quickstart --type openai` could just be `memgpt openai`

---

Examples:
```
% memgpt quickstart --debug
JSON config file downloaded successfully.
Replacing config model: gpt-4 -> ehartford/dolphin-2.5-mixtral-8x7b
Replacing config model_endpoint_type: openai -> vllm
Replacing config model_endpoint: https://api.openai.com/v1 -> http://api.memgpt.ai
Replacing config model_wrapper: None -> airoboros-l2-70b-2.1
Replacing config context_window: 8192 -> 32768
Replacing config embedding_endpoint_type: openai -> hugging-face
Replacing config embedding_endpoint: https://api.openai.com/v1 -> http://embeddings.memgpt.ai
Replacing config embedding_model: None -> BAAI/bge-large-en-v1.5
Skipping new config embedding_dim: 1536 == 1536
Skipping new config embedding_chunk_size: 300 == 300
Saving new config file.
```

```
% memgpt quickstart --debug --type openai
? Enter your OpenAI API key (starts with 'sk..'): dummy key
JSON config file downloaded successfully.
Replacing config model: ehartford/dolphin-2.5-mixtral-8x7b -> gpt-4
Replacing config model_endpoint_type: vllm -> openai
Replacing config model_endpoint: http://api.memgpt.ai -> https://api.openai.com/v1
Replacing config model_wrapper: airoboros-l2-70b-2.1 -> None
Replacing config context_window: 32768 -> 8192
Replacing config openai_key: sk-... -> dummy key
Replacing config embedding_endpoint_type: hugging-face -> openai
Replacing config embedding_endpoint: http://embeddings.memgpt.ai -> https://api.openai.com/v1
Replacing config embedding_model: BAAI/bge-large-en-v1.5 -> None
Skipping new config embedding_dim: 1536 == 1536
Skipping new config embedding_chunk_size: 300 == 300
Saving new config file.
```