### PR TITLE
fix: Fix invalid entry in agent_config dict in documentation

### DIFF
--- a/docs/python_client.md
+++ b/docs/python_client.md
@@ -20,7 +20,7 @@ client = MemGPT(
 agent_id = client.create_agent(
   agent_config={
     "persona": "sam_pov",
-    "user": "cs_phd",
+    "human": "cs_phd",
   }
 )
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fix invalid entry in agent_config dict in documentation. The example in `python_client.md` is broken due to changes from AgentConfigs.

**How to test**
You can test it with latest `memgpt` in main branch. And I suggest examples in documentation should be synced with test cases.

**Have you tested this PR?**
Yes, it runs with `memgpt="0.2.10"` in main branch. I ran it with installation from source.

**Is your PR over 500 lines of code?**
No

