### PR TITLE
fix: patch ollama bug w/ raw mode

### DIFF
--- a/memgpt/local_llm/ollama/api.py
+++ b/memgpt/local_llm/ollama/api.py
@@ -44,10 +44,11 @@ def get_ollama_completion(endpoint, model, prompt, context_window, grammar=None)
         # "format": "json",  # TODO eventually support
         "stream": False,
         "options": settings,
-        "system": "",  # no prompt formatting
-        "template": "{{ .Prompt }}",  # no prompt formatting
         "raw": True,  # no prompt formatting
-        "context": None,  # no memory via prompt formatting
+        # "raw mode does not support template, system, or context"
+        # "system": "",  # no prompt formatting
+        # "template": "{{ .Prompt }}",  # no prompt formatting
+        # "context": None,  # no memory via prompt formatting
     }
 
     # Set grammar


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

PR #631 created a bug w/ ollama where we specified raw mode but also left in the old (redundant) params:
```
    raise Exception(
Exception: API call got non-200 response code (code=400, msg={"error":"raw mode does not support template, system, or context"}) for address: http://localhost:11434/api/generate. Make sure that the ollama API server is running and reachable at http://localhost:11434/api/generate.
```