### PR TITLE
fix: Patch quickstart via run on empty dir

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -322,10 +322,14 @@ def run(
             ).ask()
 
             if config_selection == config_choices["memgpt"]:
+                MemGPTConfig.create_config_dir()
                 quickstart(backend=QuickstartChoice.memgpt_hosted, debug=debug, terminal=False, latest=False)
             elif config_selection == config_choices["openai"]:
+                MemGPTConfig.create_config_dir()
                 quickstart(backend=QuickstartChoice.openai, debug=debug, terminal=False, latest=False)
             elif config_selection == config_choices["other"]:
+                # create_config_dir() is run inside configure()
+                # MemGPTConfig.create_config_dir()
                 configure()
             else:
                 raise ValueError(config_selection)

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -322,9 +322,9 @@ def run(
             ).ask()
 
             if config_selection == config_choices["memgpt"]:
-                quickstart(backend=QuickstartChoice.memgpt_hosted, debug=debug, terminal=False)
+                quickstart(backend=QuickstartChoice.memgpt_hosted, debug=debug, terminal=False, latest=False)
             elif config_selection == config_choices["openai"]:
-                quickstart(backend=QuickstartChoice.openai, debug=debug, terminal=False)
+                quickstart(backend=QuickstartChoice.openai, debug=debug, terminal=False, latest=False)
             elif config_selection == config_choices["other"]:
                 configure()
             else:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- Patch bug where quickstart invoked via run was using `latest=True` instead of pulling from local bundled config
- Patch runtime error where agent directory does not exist yet on first time `memgpt run`

**How to test**

- Delete memgpt dir, then do `memgpt run` and get to the agent step