### PR TITLE
fix: add config mirrors for people on old versions

### DIFF
--- a/configs/memgpt_hosted.json
+++ b/configs/memgpt_hosted.json
@@ -1,0 +1,12 @@
+{
+    "context_window": 32768,
+    "model": "ehartford/dolphin-2.5-mixtral-8x7b",
+    "model_endpoint_type": "vllm",
+    "model_endpoint": "http://api.memgpt.ai",
+    "model_wrapper": "chatml",
+    "embedding_endpoint_type": "hugging-face",
+    "embedding_endpoint": "http://embeddings.memgpt.ai",
+    "embedding_model": "BAAI/bge-large-en-v1.5",
+    "embedding_dim": 1536,
+    "embedding_chunk_size": 300
+}

--- a/configs/openai.json
+++ b/configs/openai.json
@@ -1,0 +1,12 @@
+{
+    "context_window": 8192,
+    "model": "gpt-4",
+    "model_endpoint_type": "openai",
+    "model_endpoint": "https://api.openai.com/v1",
+    "model_wrapper": null,
+    "embedding_endpoint_type": "openai",
+    "embedding_endpoint": "https://api.openai.com/v1",
+    "embedding_model": null,
+    "embedding_dim": 1536,
+    "embedding_chunk_size": 300
+}


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

#680 changes the config location, we should leave a mirror in for now until we have a new release.

**How to test**

- On pypi 0.2.8 do `memgpt quickstart latest` (pre-PR should 404, post-PR should be fine)