### PR TITLE
fix: cleanup failed agent creation

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -2,6 +2,7 @@ import typer
 import json
 import requests
 import sys
+import shutil
 import io
 import logging
 import questionary
@@ -466,6 +467,21 @@ def run(
             )
         except ValueError as e:
             typer.secho(f"Failed to create agent from provided information:\n{e}", fg=typer.colors.RED)
+            # Delete the directory of the failed agent
+            try:
+                # Path to the specific file
+                agent_config_file = agent_config.agent_config_path
+
+                # Check if the file exists
+                if os.path.isfile(agent_config_file):
+                    # Delete the file
+                    os.remove(agent_config_file)
+
+                # Now, delete the directory along with any remaining files in it
+                agent_save_dir = os.path.join(MEMGPT_DIR, "agents", agent_config.name)
+                shutil.rmtree(agent_save_dir)
+            except:
+                typer.secho(f"Failed to delete agent directory during cleanup:\n{e}", fg=typer.colors.RED)
             sys.exit(1)
         typer.secho(f"🎉 Created new agent '{agent_config.name}'", fg=typer.colors.GREEN)
 


### PR DESCRIPTION
Close #709 

**Please describe the purpose of this pull request.**

From Discord:
> When running memgpt run --preset foo-system --persona foo --agent foo --human bar for the first time, if the setup fails (in my case because i hadn't deployed the preset files yet), the new agent dir and config is created, but not the state file. 
> When I run it again, startup fails due to a missing agent state file. 
> Deleting the agent dir allows the agent to be created successfully

Reproducing the error:
```sh
memgpt run --preset banana
```
```
? Would you like to select an existing agent? No

🧬 Creating new agent...
->  🤖 Using persona profile 'sam_pov'
->  🧑 Using human profile 'basic'
Failed to create agent from provided information:
Preset 'banana.yaml' not found
```
```
$ ls -lrt ~/.memgpt/agents
agent_1
agent_2
```
```
$ ls -lrt ~/.memgpt/agents/agent_2
config.json
```

**How to test**

Run `memgpt run --preset banana` and make sure no new directory is created (ie it's created, then deleted).

**Have you tested this PR?**

Yes:
```
% ls -rt ~/.memgpt/agents
agent_1
```
```
% memgpt run --preset banana

? Would you like to select an existing agent? No

🧬 Creating new agent...
->  🤖 Using persona profile 'sam_pov'
->  🧑 Using human profile 'basic'
Failed to create agent from provided information:
Preset 'banana.yaml' not found
```
```
% ls -rt ~/.memgpt/agents   
agent_1
```
