### PR TITLE
fix: Remove match/case to support python <3.10

### DIFF
--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -213,19 +213,18 @@ class MemGPTAgent(ConversableAgent):
 
     def load(self, name: str, type: str, **kwargs):
         # call load function based on type
-        match type:
-            case "directory":
-                load_directory(name=name, **kwargs)
-            case "webpage":
-                load_webpage(name=name, **kwargs)
-            case "index":
-                load_index(name=name, **kwargs)
-            case "database":
-                load_database(name=name, **kwargs)
-            case "vector_database":
-                load_vector_database(name=name, **kwargs)
-            case _:
-                raise ValueError(f"Invalid data source type {type}")
+        if type == "directory":
+            load_directory(name=name, **kwargs)
+        elif type == "webpage":
+            load_webpage(name=name, **kwargs)
+        elif type == "index":
+            load_index(name=name, **kwargs)
+        elif type == "database":
+            load_database(name=name, **kwargs)
+        elif type == "vector_database":
+            load_vector_database(name=name, **kwargs)
+        else:
+            raise ValueError(f"Invalid data source type {type}")
 
     def attach(self, data_source: str):
         # attach new data


### PR DESCRIPTION
fixes #670, fixes #664

---

**Please describe the purpose of this pull request.**

Remove match/case (one instance inside autogen class) that was causing errors on Python versions <3.10.

**How to test**

Run autogen examples w/ python <3.10.

**Have you tested this PR?**

Basic regression testing.