### PR TITLE
feat: enum choices for list command argument (issue #732)

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -4,6 +4,8 @@ from prettytable import PrettyTable
 import typer
 import os
 import shutil
+from typing import Annotated
+from enum import Enum
 
 # from memgpt.cli import app
 from memgpt import utils
@@ -475,9 +477,17 @@ def configure():
     config.save()
 
 
+class ListChoice(str, Enum):
+    agents = "agents"
+    humans = "humans"
+    personas = "personas"
+    sources = "sources"
+
+
 @app.command()
-def list(option: str):
-    if option == "agents":
+def list(arg: Annotated[ListChoice, typer.Argument]):
+    typer.echo(f"You chose {arg}")
+    if arg == ListChoice.agents:
         """List all agents"""
         table = PrettyTable()
         table.field_names = ["Name", "Model", "Persona", "Human", "Data Source", "Create Time"]
@@ -495,7 +505,7 @@ def list(option: str):
                 ]
             )
         print(table)
-    elif option == "humans":
+    elif arg == ListChoice.humans:
         """List all humans"""
         table = PrettyTable()
         table.field_names = ["Name", "Text"]
@@ -504,7 +514,7 @@ def list(option: str):
             name = os.path.basename(human_file).replace("txt", "")
             table.add_row([name, text])
         print(table)
-    elif option == "personas":
+    elif arg == ListChoice.personas:
         """List all personas"""
         table = PrettyTable()
         table.field_names = ["Name", "Text"]
@@ -514,7 +524,7 @@ def list(option: str):
             name = os.path.basename(persona_file).replace(".txt", "")
             table.add_row([name, text])
         print(table)
-    elif option == "sources":
+    elif arg == ListChoice.sources:
         """List all data sources"""
         table = PrettyTable()
         table.field_names = ["Name", "Location", "Agents"]
@@ -536,7 +546,7 @@ def list(option: str):
             table.add_row([data_source, location, agents])
         print(table)
     else:
-        raise ValueError(f"Unknown option {option}")
+        raise ValueError(f"Unknown argument {arg}")
 
 
 @app.command()

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -486,7 +486,6 @@ class ListChoice(str, Enum):
 
 @app.command()
 def list(arg: Annotated[ListChoice, typer.Argument]):
-    typer.echo(f"You chose {arg}")
     if arg == ListChoice.agents:
         """List all agents"""
         table = PrettyTable()


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Adds a new simple feature to make CLI help and usage nicer.

**How to test**
This is a change to the CLI only, and currently only for the `memgpt list` command. If you have any automated tests that would cover this please direct me to them.

**Have you tested this PR?**
Yes. I only tested that the CLI for `memgpt list ...` behaves correctly for the various positive and negative scenarios, i.e. all of the previously supported `memgpt list <options>` still work as expected, and when help is requested or when bad options are given an appropriate usage message is given.

**Related issues or PRs**
#732 

**Is your PR over 500 lines of code?**
No

**Additional context**
This is my first PR. I'm happy to incorporate any feedback. I'm also happy to extend this PR to cover other CLI cases, such as the `memgpt add` command.