### PR TITLE
fix: don't insert request heartbeat into pause heartbeat

### DIFF
--- a/memgpt/local_llm/function_parser.py
+++ b/memgpt/local_llm/function_parser.py
@@ -2,7 +2,7 @@ import copy
 import json
 
 
-NO_HEARTBEAT_FUNCS = ["send_message"]
+NO_HEARTBEAT_FUNCS = ["send_message", "pause_heartbeats"]
 
 
 def insert_heartbeat(message):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

#621 added frequent inserting of heartbeats but this doesn't make sense for `pause_heartbeats`. Add `pause_heartbeats` to the reserved out-opt (with `send_message`).