### PR TITLE
fix: patch bug on TEI embedding lookup

### DIFF
--- a/memgpt/connectors/local.py
+++ b/memgpt/connectors/local.py
@@ -9,6 +9,7 @@ import os
 from typing import List, Optional
 
 from llama_index import VectorStoreIndex, ServiceContext, set_global_service_context
+from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.empty.base import EmptyIndex
 from llama_index.retrievers import VectorIndexRetriever
 from llama_index.schema import TextNode
@@ -117,7 +118,7 @@ class LocalStorageConnector(StorageConnector):
             index=self.index,  # does this get refreshed?
             similarity_top_k=top_k,
         )
-        nodes = retriever.retrieve(query)
+        nodes = retriever.retrieve(str_or_query_bundle=QueryBundle(query_str=query, embedding=query_vec))
         results = [Passage(embedding=node.embedding, text=node.text) for node in nodes]
         return results
 

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -351,6 +351,8 @@ class EmbeddingArchivalMemory(ArchivalMemory):
                         raise TypeError(
                             f"Got back an unexpected payload from text embedding function, type={type(embedding)}, value={embedding}"
                         )
+                if not isinstance(embedding, list):
+                    raise TypeError(f"Embedding was not a list:\n{embedding}\n{type(embedding)}")
                 passages.append(Passage(text=node.text, embedding=embedding, doc_id=f"agent_{self.agent_config.name}_memory"))
 
             # insert passages
@@ -379,6 +381,8 @@ class EmbeddingArchivalMemory(ArchivalMemory):
                         raise TypeError(
                             f"Got back an unexpected payload from text embedding function, type={type(query_vec)}, value={query_vec}"
                         )
+                if not isinstance(query_vec, list):
+                    raise TypeError(f"Embedding was not a list:\n{query_vec}\n{type(query_vec)}")
                 self.cache[query_string] = self.storage.query(query_string, query_vec, top_k=self.top_k)
 
             start = int(start if start else 0)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Same bug we patched before with having to unpack TEI embedding payload. However, I noticed that in LocalIndex the embeddings on a query get created again, so our previous patch doesn't apply, and thus we get a similar error. This patch uses QueryBundle to make sure we don't create another embedding on query, so that we don't have another unpacking problem.

**How to test**

Use `memgpt quickstart`

On main, ask "insert "banana" into archival memory", then "search archival memory for "banana"" and you'll get this error:
```
💭 Processing user request to search archival memory for a specific term.
⚡🧠 [function] updating memory with archival_memory_search
'page'
{'query': 'banana'}
Archival search error unsupported operand type(s) for /: 'dict' and 'int'
Error calling function archival_memory_search: unsupported operand type(s) for /: 'dict' and 'int'
Traceback (most recent call last):
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/memgpt/agent.py", line 521, in handle_ai_response
    function_response = function_to_call(**function_args)
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/memgpt/functions/function_sets/base.py", line 178, in archival_memory_search
    results, total = self.persistence_manager.archival_memory.search(query, count=count, start=page * count)
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/memgpt/memory.py", line 393, in search
    raise e
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/memgpt/memory.py", line 382, in search
    self.cache[query_string] = self.storage.query(query_string, query_vec, top_k=self.top_k)
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/memgpt/connectors/local.py", line 120, in query
    nodes = retriever.retrieve(query)
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/llama_index/core/base_retriever.py", line 54, in retrieve
    nodes = self._retrieve(query_bundle)
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/llama_index/indices/vector_store/retrievers/retriever.py", line 84, in _retrieve
    self._service_context.embed_model.get_agg_embedding_from_queries(
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/llama_index/embeddings/base.py", line 144, in get_agg_embedding_from_queries
    return agg_fn(query_embeddings)
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/llama_index/embeddings/base.py", line 33, in mean_agg
    return list(np.array(embeddings).mean(axis=0))
  File "/home/cpacker/memgpt-test-2/venv/lib/python3.9/site-packages/numpy/core/_methods.py", line 131, in _mean
    ret = ret / rcount
TypeError: unsupported operand type(s) for /: 'dict' and 'int'

⚡🔴 [function] Error: Error calling function archival_memory_search: unsupported operand type(s) for /: 'dict' and 'int'
```

With this PR, you won't get the error:
<img width="808" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/905fac5f-f5a4-4c36-9b20-5cf01ea8c267">

**Have you tested this PR?**

Yes, using memgpt quickstart.