### PR TITLE
fix: patch TEI error in load

### DIFF
--- a/configs/memgpt_hosted.json
+++ b/configs/memgpt_hosted.json
@@ -7,6 +7,6 @@
     "embedding_endpoint_type": "hugging-face",
     "embedding_endpoint": "https://embeddings.memgpt.ai",
     "embedding_model": "BAAI/bge-large-en-v1.5",
-    "embedding_dim": 1536,
+    "embedding_dim": 1024,
     "embedding_chunk_size": 300
 }

--- a/memgpt/cli/cli_load.py
+++ b/memgpt/cli/cli_load.py
@@ -35,7 +35,8 @@ def store_docs(name, docs, show_progress=True):
     embed_model = embedding_model()
 
     # use llama index to run embeddings code
-    service_context = ServiceContext.from_defaults(llm=None, embed_model=embed_model, chunk_size=config.embedding_chunk_size)
+    with suppress_stdout():
+        service_context = ServiceContext.from_defaults(llm=None, embed_model=embed_model, chunk_size=config.embedding_chunk_size)
     index = VectorStoreIndex.from_documents(docs, service_context=service_context, show_progress=True)
     embed_dict = index._vector_store._data.embedding_dict
     node_dict = index._docstore.docs

--- a/memgpt/cli/cli_load.py
+++ b/memgpt/cli/cli_load.py
@@ -45,18 +45,6 @@ def store_docs(name, docs, show_progress=True):
     passages = []
     for node_id, node in tqdm(node_dict.items()):
         vector = embed_dict[node_id]
-
-        # fixing weird bug where type returned isn't a list, but instead is an object
-        # eg: embedding={'object': 'list', 'data': [{'object': 'embedding', 'embedding': [-0.0071973633, -0.07893023,
-        if isinstance(vector, dict):
-            try:
-                vector = vector["data"][0]["embedding"]
-            except (KeyError, IndexError):
-                # TODO as a fallback, see if we can find any lists in the payload
-                raise TypeError(f"Got back an unexpected payload from text embedding function, type={type(vector)}, value={vector}")
-        if not isinstance(vector, list):
-            raise TypeError(f"Embedding was not a list:\n{vector}\n{type(vector)}")
-
         node.embedding = vector
         text = node.text.replace("\x00", "\uFFFD")  # hacky fix for error on null characters
         assert (

--- a/memgpt/configs/memgpt_hosted.json
+++ b/memgpt/configs/memgpt_hosted.json
@@ -7,6 +7,6 @@
     "embedding_endpoint_type": "hugging-face",
     "embedding_endpoint": "https://embeddings.memgpt.ai",
     "embedding_model": "BAAI/bge-large-en-v1.5",
-    "embedding_dim": 1536,
+    "embedding_dim": 1024,
     "embedding_chunk_size": 300
 }

--- a/memgpt/embeddings.py
+++ b/memgpt/embeddings.py
@@ -51,7 +51,22 @@ class EmbeddingEndpoint(BaseEmbedding):
                 timeout=self._timeout,
             )
 
-        return response.json()
+        response_json = response.json()
+
+        if isinstance(response_json, list):
+            # embedding directly in response
+            embedding = response_json
+        elif isinstance(response_json, dict):
+            # TEI embedding packaged inside openai-style response
+            try:
+                embedding = response_json["data"][0]["embedding"]
+            except (KeyError, IndexError):
+                raise TypeError(f"Got back an unexpected payload from text embedding function, response=\n{response_json}")
+        else:
+            # unknown response, can't parse
+            raise TypeError(f"Got back an unexpected payload from text embedding function, response=\n{response_json}")
+
+        return embedding
 
     async def _acall_api(self, text: str) -> List[float]:
         import httpx
@@ -66,8 +81,22 @@ class EmbeddingEndpoint(BaseEmbedding):
                 json=json_data,
                 timeout=self._timeout,
             )
+        response_json = response.json()
 
-        return response.json()
+        if isinstance(response_json, list):
+            # embedding directly in response
+            embedding = response_json
+        elif isinstance(response_json, dict):
+            # TEI embedding packaged inside openai-style response
+            try:
+                embedding = response_json["data"][0]["embedding"]
+            except (KeyError, IndexError):
+                raise TypeError(f"Got back an unexpected payload from text embedding function, response=\n{response_json}")
+        else:
+            # unknown response, can't parse
+            raise TypeError(f"Got back an unexpected payload from text embedding function, response=\n{response_json}")
+
+        return embedding
 
     def _get_query_embedding(self, query: str) -> list[float]:
         """get query embedding."""

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -341,16 +341,6 @@ class EmbeddingArchivalMemory(ArchivalMemory):
             # breakup string into passages
             for node in parser.get_nodes_from_documents([Document(text=memory_string)]):
                 embedding = self.embed_model.get_text_embedding(node.text)
-                # fixing weird bug where type returned isn't a list, but instead is an object
-                # eg: embedding={'object': 'list', 'data': [{'object': 'embedding', 'embedding': [-0.0071973633, -0.07893023,
-                if isinstance(embedding, dict):
-                    try:
-                        embedding = embedding["data"][0]["embedding"]
-                    except (KeyError, IndexError):
-                        # TODO as a fallback, see if we can find any lists in the payload
-                        raise TypeError(
-                            f"Got back an unexpected payload from text embedding function, type={type(embedding)}, value={embedding}"
-                        )
                 passages.append(Passage(text=node.text, embedding=embedding, doc_id=f"agent_{self.agent_config.name}_memory"))
 
             # insert passages
@@ -369,16 +359,6 @@ class EmbeddingArchivalMemory(ArchivalMemory):
             if query_string not in self.cache:
                 # self.cache[query_string] = self.retriever.retrieve(query_string)
                 query_vec = self.embed_model.get_text_embedding(query_string)
-                # fixing weird bug where type returned isn't a list, but instead is an object
-                # eg: embedding={'object': 'list', 'data': [{'object': 'embedding', 'embedding': [-0.0071973633, -0.07893023,
-                if isinstance(query_vec, dict):
-                    try:
-                        query_vec = query_vec["data"][0]["embedding"]
-                    except (KeyError, IndexError):
-                        # TODO as a fallback, see if we can find any lists in the payload
-                        raise TypeError(
-                            f"Got back an unexpected payload from text embedding function, type={type(query_vec)}, value={query_vec}"
-                        )
                 self.cache[query_string] = self.storage.query(query_string, query_vec, top_k=self.top_k)
 
             start = int(start if start else 0)


### PR DESCRIPTION
Close #723

**Please describe the purpose of this pull request.**

Example command to test:
```sh
memgpt load directory --name test_load --input-dir memgpt/personas/examples --recursive
```

### On main:

Works fine with OpenAI:
```
(pymemgpt-py3.10) (base) loaner@MacBook-Pro-5 MemGPT-2 % memgpt load directory --name test_load --input-dir memgpt/personas/examples 
--recursive
LLM is explicitly disabled. Using MockLLM.
LLM is explicitly disabled. Using MockLLM.
Parsing nodes: 100%|███████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 30.85it/s]
Generating embeddings: 100%|███████████████████████████████████████████████████████████████████████| 100/100 [00:03<00:00, 31.43it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 609637.21it/s]
Generating embeddings: 0it [00:00, ?it/s]
```

Doesn't work with `memgpt quickstart`:
```
(pymemgpt-py3.10) (base) loaner@MacBook-Pro-5 MemGPT-2 % memgpt quickstart
📖 MemGPT configuration file updated!
🧠 model        -> ehartford/dolphin-2.5-mixtral-8x7b
🖥️  endpoint     -> https://api.memgpt.ai
⚡ Run "memgpt run" to create an agent with the new config.
(pymemgpt-py3.10) (base) loaner@MacBook-Pro-5 MemGPT-2 % memgpt load directory --name test_load2 --input-dir memgpt/personas/examples --recursive
LLM is explicitly disabled. Using MockLLM.
LLM is explicitly disabled. Using MockLLM.
Parsing nodes: 100%|███████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 50.50it/s]
Generating embeddings: 100%|███████████████████████████████████████████████████████████████████████| 100/100 [00:10<00:00,  9.56it/s]
  0%|                                                                                                        | 0/100 [00:00<?, ?it/s]
    return callback(**use_params)  # type: ignore
  File "/Users/loaner/dev/MemGPT-2/memgpt/cli/cli_load.py", line 106, in load_directory
    store_docs(name, docs)
  File "/Users/loaner/dev/MemGPT-2/memgpt/cli/cli_load.py", line 48, in store_docs
    len(node.embedding) == config.embedding_dim
AssertionError: Expected embedding dimension 1536, got 4: {'object': 'list', 'data': [{'object': 'embedding', 'embedding': [0.0072218 ...
```

### On PR (with patch)

```sh
% memgpt load directory --name test_load --input-dir memgpt/personas/examples --recursive
Parsing nodes: 100%|███████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 51.74it/s]
Generating embeddings: 100%|███████████████████████████████████████████████████████████████████████| 100/100 [00:10<00:00,  9.25it/s]
  0%|                                                                                                        | 0/100 [00:00<?, ?it/s]
Traceback (most recent call last)
...
  File "/Users/loaner/dev/MemGPT-2/memgpt/cli/cli_load.py", line 121, in load_directory
    store_docs(name, docs)
  File "/Users/loaner/dev/MemGPT-2/memgpt/cli/cli_load.py", line 63, in store_docs
    len(node.embedding) == config.embedding_dim
AssertionError: Expected embedding dimension 1536, got 1024: [0.00722182, -0.028529543, 
```

config for reference:
```
[defaults]
preset = memgpt_chat
persona = sam_pov
human = basic

[model]
model = ehartford/dolphin-2.5-mixtral-8x7b
model_endpoint = https://api.memgpt.ai
model_endpoint_type = vllm
model_wrapper = chatml
context_window = 32768

[embedding]
embedding_endpoint_type = hugging-face
embedding_endpoint = https://embeddings.memgpt.ai
embedding_model = BAAI/bge-large-en-v1.5
embedding_dim = 1536
embedding_chunk_size = 300

[archival_storage]
type = local

[version]
memgpt_version = 0.2.10

[client]
anon_clientid = ...
```

**How to test**

See above.

**Have you tested this PR?**

- [x] load works
- [x] insert banana / search banana test works (quickstart)
- [x] insert banana / search banana test works (quickstart --backend openai)