### PR TITLE
feat: set a default temperature in the common local llm settings

### DIFF
--- a/memgpt/local_llm/settings/simple.py
+++ b/memgpt/local_llm/settings/simple.py
@@ -23,4 +23,6 @@ settings = {
         # NOTE: this requires the ability to patch the extra '}}' back into the prompt
         "  }\n}\n",
     ],
+    # most lm frontends default to 0.7-0.8 these days
+    "temperature": 0.8,
 }


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- set a default temperature in the common local llm settings (use 0.8, most user-friendly lm frontends seem to be using 0.7/0.8 atm)
- this shouldn't change LM Studio calls (0.8 default) but it should change vLLM calls (1.0 default)
  - default settings on vLLM make it hard for the LLM to output structured content (eg lists) 

**How to test**

Regression test to check runtime errors on various backends (caused by additional param in payload):

- [x] lmstudio
- [x] ollama
- [ ] webui
- [x] llama.cpp
- [x] koboldcpp
- [x] vLLM

**Have you tested this PR?**

See checklist