### PR TITLE
fix: Update memgpt_coder_autogen.ipynb

### DIFF
--- a/memgpt/autogen/examples/memgpt_coder_autogen.ipynb
+++ b/memgpt/autogen/examples/memgpt_coder_autogen.ipynb
@@ -85,7 +85,8 @@
         "        \"model_wrapper\": None,\n",
         "        \"model_endpoint_type\": \"openai\",\n",
         "        \"model_endpoint\": \"https://api.openai.com/v1\",\n",
-        "        \"context_window\": 8192,  # gpt-4 context window\n",
+        "        \"model_endpoint\": \"https://api.openai.com/v1\",\n",
+        "        \"openai_key\": OPENAI_API_KEY,\n",
         "    },\n",
         "]\n",
         "llm_config_memgpt = {\"config_list\": config_list_memgpt, \"seed\": 42}"


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Typo pointed out by @ron_a_barrett on [Discord](https://discord.com/channels/1161736243340640419/1161736244074659893/1190387909476491404):
> regarding 'fix: memgpt agent ignores user messages #679' there's a small bug in 'memgpt_coder_autogen.ipynb'.  The config_list_memgpt doesn't include assignment of the openai_key value.  Should add, "openai_key": OPENAI_API_KEY
