### PR TITLE
fix: Patch openai error message + openai quickstart

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -52,10 +52,10 @@ def set_config_with_dict(new_config: dict):
         printd(f"Saving new config file.")
         old_config.save()
         typer.secho(f"\nMemGPT configuration file updated!", fg=typer.colors.GREEN)
+        typer.secho('Run "memgpt run" to create an agent with the new config.', fg=typer.colors.YELLOW)
     else:
         typer.secho(f"\nMemGPT configuration file unchanged.", fg=typer.colors.GREEN)
-
-    typer.secho('Run "memgpt run" to create an agent with the new config.', fg=typer.colors.YELLOW)
+        typer.secho('Run "memgpt run" to create an agent.', fg=typer.colors.YELLOW)
 
 
 def quickstart(

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -51,6 +51,11 @@ def set_config_with_dict(new_config: dict):
     if modified:
         printd(f"Saving new config file.")
         old_config.save()
+        typer.secho(f"\nMemGPT configuration file updated!", fg=typer.colors.GREEN)
+    else:
+        typer.secho(f"\nMemGPT configuration file unchanged.", fg=typer.colors.GREEN)
+
+    typer.secho('Run "memgpt run" to create an agent with the new config.', fg=typer.colors.YELLOW)
 
 
 def quickstart(
@@ -106,15 +111,15 @@ def quickstart(
                 print(f"Config file not found at {backup_config_path}")
 
     elif backend == QuickstartChoice.openai:
+        # Make sure we have an API key
+        api_key = os.getenv("OPENAI_API_KEY")
+        while api_key is None or len(api_key) == 0:
+            # Ask for API key as input
+            api_key = questionary.text("Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):").ask()
+
         # if latest, try to pull the config from the repo
         # fallback to using local
         if latest:
-            # Make sure we have an API key
-            api_key = os.getenv("OPENAI_API_KEY")
-            while api_key is None or len(api_key) == 0:
-                # Ask for API key as input
-                api_key = questionary.text("Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):").ask()
-
             url = "https://raw.githubusercontent.com/cpacker/MemGPT/main/configs/openai.json"
             response = requests.get(url)
 
@@ -136,6 +141,7 @@ def quickstart(
                 try:
                     with open(backup_config_path, "r") as file:
                         backup_config = json.load(file)
+                        backup_config["openai_key"] = api_key
                     print("Loaded backup config file successfully.")
                     set_config_with_dict(backup_config)
                 except FileNotFoundError:
@@ -147,6 +153,7 @@ def quickstart(
             try:
                 with open(backup_config_path, "r") as file:
                     backup_config = json.load(file)
+                    backup_config["openai_key"] = api_key
                 print("Loaded config file successfully.")
                 set_config_with_dict(backup_config)
             except FileNotFoundError:

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -109,27 +109,15 @@ def openai_chat_completions_request(url, api_key, data):
         return response
     except requests.exceptions.HTTPError as http_err:
         # Handle HTTP errors (e.g., response 4XX, 5XX)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got HTTPError, exception={http_err}, payload={data}, response={response}")
+        printd(f"Got HTTPError, exception={http_err}, payload={data}")
         raise http_err
     except requests.exceptions.RequestException as req_err:
         # Handle other requests-related errors (e.g., connection error)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got RequestException, exception={req_err}, response={response}")
+        printd(f"Got RequestException, exception={req_err}")
         raise req_err
     except Exception as e:
         # Handle other potential errors
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got unknown Exception, exception={e}, response={response}")
+        printd(f"Got unknown Exception, exception={e}")
         raise e
 
 
@@ -150,27 +138,15 @@ def openai_embeddings_request(url, api_key, data):
         return response
     except requests.exceptions.HTTPError as http_err:
         # Handle HTTP errors (e.g., response 4XX, 5XX)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got HTTPError, exception={http_err}, response={response}")
+        printd(f"Got HTTPError, exception={http_err}, payload={data}")
         raise http_err
     except requests.exceptions.RequestException as req_err:
         # Handle other requests-related errors (e.g., connection error)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got RequestException, exception={req_err}, response={response}")
+        printd(f"Got RequestException, exception={req_err}")
         raise req_err
     except Exception as e:
         # Handle other potential errors
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got unknown Exception, exception={e}, response={response}")
+        printd(f"Got unknown Exception, exception={e}")
         raise e
 
 
@@ -200,27 +176,15 @@ def azure_openai_chat_completions_request(resource_name, deployment_id, api_vers
         return response
     except requests.exceptions.HTTPError as http_err:
         # Handle HTTP errors (e.g., response 4XX, 5XX)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got HTTPError, exception={http_err}, response={response}")
+        printd(f"Got HTTPError, exception={http_err}, payload={data}")
         raise http_err
     except requests.exceptions.RequestException as req_err:
         # Handle other requests-related errors (e.g., connection error)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got RequestException, exception={req_err}, response={response}")
+        printd(f"Got RequestException, exception={req_err}")
         raise req_err
     except Exception as e:
         # Handle other potential errors
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got unknown Exception, exception={e}, response={response}")
+        printd(f"Got unknown Exception, exception={e}")
         raise e
 
 
@@ -242,27 +206,15 @@ def azure_openai_embeddings_request(resource_name, deployment_id, api_version, a
         return response
     except requests.exceptions.HTTPError as http_err:
         # Handle HTTP errors (e.g., response 4XX, 5XX)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got HTTPError, exception={http_err}, response={response}")
+        printd(f"Got HTTPError, exception={http_err}, payload={data}")
         raise http_err
     except requests.exceptions.RequestException as req_err:
         # Handle other requests-related errors (e.g., connection error)
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got RequestException, exception={req_err}, response={response}")
+        printd(f"Got RequestException, exception={req_err}")
         raise req_err
     except Exception as e:
         # Handle other potential errors
-        try:
-            response = response.json()
-        except:
-            pass
-        printd(f"Got unknown Exception, exception={e}, response={response}")
+        printd(f"Got unknown Exception, exception={e}")
         raise e
 
 

--- a/memgpt/openai_tools.py
+++ b/memgpt/openai_tools.py
@@ -1,9 +1,7 @@
 import random
-import os
 import time
 import requests
 import time
-from typing import Callable, TypeVar
 import urllib
 
 from box import Box


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Patch error handling w/ openai:
```
requests.exceptions.ConnectionError: HTTPConnectionPool(host='ollama.private', port=8000): Max retries exceeded with url: /chat/completions (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x12d1acf90>: Failed to establish a new connection: [Errno 61] Connection refused'))

During handling of the above exception, another exception occurred:

..
memgpt-test/venv/lib/python3.11/site-packages/memgpt/openai_tools.py", line 124, in openai_chat_completions_request
    printd(f"Got RequestException, exception={req_err}, response={response}")
                                                                  ^^^^^^^^
UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
? Retry agent.step()? (Y/n)

```

Separately, patch the quickstart command to properly ask for openai api keys each time unless set.

