### PR TITLE
feat: add description attribute to AgentConfig (#756)

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -369,8 +369,8 @@ def run(
 
         for f in agent_files:
             agent_config = AgentConfig.load(f)
-            agent_info = f" | 👉 {agent_config.name}" if agent_config.name != f else ""
-            agents[agent_config.name] = f"{f}    🤖 {agent_config.persona} | 🧑 {agent_config.human}{agent_info}"
+            agent_info = f" | 👉 {agent_config.description}" if agent_config.description != "" else ""
+            agents[agent_config.name] = f"{agent_config.name}    🤖 {agent_config.persona} | 🧑 {agent_config.human}{agent_info}"
 
         if len(agents) > 0 and not any([persona, human, model]):
             print()
@@ -379,12 +379,12 @@ def run(
             if select_agent:
                 selected_desc = questionary.select("Select agent:", choices=list(agents.values())).ask()
 
-                # Check, if a selection was made
+                # check, if an agent was selected
                 if selected_desc:
-                    # Extract the agent name from the selected choice
+                    # extract the agent name from the selected choice
                     agent = [name for name, desc in agents.items() if desc == selected_desc][0]
                 else:
-                    # Handle the case where no selection is made (e.g., aborting via CTRL-C)
+                    # handle the case where no selection is made (e.g., aborting via CTRL-C)
                     sys.exit(0)
 
     # configure llama index
@@ -560,3 +560,17 @@ def version():
 
     print(memgpt.__version__)
     return memgpt.__version__
+
+
+def describe_agent(
+    agent: str = typer.Option(help="Specify agent to describe"),
+    description: str = typer.Option(help="Description of the agent"),
+):
+    """Add a description to an existing agent
+    """
+
+    agent_config = AgentConfig.load(agent)
+    agent_config.description = description;
+    agent_config.save()
+
+    print(f"Updated description of {agent}.")

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -365,13 +365,26 @@ def run(
     # determine agent to use, if not provided
     if not yes and not agent:
         agent_files = utils.list_agent_config_files()
-        agents = [AgentConfig.load(f).name for f in agent_files]
+        agents = {}
+
+        for f in agent_files:
+            agent_config = AgentConfig.load(f)
+            agents[agent_config.name] = f"{agent_config.name} - 🤖 {agent_config.persona} | 🧑 {agent_config.human}"
 
         if len(agents) > 0 and not any([persona, human, model]):
             print()
             select_agent = questionary.confirm("Would you like to select an existing agent?").ask()
+
             if select_agent:
-                agent = questionary.select("Select agent:", choices=agents).ask()
+                selected_desc = questionary.select("Select agent:", choices=list(agents.values())).ask()
+
+                # Check, if a selection was made
+                if selected_desc:
+                    # Extract the agent name from the selected choice
+                    agent = [name for name, desc in agents.items() if desc == selected_desc][0]
+                else:
+                    # Handle the case where no selection is made (e.g., aborting via CTRL-C)
+                    sys.exit(0)
 
     # configure llama index
     config = MemGPTConfig.load()

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -369,7 +369,8 @@ def run(
 
         for f in agent_files:
             agent_config = AgentConfig.load(f)
-            agents[agent_config.name] = f"{agent_config.name}   [🤖 {agent_config.persona} | 🧑 {agent_config.human}]"
+            agent_info = f" | 👉 {agent_config.name}" if agent_config.name != f else ""
+            agents[agent_config.name] = f"{f}    🤖 {agent_config.persona} | 🧑 {agent_config.human}{agent_info}"
 
         if len(agents) > 0 and not any([persona, human, model]):
             print()

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -566,11 +566,10 @@ def describe_agent(
     agent: str = typer.Option(help="Specify agent to describe"),
     description: str = typer.Option(help="Description of the agent"),
 ):
-    """Add a description to an existing agent
-    """
+    """Add a description to an existing agent"""
 
     agent_config = AgentConfig.load(agent)
-    agent_config.description = description;
+    agent_config.description = description
     agent_config.save()
 
     print(f"Updated description of {agent}.")

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -369,7 +369,7 @@ def run(
 
         for f in agent_files:
             agent_config = AgentConfig.load(f)
-            agents[agent_config.name] = f"{agent_config.name} - 🤖 {agent_config.persona} | 🧑 {agent_config.human}"
+            agents[agent_config.name] = f"{agent_config.name}   [🤖 {agent_config.persona} | 🧑 {agent_config.human}]"
 
         if len(agents) > 0 and not any([persona, human, model]):
             print()

--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -252,6 +252,7 @@ class AgentConfig:
         name=None,
         create_time=None,
         memgpt_version=None,
+        description="",
     ):
         if name is None:
             self.name = f"agent_{self.generate_agent_id()}"
@@ -282,6 +283,8 @@ class AgentConfig:
             self.memgpt_version = memgpt.__version__
         else:
             self.memgpt_version = memgpt_version
+
+        self.description = description
 
         # save agent config
         self.agent_config_path = (
@@ -343,6 +346,7 @@ class AgentConfig:
             # https://github.com/pytorch/pytorch/issues/15344
             class_args = inspect.getfullargspec(cls.__init__).args
         agent_fields = list(agent_config.keys())
+
         for key in agent_fields:
             if key not in class_args:
                 utils.printd(f"Removing missing argument {key} from agent config")

--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -346,7 +346,6 @@ class AgentConfig:
             # https://github.com/pytorch/pytorch/issues/15344
             class_args = inspect.getfullargspec(cls.__init__).args
         agent_fields = list(agent_config.keys())
-
         for key in agent_fields:
             if key not in class_args:
                 utils.printd(f"Removing missing argument {key} from agent config")

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -22,7 +22,7 @@ import memgpt.agent as agent
 import memgpt.system as system
 import memgpt.constants as constants
 import memgpt.errors as errors
-from memgpt.cli.cli import run, attach, version, server, open_folder, quickstart, suppress_stdout
+from memgpt.cli.cli import run, attach, version, server, open_folder, quickstart, suppress_stdout, describe_agent
 from memgpt.cli.cli_config import configure, list, add
 from memgpt.cli.cli_load import app as load_app
 from memgpt.connectors.storage import StorageConnector
@@ -37,6 +37,7 @@ app.command(name="add")(add)
 app.command(name="server")(server)
 app.command(name="folder")(open_folder)
 app.command(name="quickstart")(quickstart)
+app.command(name="describe")(describe_agent)
 # load data commands
 app.add_typer(load_app, name="load")
 
@@ -299,7 +300,6 @@ def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, strip_ui=Fals
 
     print("Finished.")
 
-
 USER_COMMANDS = [
     ("//", "toggle multiline input mode"),
     ("/exit", "exit the CLI"),
@@ -314,4 +314,5 @@ USER_COMMANDS = [
     ("/heartbeat", "send a heartbeat system message to the agent"),
     ("/memorywarning", "send a memory warning system message to the agent"),
     ("/attach", "attach data source to agent"),
+    ("/describe", "add a custom description for an existing agent"),
 ]

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -300,6 +300,7 @@ def run_agent_loop(memgpt_agent, first, no_verify=False, cfg=None, strip_ui=Fals
 
     print("Finished.")
 
+
 USER_COMMANDS = [
     ("//", "toggle multiline input mode"),
     ("/exit", "exit the CLI"),


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

1. Introduce a new `description` attribute to the AgentConfig
2. New `describe` CLI command: `memgpt describe --agent=NAME --description="Short description here"`
3. During `run` command, the agent selector has changed:
    * AI Persona is always displayed
    * Human name is always displayed
    * If description is set, it is also displayed
4. When `run` is cancelled during agent selection (using CTRL-C), the command exits instead of creating a new agent

The description is only used in the agent selector of the `run` command.

**How to test**
Start a new chat using `memgpt run` using existing agents.

**Have you tested this PR?**

Tested with existing agents & creating new ones via CLI.

**Additional context**

<img width="917" alt="image" src="https://github.com/cpacker/MemGPT/assets/2669200/2f9b991c-ea3e-4b64-9b94-ad67dced7cc1">
