### PR TITLE
feat: Reload functions and system prompt

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -6,6 +6,7 @@ import traceback
 
 from memgpt.persistence_manager import LocalStateManager
 from memgpt.config import AgentConfig, MemGPTConfig
+from memgpt.presets.utils import load_all_presets
 from memgpt.system import get_login_event, package_function_response, package_summarize_message, get_initial_boot_messages
 from memgpt.memory import CoreMemory as Memory, summarize_messages
 from memgpt.openai_tools import create, is_context_overflow_error
@@ -22,6 +23,7 @@ from memgpt.constants import (
 )
 from .errors import LLMError
 from .functions.functions import load_all_function_sets
+from .prompts import gpt_system
 
 
 def initialize_memory(ai_notes, human_notes):
@@ -308,6 +310,7 @@ class Agent(object):
         # [{'name': ..., 'description': ...}, {...}]
         available_functions = load_all_function_sets()
         linked_function_set = {}
+
         for f_schema in state["functions"]:
             # Attempt to find the function in the existing function library
             f_name = f_schema.get("name")
@@ -781,6 +784,47 @@ class Agent(object):
         # Check if it's been more than pause_heartbeats_minutes since pause_heartbeats_start
         elapsed_time = datetime.datetime.now() - self.pause_heartbeats_start
         return elapsed_time.total_seconds() < self.pause_heartbeats_minutes * 60
+
+    def reload_functions(self):
+        """Resets the functions functions available to the agent to those currently configured in the agent's preset"""
+        preset_function_names = load_all_presets()[self.config.preset]["functions"]
+        new_functions = {f_name: f_dict for f_name, f_dict in load_all_function_sets().items() if f_name in preset_function_names}
+
+        unconfigured_functions = set(preset_function_names) - set(new_functions.keys())
+        if len(unconfigured_functions) > 0:
+            printd(f"One or more function configured for preset but not defined in function library: {unconfigured_functions}")
+
+        new_functions_schema = [f_dict["json_schema"] for f_name, f_dict in new_functions.items()]
+
+        # check to establish what has been changed
+        added_functions = set(new_functions.keys()) - set(self.functions_python.keys())
+        removed_functions = set(self.functions_python.keys()) - set(new_functions.keys())
+        changed_schema_functions = [f_dict["name"] for f_dict in self.functions if f_dict != new_functions[f_dict["name"]]["json_schema"]]
+
+        if len(added_functions) + len(removed_functions) + len(changed_schema_functions) == 0:
+            printd("No functions added, removed, or have altered schemas. Source code of functions may have changed.")
+        else:
+            if len(added_functions) > 0:
+                printd(f"Adding functions: {added_functions}")
+            if len(removed_functions) > 0:
+                printd(f"Removing functions: {removed_functions}")
+            if len(changed_schema_functions) > 0:
+                printd(f"Changing schema for functions: {changed_schema_functions}")
+
+        self.functions = new_functions_schema
+        self.functions_python = {f_name: f_dict["python_function"] for f_name, f_dict in new_functions.items()}
+
+    def reload_system_prompt(self):
+        """Sets the system prompt to that currently configured in the agent's preset"""
+        preset_system_prompt = load_all_presets()[self.config.preset]["system_prompt"]
+        new_system = gpt_system.get_system_text(preset_system_prompt)
+
+        if new_system == self.system:
+            printd(f"System prompt unchanged")
+        else:
+            printd(f"System prompt changed, reloading...")
+
+        self.system = new_system
 
     def get_ai_reply(
         self,

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -207,6 +207,31 @@ def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, strip_ui=Fals
                             break
                     continue
 
+                elif user_input.lower() == "/reload" or user_input.lower().startswith("/reload "):
+                    if user_input.lower() == "/reload functions":
+                        memgpt_agent.reload_functions()
+                        memgpt_agent.save()
+                        typer.secho(
+                            f"/reload functions succeeded",
+                            fg=typer.colors.GREEN,
+                            bold=True,
+                        )
+
+                    elif user_input.lower() == "/reload system_prompt":
+                        memgpt_agent.reload_system_prompt()
+                        memgpt_agent.save()
+                        typer.secho(
+                            f"/reload system_prompt succeeded",
+                            fg=typer.colors.GREEN,
+                            bold=True,
+                        )
+                    else:
+                        typer.secho(
+                            "Invalid reload command: Valid options are 'system_prompt' and 'functions'",
+                            fg=typer.colors.RED,
+                            bold=True,
+                        )
+
                 elif user_input.lower() == "/summarize":
                     try:
                         memgpt_agent.summarize_messages_inplace()


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This is a new feature to support `/reload functions` and `/reload system_prompt`. It enables users to add or remove functions from an existing agent.

To add a function to an agent, the user must author a new function AND edit the preset for the agent

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

I didn't see a great way to add an actual test for this. But I've tested the following cases:
- new function added: agent able to call the function
- function removed: agent unable to call the function (no exception)
- function schema changed: this is handled by reload code, but is not actually supported as memgpt refused to start
- new function configured but not implemented: debug message logged but no exception


**Have you tested this PR?**
I have tested the above use cases.

**Related issues or PRs**
https://github.com/cpacker/MemGPT/issues/577

**Is your PR over 500 lines of code?**
No

**Additional context**

Some open questions:
- should we add a system message to the agent to notify them that their function list has changed? I have left this off for now, but the feature is not all that usable, in my usage the agent is somewhat reluctant to try a new function
- should we document this feature in the README? Or leave for power users to discover?
- I'm wondering if there'd be a good way to test out alterations of the configs, etc. I think I saw somewhere that there's a major refactor coming that puts everything in the database, so not sure it'd be worth it
