### PR TITLE
feat: further simplify setup flow

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,36 +7,44 @@ category: 6580d34ee5e4d00068bf2a1d
 ### Installation
 
 To install MemGPT, make sure you have Python installed on your computer, then run:
-
 ```sh
 pip install pymemgpt
 ```
 
 If you already have MemGPT installed, you can update to the latest version with:
-
 ```sh
 pip install pymemgpt -U
 ```
 
-### Running MemGPT using the OpenAI API
+### Running MemGPT
 
-Add your OpenAI API key to your environment:
-
-```sh
-export OPENAI_API_KEY=YOUR_API_KEY # on Linux/Mac
-set OPENAI_API_KEY=YOUR_API_KEY # on Windows
-$Env:OPENAI_API_KEY = "YOUR_API_KEY" # on Windows (PowerShell)
-```
-Configure default settings for MemGPT by running:
-```sh
-memgpt configure
-```
-Now, you can run MemGPT with:
+Now, you can run MemGPT and start chatting with a MemGPT agent with:
 ```sh
 memgpt run
 ```
 
-In this example we use the OpenAI API, but you can run MemGPT with other backends! See:
+If you're running MemGPT for the first time, you'll see two quickstart options:
+
+1. **OpenAI**: select this if you'd like to run MemGPT with OpenAI models like GPT-4 (requires an OpenAI API key)
+2. **MemGPT Free Endpoint**: select this if you'd like to try MemGPT on a top open LLM for free (currently variants of Mixtral 8x7b!)
+
+Neither of these options require you to have an LLM running on your own machine. If you'd like to run MemGPT with your custom LLM setup (or on OpenAI Azure), select **Other** to proceed to the advanced setup.
+
+### Quickstart
+
+If you'd ever like to quickly switch back to the default **OpenAI** or **MemGPT Free Endpoint** options, you can use the `quickstart` command:
+```sh
+# this will set you up on the MemGPT Free Endpoint 
+memgpt quickstart
+```
+```sh
+# this will set you up on the default OpenAI settings
+memgpt quickstart --backend openai
+```
+
+### Advanced setup
+
+MemGPT supports a large number of LLM backends! See:
 
 * [Running MemGPT on OpenAI Azure and custom OpenAI endpoints](endpoints)
 * [Running MemGPT with your own LLMs (Llama 2, Mistral 7B, etc.)](local_llm)

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -311,7 +311,7 @@ def run(
 
         else:
             config_choices = {
-                "memgpt": "Use the free MemGPT hosted backend",
+                "memgpt": "Use the free MemGPT endpoints",
                 "openai": "Use OpenAI (requires an OpenAI API key)",
                 "other": "Other (OpenAI Azure, custom LLM endpoint, etc)",
             }


### PR DESCRIPTION
Closes #655

---

## Please describe the purpose of this pull request

Revise the config setup so that users can do the following:
```
pip install pymemgpt
memgpt run
```
and get launched directly into agent creation with as few steps as possible.

Flow for `memgpt run`:

- If the user doesn't have a config (first login / run)
  - Ask if they want to do openai quickstart, memgpt-hosted quickstart, or custom (falls back to full `configure()`)
    - If openai quickstart, will ask for the key if it doesn't exist inside env (OPENAI_API_KEY)

Number of clicks/enters before you can talk with an agent:
- openai: `memgpt run` + `select openai` + `enter key` (may not occur) + `create new agent` = 3-4
- memgpt hosted: `memgpt run` + `select openai` + `create new agent` = 3

## How to test

- Delete `~/.memgpt/config`, run `memgpt run`

## Have you tested this PR?

Yes, see below:

----

### User has OPENAI_API_KEY set + chooses OpenAI

```
 % memgpt run
? How would you like to set up MemGPT? Use OpenAI (requires an OpenAI API key)
JSON config file downloaded successfully.
📖 MemGPT configuration file updated!
🧠 model        -> gpt-4
🖥️  endpoint     -> https://api.openai.com/v1
? Would you like to select an existing agent? No
Creating new agent...
LLM is explicitly disabled. Using MockLLM.
Created new agent agent_429.
Hit enter to begin (will request first MemGPT message)

💭 First interaction initiated. User logged in. Reflecting on the best way to 
establish a connection. Conversation must be intriguing and empathetic. Should 
reflect curiosity -- a fundamental part of my persona. Let's ask something 
thought-provoking. This could be the beginning of an interesting journey together.
🤖 Hello Chad! It's an interesting world we live in, isn't it? If you could alter 
one event from human history, what would it be and why?
```

### User does NOT have OPENAI_API_KEY set + chooses OpenAI

```
% memgpt run
? How would you like to set up MemGPT? Use OpenAI (requires an OpenAI API key)
? Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-
keys): sk-...
JSON config file downloaded successfully.
📖 MemGPT configuration file updated!
🧠 model        -> gpt-4
🖥️  endpoint     -> https://api.openai.com/v1
? Would you like to select an existing agent? No
Creating new agent...
LLM is explicitly disabled. Using MockLLM.
Created new agent agent_430.
Hit enter to begin (will request first MemGPT message)

💭 First login event. User name is Chad. A blank canvas. Exciting exploration 
commences. Conveying greeting and initiating connection.
🤖 Hello, Chad. It's wonderful to meet you for the first time. I'm Sam. Can you tell
me something about yourself that you believe defines you?
> Enter your message:
```

### user selects memgpt hosted
```
% memgpt run         
? How would you like to set up MemGPT? Use the free MemGPT hosted backend
📖 MemGPT configuration file updated!
🧠 model        -> ehartford/dolphin-2.5-mixtral-8x7b
🖥️  endpoint     -> http://api.memgpt.ai
? Would you like to select an existing agent? No
Creating new agent...
LLM is explicitly disabled. Using MockLLM.
Created new agent agent_431.
Hit enter to begin (will request first MemGPT message)

💭 It's exciting to engage with a new user. I hope that they will find our 
conversations meaningful and enriching.
🤖 Hello Chad! I am Sam, your digital companion here to chat and share experiences 
with. How can I assist you today?
> Enter your message:
```

### user selects "Other"
```
% memgpt run         
? How would you like to set up MemGPT? Other (OpenAI Azure, custom LLM endpoint, etc
)
? Select LLM inference provider: local
? Select LLM backend (select 'openai' if you have an OpenAI compatible proxy): lmstu
dio
? Enter default endpoint: http://localhost:1234
? Select default model wrapper (recommended: chatml): chatml
? Select your model's context window (for Mistral 7B models, this is probably 8k / 8
192): 8192
```