### PR TITLE
fix: Throw "env vars not set" early and enhance /attach for KeyboardInterrupt (#669)

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -421,34 +421,37 @@ def attach(
     agent: str = typer.Option(help="Specify agent to attach data to"),
     data_source: str = typer.Option(help="Data source to attach to avent"),
 ):
-    # loads the data contained in data source into the agent's memory
-    from memgpt.connectors.storage import StorageConnector
-    from tqdm import tqdm
+    try:
+        # loads the data contained in data source into the agent's memory
+        from memgpt.connectors.storage import StorageConnector
+        from tqdm import tqdm
 
-    agent_config = AgentConfig.load(agent)
+        agent_config = AgentConfig.load(agent)
 
-    # get storage connectors
-    source_storage = StorageConnector.get_storage_connector(name=data_source)
-    dest_storage = StorageConnector.get_storage_connector(agent_config=agent_config)
+        # get storage connectors
+        source_storage = StorageConnector.get_storage_connector(name=data_source)
+        dest_storage = StorageConnector.get_storage_connector(agent_config=agent_config)
 
-    size = source_storage.size()
-    typer.secho(f"Ingesting {size} passages into {agent_config.name}", fg=typer.colors.GREEN)
-    page_size = 100
-    generator = source_storage.get_all_paginated(page_size=page_size)  # yields List[Passage]
-    passages = []
-    for i in tqdm(range(0, size, page_size)):
-        passages = next(generator)
-        dest_storage.insert_many(passages)
+        size = source_storage.size()
+        typer.secho(f"Ingesting {size} passages into {agent_config.name}", fg=typer.colors.GREEN)
+        page_size = 100
+        generator = source_storage.get_all_paginated(page_size=page_size)  # yields List[Passage]
+        passages = []
+        for i in tqdm(range(0, size, page_size)):
+            passages = next(generator)
+            dest_storage.insert_many(passages)
 
-    # save destination storage
-    dest_storage.save()
+        # save destination storage
+        dest_storage.save()
 
-    total_agent_passages = dest_storage.size()
+        total_agent_passages = dest_storage.size()
 
-    typer.secho(
-        f"Attached data source {data_source} to agent {agent}, consisting of {len(passages)}. Agent now has {total_agent_passages} embeddings in archival memory.",
-        fg=typer.colors.GREEN,
-    )
+        typer.secho(
+            f"Attached data source {data_source} to agent {agent}, consisting of {len(passages)}. Agent now has {total_agent_passages} embeddings in archival memory.",
+            fg=typer.colors.GREEN,
+        )
+    except KeyboardInterrupt:
+        typer.secho(" Operation interrupted by KeyboardInterrupt.", fg=typer.colors.YELLOW)
 
 
 def version():

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -288,6 +288,27 @@ def configure_archival_storage(config: MemGPTConfig):
 def configure():
     """Updates default MemGPT configurations"""
 
+    # check credentials
+    openai_key = get_openai_credentials()
+    azure_creds = get_azure_credentials()
+
+    if not openai_key and all(value is None or value == "" for value in azure_creds.values()):
+        raise ValueError(
+            "Missing environment variables (see https://memgpt.readme.io/docs/endpoints). Please set them and run `memgpt configure` again."
+        )
+    else:  # Detecting non-empty configurations for Azure or OpenAI
+        detected_services = []
+
+        if all([azure_creds["azure_key"], azure_creds["azure_endpoint"], azure_creds["azure_version"]]):
+            detected_services.append("Azure")
+
+        if openai_key:
+            detected_services.append("OpenAI")
+
+        if detected_services:
+            detected_services_message = ", ".join(detected_services)
+            typer.secho(f"Detected {detected_services_message} configuration.", fg=typer.colors.YELLOW)
+
     MemGPTConfig.create_config_dir()
 
     # Will pre-populate with defaults, or what the user previously set
@@ -297,26 +318,6 @@ def configure():
     embedding_endpoint_type, embedding_endpoint, embedding_dim, embedding_model = configure_embedding_endpoint(config)
     default_preset, default_persona, default_human, default_agent = configure_cli(config)
     archival_storage_type, archival_storage_uri, archival_storage_path = configure_archival_storage(config)
-
-    # check credentials
-    azure_creds = get_azure_credentials()
-    # azure_key, azure_endpoint, azure_version, azure_deployment, azure_embedding_deployment = get_azure_credentials()
-    openai_key = get_openai_credentials()
-    if model_endpoint_type == "azure" or embedding_endpoint_type == "azure":
-        if all([azure_creds["azure_key"], azure_creds["azure_endpoint"], azure_creds["azure_version"]]):
-            print(f"Using Microsoft endpoint {azure_creds['azure_endpoint']}.")
-            # Deployment can optionally customize your endpoint model name
-            if all([azure_creds["azure_deployment"], azure_creds["azure_embedding_deployment"]]):
-                print(f"Using deployment id {azure_creds['azure_deployment']}")
-        else:
-            raise ValueError(
-                "Missing environment variables for Azure (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set then run `memgpt configure` again."
-            )
-    if model_endpoint_type == "openai" or embedding_endpoint_type == "openai":
-        if not openai_key:
-            raise ValueError(
-                "Missing environment variables for OpenAI (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set them and run `memgpt configure` again."
-            )
 
     config = MemGPTConfig(
         # model configs


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This pull request addresses Issue #669, which is related to CLI conveniences. It fixes the issue of environment variables not being set early and enhances the /attach command to respect KeyboardInterrupt.

**How to test**
- Run `memgpt configure` without setting OpenAI and Azure environment variables.
- Verify that "env vars not set" error is thrown.
- Test the /attach command and ensure it respects KeyboardInterrupt.

**Have you tested this PR?**
Yes, I have tested the latest commit on this PR. The /attach command now behaves as expected, and the "env vars not set" error is thrown early during `memgpt configure`.

**Related issues or PRs**
[Issue #669](https://github.com/cpacker/MemGPT/issues/669)

**Is your PR over 500 lines of code?**
No, the changes are concise and do not exceed 500 lines.