### PR TITLE
fix: CLI conveniences (add-on to #674)

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -63,6 +63,7 @@ def configure_llm_endpoint(config: MemGPTConfig):
                     openai_api_key = questionary.text(
                         "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):"
                     ).ask()
+                config.save()
 
         model_endpoint_type = "openai"
         model_endpoint = "https://api.openai.com/v1"
@@ -70,9 +71,9 @@ def configure_llm_endpoint(config: MemGPTConfig):
         provider = "openai"
 
     elif provider == "azure":
-        # check for key
+        # check for necessary vars
         azure_creds = get_azure_credentials()
-        if azure_creds["azure_key"] is None:
+        if not all([azure_creds["azure_key"], azure_creds["azure_endpoint"], azure_creds["azure_version"]]):
             raise ValueError(
                 "Missing environment variables for Azure (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set then run `memgpt configure` again."
             )
@@ -199,14 +200,37 @@ def configure_embedding_endpoint(config: MemGPTConfig):
     embedding_provider = questionary.select(
         "Select embedding provider:", choices=["openai", "azure", "hugging-face", "local"], default=default_embedding_endpoint_type
     ).ask()
+
     if embedding_provider == "openai":
+        # check for key
+        if config.openai_key is None:
+            # allow key to get pulled from env vars
+            openai_api_key = os.getenv("OPENAI_API_KEY", None)
+            if openai_api_key is None:
+                # if we still can't find it, ask for it as input
+                while openai_api_key is None or len(openai_api_key) == 0:
+                    # Ask for API key as input
+                    openai_api_key = questionary.text(
+                        "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):"
+                    ).ask()
+                config.save()
+
         embedding_endpoint_type = "openai"
         embedding_endpoint = "https://api.openai.com/v1"
         embedding_dim = 1536
+
     elif embedding_provider == "azure":
+        # check for necessary vars
+        azure_creds = get_azure_credentials()
+        if not all([azure_creds["azure_key"], azure_creds["azure_embedding_endpoint"], azure_creds["azure_embedding_version"]]):
+            raise ValueError(
+                "Missing environment variables for Azure (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set then run `memgpt configure` again."
+            )
+
         embedding_endpoint_type = "azure"
-        embedding_endpoint = get_azure_credentials()["azure_embedding_endpoint"]
+        embedding_endpoint = azure_creds["azure_embedding_endpoint"]
         embedding_dim = 1536
+
     elif embedding_provider == "hugging-face":
         # configure hugging face embedding endpoint (https://github.com/huggingface/text-embeddings-inference)
         # supports custom model/endpoints
@@ -312,23 +336,6 @@ def configure():
     # check credentials
     openai_key = get_openai_credentials()
     azure_creds = get_azure_credentials()
-
-    if not openai_key and all(value is None or value == "" for value in azure_creds.values()):
-        raise ValueError(
-            "Missing environment variables (see https://memgpt.readme.io/docs/endpoints). Please set them and run `memgpt configure` again."
-        )
-    else:  # Detecting non-empty configurations for Azure or OpenAI
-        detected_services = []
-
-        if all([azure_creds["azure_key"], azure_creds["azure_endpoint"], azure_creds["azure_version"]]):
-            detected_services.append("Azure")
-
-        if openai_key:
-            detected_services.append("OpenAI")
-
-        if detected_services:
-            detected_services_message = ", ".join(detected_services)
-            typer.secho(f"Detected {detected_services_message} configuration.", fg=typer.colors.YELLOW)
 
     MemGPTConfig.create_config_dir()
 

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -63,6 +63,7 @@ def configure_llm_endpoint(config: MemGPTConfig):
                     openai_api_key = questionary.text(
                         "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):"
                     ).ask()
+                config.openai_key = openai_api_key
                 config.save()
 
         model_endpoint_type = "openai"
@@ -213,6 +214,7 @@ def configure_embedding_endpoint(config: MemGPTConfig):
                     openai_api_key = questionary.text(
                         "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):"
                     ).ask()
+                config.openai_key = openai_api_key
                 config.save()
 
         embedding_endpoint_type = "openai"

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -343,11 +343,15 @@ def configure():
 
     # Will pre-populate with defaults, or what the user previously set
     config = MemGPTConfig.load()
-    model_endpoint_type, model_endpoint = configure_llm_endpoint(config)
-    model, model_wrapper, context_window = configure_model(config, model_endpoint_type)
-    embedding_endpoint_type, embedding_endpoint, embedding_dim, embedding_model = configure_embedding_endpoint(config)
-    default_preset, default_persona, default_human, default_agent = configure_cli(config)
-    archival_storage_type, archival_storage_uri, archival_storage_path = configure_archival_storage(config)
+    try:
+        model_endpoint_type, model_endpoint = configure_llm_endpoint(config)
+        model, model_wrapper, context_window = configure_model(config, model_endpoint_type)
+        embedding_endpoint_type, embedding_endpoint, embedding_dim, embedding_model = configure_embedding_endpoint(config)
+        default_preset, default_persona, default_human, default_agent = configure_cli(config)
+        archival_storage_type, archival_storage_uri, archival_storage_path = configure_archival_storage(config)
+    except ValueError as e:
+        typer.secho(str(e), fg=typer.colors.RED)
+        return
 
     config = MemGPTConfig(
         # model configs
@@ -378,7 +382,7 @@ def configure():
         archival_storage_uri=archival_storage_uri,
         archival_storage_path=archival_storage_path,
     )
-    print(f"Saving config to {config.config_path}")
+    typer.secho(f"📖 Saving config to {config.config_path}", fg=typer.colors.GREEN)
     config.save()
 
 


### PR DESCRIPTION
## Please describe the purpose of this pull request

Improving the workflow a bit more.

- Only raise errors about openai or azure keys missing once the user selects openai/azure as an option
  - Do this for both the LLM endpoint step and the embeddings endpoint step
    - e.g. if the user selects localllm and no openai key is specified, don't throw an error until they try to use openai for embeddings
  - For openai, allow the user to provide the key in real-time (if missing)
- When key-related errors happen in configure, they're thrown as ValueErrors
  - Catch the ValueErrors and print them cleanly vs a fat stacktrace


---

## Tested: example runs of `memgpt configure`

### User does not have openai key set, and tries to do openai LLM
```
% memgpt configure
? Select LLM inference provider: openai
? Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-
keys): banana
? Override default endpoint: https://api.openai.com/v1
? Select default model (recommended: gpt-4): gpt-4
? Select embedding provider: openai
? Select default preset: memgpt_chat
? Select default persona: sam_pov
? Select default human: basic
? Select storage backend for archival data: local
Saving config to /Users/loaner/.memgpt/config
```

### User does not have openai key set, tried to do local LLM + openai embeddings
```
 % memgpt configure
? Select LLM inference provider: local
? Select LLM backend (select 'openai' if you have an OpenAI compatible proxy): lmstu
dio
? Enter default endpoint: http://localhost:1234
? Select default model wrapper (recommended: chatml): chatml
? Select your model's context window (for Mistral 7B models, this is probably 8k / 8
192): 8192
? Select embedding provider: openai
? Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-
keys): banana
? Select default preset: memgpt_chat
? Select default persona: sam_pov
? Select default human: basic
? Select storage backend for archival data: local
Saving config to /Users/loaner/.memgpt/config
```

### User has no config, but openai is set in the env vars
```
% memgpt configure            
? Select LLM inference provider: openai
? Override default endpoint: https://api.openai.com/v1
? Select default model (recommended: gpt-4): gpt-4
? Select embedding provider: openai
? Select default preset: memgpt_chat
? Select default persona: sam_pov
? Select default human: basic
? Select storage backend for archival data: local
Saving config to /Users/loaner/.memgpt/config
```

### User has no azure vars set, tries to use azure LLM (immediate error)
```
 % memgpt configure            
? Select LLM inference provider: azure
Missing environment variables for Azure (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set then run `memgpt configure` again.
```
### User has no azure vars set, tries to use local LLM but azure embedding
```
 % memgpt configure
? Select LLM inference provider: local
? Select LLM backend (select 'openai' if you have an OpenAI compatible proxy): lmstu
dio
? Enter default endpoint: http://localhost:1234
? Select default model wrapper (recommended: chatml): chatml
? Select your model's context window (for Mistral 7B models, this is probably 8k / 8
192): 8192
? Select embedding provider: azure
Missing environment variables for Azure (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set then run `memgpt configure` again.
```

### User has only azure LLM vars set, tries to use azure LLM + embeddings (expected success, since in `get_azure_credentials` we default from LLM->embeddings)
```
% memgpt configure
? Select LLM inference provider: azure
? Select default model (recommended: gpt-4): gpt-4-1106-preview
? Select embedding provider: azure
? Select default preset: memgpt_chat
? Select default persona: sam_pov
? Select default human: basic
? Select storage backend for archival data: local
📖 Saving config to /Users/loaner/.memgpt/config
```

### User has only azure embedding vars set, tries to use both LLM + embeddings
```
% memgpt configure
? Select LLM inference provider: azure
Missing environment variables for Azure (see https://memgpt.readme.io/docs/endpoints#azure-openai). Please set then run `memgpt configure` again.
```