### PR TITLE
fix: fix string & ws rules in json_func_calls...gbnf

### DIFF
--- a/memgpt/local_llm/grammars/json_func_calls_with_inner_thoughts.gbnf
+++ b/memgpt/local_llm/grammars/json_func_calls_with_inner_thoughts.gbnf
@@ -19,7 +19,14 @@ ArchivalMemorySearchParams ::= "{"   ws   InnerThoughtsParam   ","  ws   "\"quer
 InnerThoughtsParam ::= "\"inner_thoughts\":"   ws   string
 RequestHeartbeatParam ::= "\"request_heartbeat\":"   ws   boolean
 namestring ::= "\"human\"" | "\"persona\""
-string ::= "\""   ([^"\[\]{}]*)   "\""
 boolean ::= "true" | "false"
-ws ::= ""
 number ::= [0-9]+
+
+string ::=
+  "\"" (
+    [^"\\] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
I believe this fixes a bug with json_func_calls...gbnf. See issue #748 

**How to test**
Manual testing only (for now). I am currently testing with NexusRaven-V2-13B and the temperature reduced to 0.01. Engage in discussion about C/C++ or any language with braces.
 
**Have you tested this PR?**
I am still testing. This is WIP.

**Related issues or PRs**
#748 

**Is your PR over 500 lines of code?**
No

**Additional context**
See issue #748