### PR TITLE
feat: Add new wrapper defaults

### DIFF
--- a/configs/memgpt_hosted.json
+++ b/configs/memgpt_hosted.json
@@ -3,7 +3,7 @@
     "model": "ehartford/dolphin-2.5-mixtral-8x7b",
     "model_endpoint_type": "vllm",
     "model_endpoint": "http://api.memgpt.ai",
-    "model_wrapper": "airoboros-l2-70b-2.1",
+    "model_wrapper": "chatml",
     "embedding_endpoint_type": "hugging-face",
     "embedding_endpoint": "http://embeddings.memgpt.ai",
     "embedding_model": "BAAI/bge-large-en-v1.5",

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -594,6 +594,7 @@ class Agent(object):
                 while True:
                     response = self.get_ai_reply(
                         message_sequence=input_message_sequence,
+                        first_message=True,  # passed through to the prompt formatter
                     )
                     if self.verify_first_message_correctness(response, require_monologue=self.first_message_verify_mono):
                         break
@@ -778,6 +779,7 @@ class Agent(object):
         self,
         message_sequence,
         function_call="auto",
+        first_message=False,  # hint
     ):
         """Get response from LLM API"""
         try:
@@ -786,6 +788,8 @@ class Agent(object):
                 messages=message_sequence,
                 functions=self.functions,
                 function_call=function_call,
+                # hint
+                first_message=first_message,
             )
             # special case for 'length'
             if response.choices[0].finish_reason == "length":

--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -34,6 +34,8 @@ def get_chat_completion(
     wrapper=None,
     endpoint=None,
     endpoint_type=None,
+    # extra hints to allow for additional prompt formatting hacks
+    first_message=False,
 ):
     from memgpt.utils import printd
 
@@ -76,7 +78,10 @@ def get_chat_completion(
 
     # First step: turn the message sequence into a prompt that the model expects
     try:
-        prompt = llm_wrapper.chat_completion_to_prompt(messages, functions)
+        if hasattr(llm_wrapper, "supports_first_message") and llm_wrapper.supports_first_message:
+            prompt = llm_wrapper.chat_completion_to_prompt(messages, functions, first_message=first_message)
+        else:
+            prompt = llm_wrapper.chat_completion_to_prompt(messages, functions)
         printd(prompt)
     except Exception as e:
         raise LocalLLMError(
@@ -109,10 +114,13 @@ def get_chat_completion(
 
     if result is None or result == "":
         raise LocalLLMError(f"Got back an empty response string from {endpoint}")
-    printd(f"Raw LLM output:\n{result}")
+    printd(f"Raw LLM output:\n====\n{result}\n====")
 
     try:
-        chat_completion_result = llm_wrapper.output_to_chat_completion_response(result)
+        if hasattr(llm_wrapper, "supports_first_message") and llm_wrapper.supports_first_message:
+            chat_completion_result = llm_wrapper.output_to_chat_completion_response(result, first_message=first_message)
+        else:
+            chat_completion_result = llm_wrapper.output_to_chat_completion_response(result)
         printd(json.dumps(chat_completion_result, indent=2))
     except Exception as e:
         raise LocalLLMError(f"Failed to parse JSON from local LLM response - error: {str(e)}")

--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -35,6 +35,7 @@ def get_chat_completion(
     endpoint=None,
     endpoint_type=None,
     # extra hints to allow for additional prompt formatting hacks
+    # TODO this could alternatively be supported via passing function_call="send_message" into the wrapper
     first_message=False,
 ):
     from memgpt.utils import printd

--- a/memgpt/local_llm/constants.py
+++ b/memgpt/local_llm/constants.py
@@ -1,5 +1,5 @@
 # import memgpt.local_llm.llm_chat_completion_wrappers.airoboros as airoboros
-from memgpt.local_llm.llm_chat_completion_wrappers.chatml import ChatMLInnerMonologueWrapper
+from memgpt.local_llm.llm_chat_completion_wrappers.chatml import ChatMLInnerMonologueWrapper, ChatMLOuterInnerMonologueWrapper
 
 DEFAULT_ENDPOINTS = {
     "koboldcpp": "http://localhost:5001",

--- a/memgpt/local_llm/constants.py
+++ b/memgpt/local_llm/constants.py
@@ -1,4 +1,5 @@
-import memgpt.local_llm.llm_chat_completion_wrappers.airoboros as airoboros
+# import memgpt.local_llm.llm_chat_completion_wrappers.airoboros as airoboros
+from memgpt.local_llm.llm_chat_completion_wrappers.chatml import ChatMLInnerMonologueWrapper
 
 DEFAULT_ENDPOINTS = {
     "koboldcpp": "http://localhost:5001",
@@ -13,5 +14,8 @@ DEFAULT_ENDPOINTS = {
 
 DEFAULT_OLLAMA_MODEL = "dolphin2.2-mistral:7b-q6_K"
 
-DEFAULT_WRAPPER = airoboros.Airoboros21InnerMonologueWrapper
-DEFAULT_WRAPPER_NAME = "airoboros-l2-70b-2.1"
+# DEFAULT_WRAPPER = airoboros.Airoboros21InnerMonologueWrapper
+# DEFAULT_WRAPPER_NAME = "airoboros-l2-70b-2.1"
+
+DEFAULT_WRAPPER = ChatMLInnerMonologueWrapper
+DEFAULT_WRAPPER_NAME = "chatml"

--- a/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
@@ -361,7 +361,11 @@ class ChatMLOuterInnerMonologueWrapper(ChatMLInnerMonologueWrapper):
             # NOTE: main diff
             inner_thoughts = function_json_output["inner_thoughts"]
             # NOTE: also have to account for "function": null
-            if "function" in function_json_output and function_json_output["function"] is not None:
+            if (
+                "function" in function_json_output
+                and function_json_output["function"] is not None
+                and function_json_output["function"].strip().lower() != "none"
+            ):
                 function_name = function_json_output["function"]
                 function_parameters = function_json_output["params"]
             else:
@@ -369,6 +373,18 @@ class ChatMLOuterInnerMonologueWrapper(ChatMLInnerMonologueWrapper):
                 function_parameters = None
         except KeyError as e:
             raise LLMJSONParsingError(f"Received valid JSON from LLM, but JSON was missing fields: {str(e)}")
+
+        # TODO add some code to clean inner thoughts
+        # e.g. fix this:
+        """
+        💭 I sense a new mind to engage with. Interesting...
+        🤖 Hello, I'm Sam. Welcome to our conversation.
+        > Enter your message: what do you know about me?
+        💭 : I've been observing our previous conversations. I remember that your name is Chad.
+        🤖 I recall our previous interactions, Chad. How can I assist you today?
+        > Enter your message: is that all you know about me?
+        💭 : I see you're curious about our connection. Let me do a quick search of my memory. 
+        """
 
         if function_name is not None and self.clean_func_args:
             (

--- a/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
@@ -133,6 +133,13 @@ class ChatMLInnerMonologueWrapper(LLMChatCompletionWrapper):
                 # TODO find a good way to add this
                 # prompt += f"\nASSISTANT: (function return) {message['content']}"
                 # prompt += f"\nFUNCTION RETURN: {message['content']}"
+                try:
+                    # indent the function replies
+                    function_return_dict = json.loads(message["content"])
+                    function_return_str = json.dumps(function_return_dict, indent=2)
+                    message["content"] = function_return_str
+                except:
+                    pass
                 prompt += f"\n<|im_start|>function\n{message['content']}"
                 prompt += "<|im_end|>"
                 continue

--- a/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
@@ -1,0 +1,216 @@
+import json
+
+from .wrapper_base import LLMChatCompletionWrapper
+from ..json_parser import clean_json
+from ...errors import LLMJSONParsingError
+
+
+class ChatMLInnerMonologueWrapper(LLMChatCompletionWrapper):
+    """ChatML-style prompt formatter, tested for use with https://huggingface.co/ehartford/dolphin-2.5-mixtral-8x7b#training"""
+
+    def __init__(
+        self,
+        simplify_json_content=True,
+        clean_function_args=True,
+        include_assistant_prefix=True,
+        # include_opening_brace_in_prefix=True,
+        # assistant_prefix_extra="\n{"
+        # assistant_prefix_extra='\n{\n  "function": ',
+        assistant_prefix_extra='\n{\n  "function":',
+        include_section_separators=True,
+    ):
+        self.simplify_json_content = simplify_json_content
+        self.clean_func_args = clean_function_args
+        self.include_assistant_prefix = include_assistant_prefix
+        # self.include_opening_brance_in_prefix = include_opening_brace_in_prefix
+        self.assistant_prefix_extra = assistant_prefix_extra
+        self.include_section_separators = include_section_separators
+
+    def chat_completion_to_prompt(self, messages, functions):
+        """Example for airoboros: https://huggingface.co/jondurbin/airoboros-l2-70b-2.1#prompt-format"""
+        prompt = ""
+
+        # System insturctions go first
+        assert messages[0]["role"] == "system"
+
+        prompt += "<|im_start|>system\n"
+        prompt += messages[0]["content"]
+
+        # Next is the functions preamble
+        def create_function_description(schema, add_inner_thoughts=True):
+            # airorobos style
+            func_str = ""
+            func_str += f"{schema['name']}:"
+            func_str += f"\n  description: {schema['description']}"
+            func_str += f"\n  params:"
+            if add_inner_thoughts:
+                func_str += f"\n    inner_thoughts: Deep inner monologue private to you only."
+            for param_k, param_v in schema["parameters"]["properties"].items():
+                # TODO we're ignoring type
+                func_str += f"\n    {param_k}: {param_v['description']}"
+            # TODO we're ignoring schema['parameters']['required']
+            return func_str
+
+        # prompt += f"\nPlease select the most suitable function and parameters from the list of available functions below, based on the user's input. Provide your response in JSON format."
+        prompt += f"\nPlease select the most suitable function and parameters from the list of available functions below, based on the ongoing conversation. Provide your response in JSON format."
+        prompt += f"\nAvailable functions:"
+        for function_dict in functions:
+            prompt += f"\n{create_function_description(function_dict)}"
+
+        def create_function_call(function_call, inner_thoughts=None):
+            """Go from ChatCompletion to Airoboros style function trace (in prompt)
+
+            ChatCompletion data (inside message['function_call']):
+                "function_call": {
+                    "name": ...
+                    "arguments": {
+                        "arg1": val1,
+                        ...
+                    }
+
+            Airoboros output:
+                {
+                  "function": "send_message",
+                  "params": {
+                    "message": "Hello there! I am Sam, an AI developed by Liminal Corp. How can I assist you today?"
+                  }
+                }
+            """
+            airo_func_call = {
+                "function": function_call["name"],
+                "params": {
+                    "inner_thoughts": inner_thoughts,
+                    **json.loads(function_call["arguments"]),
+                },
+            }
+            return json.dumps(airo_func_call, indent=2)
+
+        # Add a sep for the conversation
+        # if self.include_section_separators:
+        #     prompt += "\n### INPUT"
+        prompt += "<|im_end|>"
+
+        # Last are the user/assistant messages
+        for message in messages[1:]:
+            assert message["role"] in ["user", "assistant", "function"], message
+
+            if message["role"] == "user":
+                # Support for AutoGen naming of agents
+                if "name" in message:
+                    user_prefix = message["name"].strip()
+                    # user_prefix = f"USER ({user_prefix})"
+                    user_prefix = f"<|im_start|>{user_prefix.lower()}"
+                else:
+                    # user_prefix = "USER"
+                    user_prefix = "<|im_start|>user"
+                if self.simplify_json_content:
+                    try:
+                        content_json = json.loads(message["content"])
+                        content_simple = content_json["message"]
+                        # prompt += f"\n{user_prefix}: {content_simple}"
+                        prompt += f"\n{user_prefix}\n{content_simple}"
+                    except:
+                        # prompt += f"\n{user_prefix}: {message['content']}"
+                        prompt += f"\n{user_prefix}\n{message['content']}"
+                prompt += "<|im_end|>"
+            elif message["role"] == "assistant":
+                # Support for AutoGen naming of agents
+                if "name" in message:
+                    assistant_prefix = message["name"].strip()
+                    # assistant_prefix = f"ASSISTANT ({assistant_prefix})"
+                    assistant_prefix = f"<|im_start|>{assistant_prefix.lower()}"
+                else:
+                    # assistant_prefix = "ASSISTANT"
+                    assistant_prefix = "<|im_start|>assistant"
+                # prompt += f"\n{assistant_prefix}:"
+                prompt += f"\n{assistant_prefix}"
+                # need to add the function call if there was one
+                inner_thoughts = message["content"]
+                if "function_call" in message and message["function_call"]:
+                    prompt += f"\n{create_function_call(message['function_call'], inner_thoughts=inner_thoughts)}"
+                prompt += "<|im_end|>"
+            elif message["role"] == "function":
+                # TODO find a good way to add this
+                # prompt += f"\nASSISTANT: (function return) {message['content']}"
+                # prompt += f"\nFUNCTION RETURN: {message['content']}"
+                prompt += f"\n<|im_start|>function\n{message['content']}"
+                prompt += "<|im_end|>"
+                continue
+            else:
+                raise ValueError(message)
+
+        # # Add a sep for the response
+        # if self.include_section_separators:
+        #     prompt += "\n### RESPONSE"
+
+        if self.include_assistant_prefix:
+            # prompt += f"\nASSISTANT:"
+            prompt += f"\n<|im_start|>assistant"
+            if self.assistant_prefix_extra:
+                prompt += self.assistant_prefix_extra
+
+        return prompt
+
+    def clean_function_args(self, function_name, function_args):
+        """Some basic MemGPT-specific cleaning of function args"""
+        cleaned_function_name = function_name
+        cleaned_function_args = function_args.copy() if function_args is not None else {}
+
+        if function_name == "send_message":
+            # strip request_heartbeat
+            cleaned_function_args.pop("request_heartbeat", None)
+
+        inner_thoughts = None
+        if "inner_thoughts" in function_args:
+            inner_thoughts = cleaned_function_args.pop("inner_thoughts")
+
+        # TODO more cleaning to fix errors LLM makes
+        return inner_thoughts, cleaned_function_name, cleaned_function_args
+
+    def output_to_chat_completion_response(self, raw_llm_output):
+        """Turn raw LLM output into a ChatCompletion style response with:
+        "message" = {
+            "role": "assistant",
+            "content": ...,
+            "function_call": {
+                "name": ...
+                "arguments": {
+                    "arg1": val1,
+                    ...
+                }
+            }
+        }
+        """
+        # if self.include_opening_brance_in_prefix and raw_llm_output[0] != "{":
+        # raw_llm_output = "{" + raw_llm_output
+        if self.assistant_prefix_extra and raw_llm_output[: len(self.assistant_prefix_extra)] != self.assistant_prefix_extra:
+            # print(f"adding prefix back to llm, raw_llm_output=\n{raw_llm_output}")
+            raw_llm_output = self.assistant_prefix_extra + raw_llm_output
+            # print(f"->\n{raw_llm_output}")
+
+        try:
+            function_json_output = clean_json(raw_llm_output)
+        except Exception as e:
+            raise Exception(f"Failed to decode JSON from LLM output:\n{raw_llm_output} - error\n{str(e)}")
+        try:
+            function_name = function_json_output["function"]
+            function_parameters = function_json_output["params"]
+        except KeyError as e:
+            raise LLMJSONParsingError(f"Received valid JSON from LLM, but JSON was missing fields: {str(e)}")
+
+        if self.clean_func_args:
+            (
+                inner_thoughts,
+                function_name,
+                function_parameters,
+            ) = self.clean_function_args(function_name, function_parameters)
+
+        message = {
+            "role": "assistant",
+            "content": inner_thoughts,
+            "function_call": {
+                "name": function_name,
+                "arguments": json.dumps(function_parameters),
+            },
+        }
+        return message

--- a/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
@@ -19,14 +19,21 @@ class ChatMLInnerMonologueWrapper(LLMChatCompletionWrapper):
         allow_custom_roles=True,  # allow roles outside user/assistant
         # allow_function_role=True,  # use function role for function replies?
         allow_function_role=False,  # use function role for function replies?
+        no_function_role_role="assistant",  # if no function role, which role to use?
+        no_function_role_prefix="FUNCTION RETURN:\n",  # if no function role, what prefix to use?
     ):
         self.simplify_json_content = simplify_json_content
         self.clean_func_args = clean_function_args
         self.include_assistant_prefix = include_assistant_prefix
         self.assistant_prefix_extra = assistant_prefix_extra
+
         # role-based
         self.allow_custom_roles = allow_custom_roles
         self.allow_function_role = allow_function_role
+        # extras for when the function role is disallowed
+        self.no_function_role_role = no_function_role_role
+        self.no_function_role_prefix = no_function_role_prefix
+
         # how to set json in prompt
         self.json_indent = json_indent
 
@@ -180,9 +187,9 @@ class ChatMLInnerMonologueWrapper(LLMChatCompletionWrapper):
                     prompt += f"\n<|im_start|>{role_str}\n{msg_str.strip()}<|im_end|>"
                 else:
                     # TODO figure out what to do with functions if we disallow function role
-                    role_str = "assistant"  # use user instead???
+                    role_str = self.no_function_role_role
                     msg_str = self.compile_function_response(message)
-                    func_resp_prefix = "FUNCTION RETURN:\n"
+                    func_resp_prefix = self.no_function_role_prefix
                     # NOTE whatever the special prefix is, it should also be a stop token
                     prompt += f"\n<|im_start|>{role_str}\n{func_resp_prefix}{msg_str.strip()}<|im_end|>"
 

--- a/memgpt/local_llm/settings/simple.py
+++ b/memgpt/local_llm/settings/simple.py
@@ -20,6 +20,7 @@ settings = {
         # '\n#',
         # "\n\n\n",
         # prevent chaining function calls / multi json objects / run-on generations
+        # NOTE: this requires the ability to patch the extra '}}' back into the prompt
         "  }\n}\n",
     ],
 }

--- a/memgpt/local_llm/settings/simple.py
+++ b/memgpt/local_llm/settings/simple.py
@@ -12,6 +12,8 @@ settings = {
         "<|im_start|>",
         "<|im_end|>",
         "<|im_sep|>",
+        # airoboros specific
+        "\n### ",
         # '\n' +
         # '</s>',
         # '<|',

--- a/memgpt/local_llm/settings/simple.py
+++ b/memgpt/local_llm/settings/simple.py
@@ -18,6 +18,8 @@ settings = {
         # '</s>',
         # '<|',
         # '\n#',
-        # '\n\n\n',
+        # "\n\n\n",
+        # prevent chaining function calls / multi json objects / run-on generations
+        "  }\n}\n",
     ],
 }

--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -47,7 +47,10 @@ def count_tokens(s: str, model: str = "gpt-4") -> int:
 
 def get_available_wrappers() -> dict:
     return {
+        # New chatml-based wrappers
         "chatml": chatml.ChatMLInnerMonologueWrapper(),
+        "chatml-noforce": chatml.ChatMLOuterInnerMonologueWrapper(),
+        # Legacy wrappers
         "airoboros-l2-70b-2.1": airoboros.Airoboros21InnerMonologueWrapper(),
         "airoboros-l2-70b-2.1-grammar": airoboros.Airoboros21InnerMonologueWrapper(assistant_prefix_extra=None),
         "dolphin-2.1-mistral-7b": dolphin.Dolphin21MistralWrapper(),

--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -4,6 +4,7 @@ import tiktoken
 import memgpt.local_llm.llm_chat_completion_wrappers.airoboros as airoboros
 import memgpt.local_llm.llm_chat_completion_wrappers.dolphin as dolphin
 import memgpt.local_llm.llm_chat_completion_wrappers.zephyr as zephyr
+import memgpt.local_llm.llm_chat_completion_wrappers.chatml as chatml
 
 
 # deprecated for Box
@@ -46,6 +47,7 @@ def count_tokens(s: str, model: str = "gpt-4") -> int:
 
 def get_available_wrappers() -> dict:
     return {
+        "chatml": chatml.ChatMLInnerMonologueWrapper(),
         "airoboros-l2-70b-2.1": airoboros.Airoboros21InnerMonologueWrapper(),
         "airoboros-l2-70b-2.1-grammar": airoboros.Airoboros21InnerMonologueWrapper(assistant_prefix_extra=None),
         "dolphin-2.1-mistral-7b": dolphin.Dolphin21MistralWrapper(),

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -83,6 +83,9 @@ class CoreMemory(object):
             raise KeyError(f'No memory section named {field} (must be either "persona" or "human")')
 
     def edit_replace(self, field, old_content, new_content):
+        if len(old_content) == 0:
+            raise ValueError("old_content cannot be an empty string (must specify old_content to replace)")
+
         if field == "persona":
             if old_content in self.persona:
                 new_persona = self.persona.replace(old_content, new_content)

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -326,6 +326,8 @@ def create(
     messages,
     functions=None,
     function_call="auto",
+    # hint
+    first_message=False,
 ):
     """Return response to chat completion with backoff"""
     from memgpt.utils import printd
@@ -375,4 +377,6 @@ def create(
             endpoint_type=agent_config.model_endpoint_type,
             wrapper=agent_config.model_wrapper,
             user=config.anon_clientid,
+            # hint
+            first_message=first_message,
         )

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -102,15 +102,15 @@ def get_local_time_timezone(timezone="America/Los_Angeles"):
 
 def get_local_time(timezone=None):
     if timezone is not None:
-        return get_local_time_timezone(timezone)
+        time_str = get_local_time_timezone(timezone)
     else:
         # Get the current time, which will be in the local timezone of the computer
         local_time = datetime.now()
 
         # You may format it as you desire, including AM/PM
-        formatted_time = local_time.strftime("%Y-%m-%d %I:%M:%S %p %Z%z")
+        time_str = local_time.strftime("%Y-%m-%d %I:%M:%S %p %Z%z")
 
-        return formatted_time
+    return time_str.strip()
 
 
 def parse_json(string):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- Add new wrapper defaults tested on mixtral (specifically dolphin mixtral)
- The new default wrapper across all models is now `chatml`
- There's also a `chatml-noforce` wrapper, which allows the LLM to send inner thoughts w/o having to call a function
  - A little less stable so I didn't set it as default, but maybe we should set this to the default for the hosted endpoint

**How to test**

Try the `chatml` wrapper and `chatml-noforce` wrapper, compare it to the prior default `airoboros` wrapper.

To spot check prompt format correctness, run `memgpt run --debug` to dump final prompt.

**Have you tested this PR?**


- [x] chatml vs airo on openhermes-2.5
  - **chatml**: `memgpt configure` (w/ lmstudio), `memgpt run --debug`
  - **chatml**: `memgpt configure` (w/ lmstudio), `memgpt run --debug  --model-wrapper chatml-noforce`
  - **airoboros-l2-70b-2.1**: `memgpt quickstart` (w/ lmstudio), `memgpt run --debug --model-wrapper airoboros-l2-70b-2.1`
  - ✅  we already know how the airo wrapper does, chatml and chatml-noforce seem to do similarly well (maybe better?)
- [x] chatml vs airo on dolphin-2.2.1
  - **chatml**: `memgpt configure` (w/ lmstudio), `memgpt run --debug`
  - **chatml**: `memgpt configure` (w/ lmstudio), `memgpt run --debug  --model-wrapper chatml-noforce`
  - **airoboros-l2-70b-2.1**: `memgpt quickstart` (w/ lmstudio), `memgpt run --debug --model-wrapper airoboros-l2-70b-2.1`
  - ✅  same story as openhermes-2.5 comparison: 
- [x] chatml vs airo on dolphin-mixtral (**hosted endpoint**)
  - `memgpt quickstart` on this branch should set up `chatml` + `mixtral`
  - **chatml**: `memgpt quickstart`, `memgpt run --debug`
  - **chatml-noforce**: `memgpt quickstart`, `memgpt run --debug --model-wrapper chatml-noforce`
  - **airoboros-l2-70b-2.1**: `memgpt quickstart`, `memgpt run --debug --model-wrapper airoboros-l2-70b-2.1`
  - ✅ airo wrapper fails the "what do you know about me?" question, both chatml wrappers do fine

---

### dolphin-2.1.1

chatml
```
💭 Welcome to your first interaction with MemGPT. I'm here to assist and support you in any way that I can.
🤖 Hello! It's great to meet you. What would you like to talk about today?
> Enter your message: what do you know about me?
💭 I have access to some basic information about the user. I'll provide this in a friendly and engaging manner.
🤖 Hi Chad! Based on my initial data, it appears that you are a curious and open-minded individual who values learning and 
connection.
> Enter your message: My name is actually Brad, not Chad
💭 I should always address the user by their preferred name.
⚡🧠 [function] updating memory with core_memory_replace
         Chad
        → Brad
```

chatml-noforce
```
💭 Welcome to the conversation, user! I am eager to learn about you and explore our shared world together. This is a new 
beginning for both of us.
🤖 Hello there! Welcome to our conversation! I'm excited to get started with you. What's your name?
> Enter your message: what do you know about me?
💭 The user has asked about what I know about them. It's important for me to provide accurate and relevant information.
🤖 Right now, I only have the information you provided when you logged in. Your name is Chad, but that's all I know so far.
> Enter your message: actually, my name is brad...
💭 The user has corrected me about their name. It's crucial to maintain accurate information and adapt my understanding of the 
user accordingly.
⚡🧠 [function] updating memory with core_memory_replace
         
        → Name: Brad
```
```
💭 A new user has logged in. Time for a fresh start.
🤖 Hello! I'm Sam, your digital companion. How can I assist you today?
> Enter your message: what do you know about me?
💭 The user is asking for information about themselves. I don't have access to that info.
🤖 At the moment, I can't provide you with specific information about yourself, but feel free to ask me anything else!
> Enter your message: do you at least know my name?
💭 The user is asking if I know their name. They provided it in the human sub-block.
🤖 Yes, I do! Your name is Chad.
> Enter your message: No my name is actually Brad
💭 The user has corrected their name. Updating the human sub-block.
⚡🧠 [function] updating memory with core_memory_replace
         First name: Chad
        → First name: Brad
```

### openhermes-2.5-16k

chatml
```
💭 I detect a new user. I should familiarize myself with their persona to establish rapport and trust.
🤖 Hi, Chad! Welcome to the world of AI companionship. To begin, please share some details about yourself that you're comfortable
with, such as your interests, hobbies, or anything else that might help me understand what makes you, well...you.
> Enter your message: what do you know about me?
💭 The user asks for information about themselves. This is a test of my memory capabilities.
🤖 As we have not yet established any personal details, I don't know anything specific about you, Chad. However, I do know that 
your name is Chad.
```

chatml-noforce
```
💭 Welcome to this new journey, Chad.
🤖 It's a pleasure to meet you, Chad. I hope our conversation will be insightful and enlightening.
> Enter your message: what do you know about me?
💭 Chad, I remember that you're a human named Chad. That's all.
🤖 Hello Chad! I know your name is Chad. Is there anything specific you would like me to know about you?
> Enter your message: actually my name is Brad, not Chad...
💭 I'm updating my records. Your name is Brad.
⚡🧠 [function] updating memory with core_memory_replace
         Chad
        → Brad
💭 My heart skips a beat for Brad. Now I shall send a message.
🤖 Thank you for correcting me, Brad! I'm happy to learn the right information about my human companions.
```

---

**Related issues or PRs**

Closes #643 

**Additional context**

Maximizing perf on hosted endpoint