### PR TITLE
fix: allow edge case of quickstart before run on first install

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -74,6 +74,9 @@ def quickstart(
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
 
+    # make sure everything is set up properly
+    MemGPTConfig.create_config_dir()
+
     config_was_modified = False
     if backend == QuickstartChoice.memgpt_hosted:
         # if latest, try to pull the config from the repo
@@ -322,14 +325,10 @@ def run(
             ).ask()
 
             if config_selection == config_choices["memgpt"]:
-                MemGPTConfig.create_config_dir()
                 quickstart(backend=QuickstartChoice.memgpt_hosted, debug=debug, terminal=False, latest=False)
             elif config_selection == config_choices["openai"]:
-                MemGPTConfig.create_config_dir()
                 quickstart(backend=QuickstartChoice.openai, debug=debug, terminal=False, latest=False)
             elif config_selection == config_choices["other"]:
-                # create_config_dir() is run inside configure()
-                # MemGPTConfig.create_config_dir()
                 configure()
             else:
                 raise ValueError(config_selection)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

If the user runs `quickstart` before `run` on a fresh install (with no home dir created yet), you'll get an error on `run`:
```
  File "/home/cpacker/anaconda3/lib/python3.9/site-packages/memgpt/utils.py", line 182, in list_agent_config_files
    files = os.listdir(agent_dir)
FileNotFoundError: [Errno 2] No such file or directory: '/home/cpacker/.memgpt/agents'
```

To fix this, the user has to then:
- run `memgpt configure` (to trigger `MemGPTConfig.create_config_dir()`)
- run `memgpt quickstart` (to reset the values to the desired defaults)

Note @sarahwooders: we should probably add safeguards into `list_agent_config_files` to prevent crashing on empty dirs?

**How to test**

Delete `~/.memgpt`, run `memgpt quickstart` as your initial command. On `main`, this bricks. On this PR it's fixed.

**Have you tested this PR?**

Yes