### PR TITLE
fix: Better errors on over length persona/human files

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -447,7 +447,6 @@ def run(
         agent_config.save()
         typer.secho(f"->  🤖 Using persona profile '{agent_config.persona}'", fg=typer.colors.WHITE)
         typer.secho(f"->  🧑 Using human profile '{agent_config.human}'", fg=typer.colors.WHITE)
-        typer.secho(f"🎉 Created new agent '{agent_config.name}'", fg=typer.colors.GREEN)
 
         # Supress llama-index noise
         with suppress_stdout():
@@ -455,15 +454,20 @@ def run(
             persistence_manager = LocalStateManager(agent_config)  # TODO: insert dataset/pre-fill
 
         # create agent
-        memgpt_agent = presets.use_preset(
-            agent_config.preset,
-            agent_config,
-            agent_config.model,
-            utils.get_persona_text(agent_config.persona),
-            utils.get_human_text(agent_config.human),
-            interface,
-            persistence_manager,
-        )
+        try:
+            memgpt_agent = presets.use_preset(
+                agent_config.preset,
+                agent_config,
+                agent_config.model,
+                utils.get_persona_text(agent_config.persona),
+                utils.get_human_text(agent_config.human),
+                interface,
+                persistence_manager,
+            )
+        except ValueError as e:
+            typer.secho(f"Failed to create agent from provided information:\n{e}", fg=typer.colors.RED)
+            sys.exit(1)
+        typer.secho(f"🎉 Created new agent '{agent_config.name}'", fg=typer.colors.GREEN)
 
     # pretty print agent config
     printd(json.dumps(vars(agent_config), indent=4, sort_keys=True))

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -14,7 +14,13 @@ import pytz
 import tiktoken
 
 import memgpt
-from memgpt.constants import MEMGPT_DIR, FUNCTION_RETURN_CHAR_LIMIT, CLI_WARNING_PREFIX
+from memgpt.constants import (
+    MEMGPT_DIR,
+    FUNCTION_RETURN_CHAR_LIMIT,
+    CLI_WARNING_PREFIX,
+    CORE_MEMORY_HUMAN_CHAR_LIMIT,
+    CORE_MEMORY_PERSONA_CHAR_LIMIT,
+)
 
 from memgpt.openai_backcompat.openai_object import OpenAIObject
 
@@ -237,21 +243,30 @@ def list_persona_files():
     return memgpt_defaults + user_added
 
 
-def get_human_text(name: str):
+def get_human_text(name: str, enforce_limit=True):
     for file_path in list_human_files():
         file = os.path.basename(file_path)
         if f"{name}.txt" == file or name == file:
-            return open(file_path, "r").read().strip()
-    raise ValueError(f"Human {name} not found")
+            human_text = open(file_path, "r").read().strip()
+            if enforce_limit and len(human_text) > CORE_MEMORY_HUMAN_CHAR_LIMIT:
+                raise ValueError(f"Contents of {name}.txt is over the character limit ({len(human_text)} > {CORE_MEMORY_HUMAN_CHAR_LIMIT})")
+            return human_text
+
+    raise ValueError(f"Human {name}.txt not found")
 
 
-def get_persona_text(name: str):
+def get_persona_text(name: str, enforce_limit=True):
     for file_path in list_persona_files():
         file = os.path.basename(file_path)
         if f"{name}.txt" == file or name == file:
-            return open(file_path, "r").read().strip()
+            persona_text = open(file_path, "r").read().strip()
+            if enforce_limit and len(persona_text) > CORE_MEMORY_PERSONA_CHAR_LIMIT:
+                raise ValueError(
+                    f"Contents of {name}.txt is over the character limit ({len(persona_text)} > {CORE_MEMORY_PERSONA_CHAR_LIMIT})"
+                )
+            return persona_text
 
-    raise ValueError(f"Persona {name} not found")
+    raise ValueError(f"Persona {name}.txt not found")
 
 
 def get_human_text(name: str):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Before:
```
% memgpt run --persona too_long

🧬 Creating new agent...
->  🤖 Using persona profile 'too_long'
->  🧑 Using human profile 'cs_phd'
🎉 Created new agent 'agent_4'

Traceback (most recent call last):
...
ValueError: Edit failed: Exceeds 2000 character limit (requested 22073). Consider summarizing existing core memories in 'persona' and/or moving lower priority content to archival memory to free up space in core memory, then trying again.
```

After:
```
 % memgpt run --persona too_long

🧬 Creating new agent...
->  🤖 Using persona profile 'too_long'
->  🧑 Using human profile 'cs_phd'
Failed to create agent from provided information:
Contents of too_long.txt is over the character limit (22073 > 2000)
```