### PR TITLE
feat: Migration tool for agents pre DB refactor (pre 0.2.12)

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -154,6 +154,7 @@ class Agent(object):
         persistence_manager,
         persona_notes,
         human_notes,
+        in_context_messages=None,
         messages_total=None,
         persistence_manager_init=True,
         first_message_verify_mono=True,
@@ -179,12 +180,24 @@ class Agent(object):
 
         # Initialize the memory object
         self.memory = initialize_memory(persona_notes, human_notes)
-        # Once the memory object is initialize, use it to "bake" the system message
-        self._messages = initialize_message_sequence(
-            self.model,
-            self.system,
-            self.memory,
-        )
+        if in_context_messages is None:
+            # Once the memory object is initialized, use it to "bake" the system message
+            self._messages = initialize_message_sequence(
+                self.model,
+                self.system,
+                self.memory,
+            )
+        else:
+            # Alternatively allow passing a message list directly
+            if (
+                isinstance(in_context_messages, list)
+                and len(in_context_messages) > 0
+                and "role" in in_context_messages[0]
+                and in_context_messages[0]["role"] == "system"
+            ):
+                self._messages = in_context_messages
+            else:
+                raise ValueError(f"Bad values provided in in_context_messages:\n{in_context_messages}")
         # Interface must implement:
         # - internal_monologue
         # - assistant_message

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -4,8 +4,10 @@ import glob
 import os
 import json
 import traceback
+from typing import List, Optional
 
-from memgpt.persistence_manager import LocalStateManager
+from memgpt.interface import AgentInterface
+from memgpt.persistence_manager import PersistenceManager, LocalStateManager
 from memgpt.config import AgentConfig, MemGPTConfig
 from memgpt.system import get_login_event, package_function_response, package_summarize_message, get_initial_boot_messages
 from memgpt.memory import CoreMemory as InContextMemory, summarize_messages
@@ -146,18 +148,18 @@ def initialize_message_sequence(
 class Agent(object):
     def __init__(
         self,
-        config,
-        model,
-        system,
-        functions,  # list of [{'schema': 'x', 'python_function': function_pointer}, ...]
-        interface,
-        persistence_manager,
-        persona_notes,
-        human_notes,
-        in_context_messages=None,
-        messages_total=None,
-        persistence_manager_init=True,
-        first_message_verify_mono=True,
+        config: AgentConfig,
+        model: str,
+        system: str,
+        functions: List[dict],  # list of [{'schema': 'x', 'python_function': function_pointer}, ...]
+        interface: AgentInterface,
+        persistence_manager: PersistenceManager,
+        persona_notes: str,
+        human_notes: str,
+        in_context_messages: Optional[List[dict]] = None,
+        messages_total: Optional[int] = None,
+        persistence_manager_init: Optional[bool] = True,
+        first_message_verify_mono: Optional[bool] = True,
     ):
         # agent config
         self.config = config

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -280,6 +280,140 @@ def server(
             sys.exit(0)
 
 
+def load_agent(
+    persona: str = None,
+    agent: str = None,
+    human: str = None,
+    # model flags
+    model: str = None,
+    model_wrapper: str = None,
+    model_endpoint: str = None,
+    model_endpoint_type: str = None,
+    context_window: int = None,
+) -> Agent:
+    """Load an existing agent"""
+    agent_config = AgentConfig.load(agent)
+    printd("State path:", agent_config.save_state_dir())
+    printd("Persistent manager path:", agent_config.save_persistence_manager_dir())
+    printd("Index path:", agent_config.save_agent_index_dir())
+
+    # persistence_manager = LocalStateManager(agent_config).load() # TODO: implement load
+    # TODO: load prior agent state
+    if persona and persona != agent_config.persona:
+        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing persona {agent_config.persona} with {persona}", fg=typer.colors.YELLOW)
+        agent_config.persona = persona
+        # raise ValueError(f"Cannot override {agent_config.name} existing persona {agent_config.persona} with {persona}")
+    if human and human != agent_config.human:
+        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing human {agent_config.human} with {human}", fg=typer.colors.YELLOW)
+        agent_config.human = human
+        # raise ValueError(f"Cannot override {agent_config.name} existing human {agent_config.human} with {human}")
+
+    # Allow overriding model specifics (model, model wrapper, model endpoint IP + type, context_window)
+    if model and model != agent_config.model:
+        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing model {agent_config.model} with {model}", fg=typer.colors.YELLOW)
+        agent_config.model = model
+    if context_window is not None and int(context_window) != agent_config.context_window:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing context window {agent_config.context_window} with {context_window}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.context_window = context_window
+    if model_wrapper and model_wrapper != agent_config.model_wrapper:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing model wrapper {agent_config.model_wrapper} with {model_wrapper}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.model_wrapper = model_wrapper
+    if model_endpoint and model_endpoint != agent_config.model_endpoint:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing model endpoint {agent_config.model_endpoint} with {model_endpoint}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.model_endpoint = model_endpoint
+    if model_endpoint_type and model_endpoint_type != agent_config.model_endpoint_type:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing model endpoint type {agent_config.model_endpoint_type} with {model_endpoint_type}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.model_endpoint_type = model_endpoint_type
+
+    # Update the agent config with any overrides
+    agent_config.save()
+
+    # Supress llama-index noise
+    with suppress_stdout():
+        # load existing agent
+        memgpt_agent = Agent.load_agent(interface, agent_config)
+
+    return memgpt_agent
+
+
+def create_agent(
+    persona: str = None,
+    agent: str = None,
+    human: str = None,
+    preset: str = None,
+    # model flags
+    model: str = None,
+    model_wrapper: str = None,
+    model_endpoint: str = None,
+    model_endpoint_type: str = None,
+    context_window: int = None,
+) -> Agent:
+    agent_config = AgentConfig(
+        name=agent,
+        persona=persona,
+        human=human,
+        preset=preset,
+        model=model,
+        model_wrapper=model_wrapper,
+        model_endpoint_type=model_endpoint_type,
+        model_endpoint=model_endpoint,
+        context_window=context_window,
+    )
+
+    # save new agent config
+    agent_config.save()
+
+    # Supress llama-index noise
+    with suppress_stdout():
+        # TODO: allow configrable state manager (only local is supported right now)
+        persistence_manager = LocalStateManager(agent_config)  # TODO: insert dataset/pre-fill
+
+    # create agent
+    try:
+        memgpt_agent = presets.use_preset(
+            agent_config.preset,
+            agent_config,
+            agent_config.model,
+            utils.get_persona_text(agent_config.persona),
+            utils.get_human_text(agent_config.human),
+            interface,
+            persistence_manager,
+        )
+    except ValueError as e:
+        typer.secho(f"Failed to create agent from provided information:\n{e}", fg=typer.colors.RED)
+        # Delete the directory of the failed agent
+        try:
+            # Path to the specific file
+            agent_config_file = agent_config.agent_config_path
+
+            # Check if the file exists
+            if os.path.isfile(agent_config_file):
+                # Delete the file
+                os.remove(agent_config_file)
+
+            # Now, delete the directory along with any remaining files in it
+            agent_save_dir = os.path.join(MEMGPT_DIR, "agents", agent_config.name)
+            shutil.rmtree(agent_save_dir)
+        except:
+            typer.secho(f"Failed to delete agent directory during cleanup:\n{e}", fg=typer.colors.RED)
+            raise
+        raise
+
+    return memgpt_agent
+
+
 def run(
     persona: str = typer.Option(None, help="Specify persona"),
     agent: str = typer.Option(None, help="Specify agent save file"),
@@ -391,116 +525,47 @@ def run(
     # create agent config
     if agent and AgentConfig.exists(agent):  # use existing agent
         typer.secho(f"\n🔁 Using existing agent {agent}", fg=typer.colors.GREEN)
-        agent_config = AgentConfig.load(agent)
-        printd("State path:", agent_config.save_state_dir())
-        printd("Persistent manager path:", agent_config.save_persistence_manager_dir())
-        printd("Index path:", agent_config.save_agent_index_dir())
-        # persistence_manager = LocalStateManager(agent_config).load() # TODO: implement load
-        # TODO: load prior agent state
-        if persona and persona != agent_config.persona:
-            typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing persona {agent_config.persona} with {persona}", fg=typer.colors.YELLOW)
-            agent_config.persona = persona
-            # raise ValueError(f"Cannot override {agent_config.name} existing persona {agent_config.persona} with {persona}")
-        if human and human != agent_config.human:
-            typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing human {agent_config.human} with {human}", fg=typer.colors.YELLOW)
-            agent_config.human = human
-            # raise ValueError(f"Cannot override {agent_config.name} existing human {agent_config.human} with {human}")
 
-        # Allow overriding model specifics (model, model wrapper, model endpoint IP + type, context_window)
-        if model and model != agent_config.model:
-            typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing model {agent_config.model} with {model}", fg=typer.colors.YELLOW)
-            agent_config.model = model
-        if context_window is not None and int(context_window) != agent_config.context_window:
-            typer.secho(
-                f"{CLI_WARNING_PREFIX}Overriding existing context window {agent_config.context_window} with {context_window}",
-                fg=typer.colors.YELLOW,
+        try:
+            memgpt_agent = load_agent(
+                agent=agent,
+                # preset=preset,
+                persona=persona,
+                human=human,
+                model=model,
+                model_wrapper=model_wrapper,
+                model_endpoint=model_endpoint,
+                model_endpoint_type=model_endpoint_type,
+                context_window=context_window,
             )
-            agent_config.context_window = context_window
-        if model_wrapper and model_wrapper != agent_config.model_wrapper:
-            typer.secho(
-                f"{CLI_WARNING_PREFIX}Overriding existing model wrapper {agent_config.model_wrapper} with {model_wrapper}",
-                fg=typer.colors.YELLOW,
-            )
-            agent_config.model_wrapper = model_wrapper
-        if model_endpoint and model_endpoint != agent_config.model_endpoint:
-            typer.secho(
-                f"{CLI_WARNING_PREFIX}Overriding existing model endpoint {agent_config.model_endpoint} with {model_endpoint}",
-                fg=typer.colors.YELLOW,
-            )
-            agent_config.model_endpoint = model_endpoint
-        if model_endpoint_type and model_endpoint_type != agent_config.model_endpoint_type:
-            typer.secho(
-                f"{CLI_WARNING_PREFIX}Overriding existing model endpoint type {agent_config.model_endpoint_type} with {model_endpoint_type}",
-                fg=typer.colors.YELLOW,
-            )
-            agent_config.model_endpoint_type = model_endpoint_type
-
-        # Update the agent config with any overrides
-        agent_config.save()
-
-        # Supress llama-index noise
-        with suppress_stdout():
-            # load existing agent
-            memgpt_agent = Agent.load_agent(interface, agent_config)
+        except Exception as e:
+            typer.secho(f"Failed to load agent from '{agent}':\n{e}", fg=typer.colors.RED)
+            sys.exit(1)
 
     else:  # create new agent
-        # create new agent config: override defaults with args if provided
         typer.secho("\n🧬 Creating new agent...", fg=typer.colors.WHITE)
-        agent_config = AgentConfig(
-            name=agent,
-            persona=persona,
-            human=human,
-            preset=preset,
-            model=model,
-            model_wrapper=model_wrapper,
-            model_endpoint_type=model_endpoint_type,
-            model_endpoint=model_endpoint,
-            context_window=context_window,
-        )
+        typer.secho(f"->  🤖 Using persona profile '{persona}'", fg=typer.colors.WHITE)
+        typer.secho(f"->  🧑 Using human profile '{human}'", fg=typer.colors.WHITE)
 
-        # save new agent config
-        agent_config.save()
-        typer.secho(f"->  🤖 Using persona profile '{agent_config.persona}'", fg=typer.colors.WHITE)
-        typer.secho(f"->  🧑 Using human profile '{agent_config.human}'", fg=typer.colors.WHITE)
-
-        # Supress llama-index noise
-        with suppress_stdout():
-            # TODO: allow configrable state manager (only local is supported right now)
-            persistence_manager = LocalStateManager(agent_config)  # TODO: insert dataset/pre-fill
-
-        # create agent
         try:
-            memgpt_agent = presets.use_preset(
-                agent_config.preset,
-                agent_config,
-                agent_config.model,
-                utils.get_persona_text(agent_config.persona),
-                utils.get_human_text(agent_config.human),
-                interface,
-                persistence_manager,
+            # create new agent config: override defaults with args if provided
+            memgpt_agent = create_agent(
+                agent=agent,
+                preset=preset,
+                persona=persona,
+                human=human,
+                model=model,
+                model_wrapper=model_wrapper,
+                model_endpoint=model_endpoint,
+                model_endpoint_type=model_endpoint_type,
+                context_window=context_window,
             )
-        except ValueError as e:
-            typer.secho(f"Failed to create agent from provided information:\n{e}", fg=typer.colors.RED)
-            # Delete the directory of the failed agent
-            try:
-                # Path to the specific file
-                agent_config_file = agent_config.agent_config_path
-
-                # Check if the file exists
-                if os.path.isfile(agent_config_file):
-                    # Delete the file
-                    os.remove(agent_config_file)
-
-                # Now, delete the directory along with any remaining files in it
-                agent_save_dir = os.path.join(MEMGPT_DIR, "agents", agent_config.name)
-                shutil.rmtree(agent_save_dir)
-            except:
-                typer.secho(f"Failed to delete agent directory during cleanup:\n{e}", fg=typer.colors.RED)
+        except:
             sys.exit(1)
-        typer.secho(f"🎉 Created new agent '{agent_config.name}'", fg=typer.colors.GREEN)
+        typer.secho(f"🎉 Created new agent '{memgpt_agent.config.name}'", fg=typer.colors.GREEN)
 
     # pretty print agent config
-    printd(json.dumps(vars(agent_config), indent=4, sort_keys=True))
+    printd(json.dumps(vars(memgpt_agent.config), indent=4, sort_keys=True))
 
     # start event loop
     from memgpt.main import run_agent_loop

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -25,6 +25,12 @@ from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX
 from memgpt.agent import Agent
 from memgpt.embeddings import embedding_model
 from memgpt.server.constants import WS_DEFAULT_PORT, REST_DEFAULT_PORT
+from memgpt.migrate import migrate_all_agents
+
+
+def migrate():
+    """Migrate old agents (pre 0.2.12) to the new database system"""
+    migrate_all_agents()
 
 
 class QuickstartChoice(Enum):

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -2,7 +2,6 @@ import typer
 import json
 import requests
 import sys
-import shutil
 import io
 import logging
 import questionary
@@ -14,12 +13,10 @@ from enum import Enum
 from llama_index import set_global_service_context
 from llama_index import ServiceContext
 
-from memgpt.interface import CLIInterface as interface  # for printing to terminal
-from memgpt.cli.cli_config import configure
-import memgpt.presets.presets as presets
 import memgpt.utils as utils
-from memgpt.utils import printd, open_folder_in_explorer, suppress_stdout
-from memgpt.persistence_manager import LocalStateManager
+from memgpt.cli.cli_config import configure
+from memgpt.cli.utils import create_agent, load_agent
+from memgpt.utils import printd, open_folder_in_explorer, suppress_stdout, list_agent_config_files
 from memgpt.config import MemGPTConfig, AgentConfig
 from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX
 from memgpt.agent import Agent
@@ -280,140 +277,6 @@ def server(
             sys.exit(0)
 
 
-def load_agent(
-    persona: str = None,
-    agent: str = None,
-    human: str = None,
-    # model flags
-    model: str = None,
-    model_wrapper: str = None,
-    model_endpoint: str = None,
-    model_endpoint_type: str = None,
-    context_window: int = None,
-) -> Agent:
-    """Load an existing agent"""
-    agent_config = AgentConfig.load(agent)
-    printd("State path:", agent_config.save_state_dir())
-    printd("Persistent manager path:", agent_config.save_persistence_manager_dir())
-    printd("Index path:", agent_config.save_agent_index_dir())
-
-    # persistence_manager = LocalStateManager(agent_config).load() # TODO: implement load
-    # TODO: load prior agent state
-    if persona and persona != agent_config.persona:
-        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing persona {agent_config.persona} with {persona}", fg=typer.colors.YELLOW)
-        agent_config.persona = persona
-        # raise ValueError(f"Cannot override {agent_config.name} existing persona {agent_config.persona} with {persona}")
-    if human and human != agent_config.human:
-        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing human {agent_config.human} with {human}", fg=typer.colors.YELLOW)
-        agent_config.human = human
-        # raise ValueError(f"Cannot override {agent_config.name} existing human {agent_config.human} with {human}")
-
-    # Allow overriding model specifics (model, model wrapper, model endpoint IP + type, context_window)
-    if model and model != agent_config.model:
-        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing model {agent_config.model} with {model}", fg=typer.colors.YELLOW)
-        agent_config.model = model
-    if context_window is not None and int(context_window) != agent_config.context_window:
-        typer.secho(
-            f"{CLI_WARNING_PREFIX}Overriding existing context window {agent_config.context_window} with {context_window}",
-            fg=typer.colors.YELLOW,
-        )
-        agent_config.context_window = context_window
-    if model_wrapper and model_wrapper != agent_config.model_wrapper:
-        typer.secho(
-            f"{CLI_WARNING_PREFIX}Overriding existing model wrapper {agent_config.model_wrapper} with {model_wrapper}",
-            fg=typer.colors.YELLOW,
-        )
-        agent_config.model_wrapper = model_wrapper
-    if model_endpoint and model_endpoint != agent_config.model_endpoint:
-        typer.secho(
-            f"{CLI_WARNING_PREFIX}Overriding existing model endpoint {agent_config.model_endpoint} with {model_endpoint}",
-            fg=typer.colors.YELLOW,
-        )
-        agent_config.model_endpoint = model_endpoint
-    if model_endpoint_type and model_endpoint_type != agent_config.model_endpoint_type:
-        typer.secho(
-            f"{CLI_WARNING_PREFIX}Overriding existing model endpoint type {agent_config.model_endpoint_type} with {model_endpoint_type}",
-            fg=typer.colors.YELLOW,
-        )
-        agent_config.model_endpoint_type = model_endpoint_type
-
-    # Update the agent config with any overrides
-    agent_config.save()
-
-    # Supress llama-index noise
-    with suppress_stdout():
-        # load existing agent
-        memgpt_agent = Agent.load_agent(interface, agent_config)
-
-    return memgpt_agent
-
-
-def create_agent(
-    persona: str = None,
-    agent: str = None,
-    human: str = None,
-    preset: str = None,
-    # model flags
-    model: str = None,
-    model_wrapper: str = None,
-    model_endpoint: str = None,
-    model_endpoint_type: str = None,
-    context_window: int = None,
-) -> Agent:
-    agent_config = AgentConfig(
-        name=agent,
-        persona=persona,
-        human=human,
-        preset=preset,
-        model=model,
-        model_wrapper=model_wrapper,
-        model_endpoint_type=model_endpoint_type,
-        model_endpoint=model_endpoint,
-        context_window=context_window,
-    )
-
-    # save new agent config
-    agent_config.save()
-
-    # Supress llama-index noise
-    with suppress_stdout():
-        # TODO: allow configrable state manager (only local is supported right now)
-        persistence_manager = LocalStateManager(agent_config)  # TODO: insert dataset/pre-fill
-
-    # create agent
-    try:
-        memgpt_agent = presets.use_preset(
-            agent_config.preset,
-            agent_config,
-            agent_config.model,
-            utils.get_persona_text(agent_config.persona),
-            utils.get_human_text(agent_config.human),
-            interface,
-            persistence_manager,
-        )
-    except ValueError as e:
-        typer.secho(f"Failed to create agent from provided information:\n{e}", fg=typer.colors.RED)
-        # Delete the directory of the failed agent
-        try:
-            # Path to the specific file
-            agent_config_file = agent_config.agent_config_path
-
-            # Check if the file exists
-            if os.path.isfile(agent_config_file):
-                # Delete the file
-                os.remove(agent_config_file)
-
-            # Now, delete the directory along with any remaining files in it
-            agent_save_dir = os.path.join(MEMGPT_DIR, "agents", agent_config.name)
-            shutil.rmtree(agent_save_dir)
-        except:
-            typer.secho(f"Failed to delete agent directory during cleanup:\n{e}", fg=typer.colors.RED)
-            raise
-        raise
-
-    return memgpt_agent
-
-
 def run(
     persona: str = typer.Option(None, help="Specify persona"),
     agent: str = typer.Option(None, help="Specify agent save file"),
@@ -504,7 +367,7 @@ def run(
 
     # determine agent to use, if not provided
     if not yes and not agent:
-        agent_files = utils.list_agent_config_files()
+        agent_files = list_agent_config_files()
         agents = [AgentConfig.load(f).name for f in agent_files]
 
         if len(agents) > 0 and not any([persona, human, model]):

--- a/memgpt/cli/utils.py
+++ b/memgpt/cli/utils.py
@@ -1,0 +1,145 @@
+import os
+import shutil
+import typer
+
+from memgpt.agent import Agent
+from memgpt.presets.presets import use_preset
+from memgpt.persistence_manager import LocalStateManager
+from memgpt.config import AgentConfig
+from memgpt.utils import printd, suppress_stdout, get_human_text, get_persona_text
+from memgpt.constants import CLI_WARNING_PREFIX, MEMGPT_DIR
+from memgpt.interface import CLIInterface as interface  # for printing to terminal
+
+
+def load_agent(
+    persona: str = None,
+    agent: str = None,
+    human: str = None,
+    # model flags
+    model: str = None,
+    model_wrapper: str = None,
+    model_endpoint: str = None,
+    model_endpoint_type: str = None,
+    context_window: int = None,
+) -> Agent:
+    """Load an existing agent"""
+    agent_config = AgentConfig.load(agent)
+    printd("State path:", agent_config.save_state_dir())
+    printd("Persistent manager path:", agent_config.save_persistence_manager_dir())
+    printd("Index path:", agent_config.save_agent_index_dir())
+
+    # persistence_manager = LocalStateManager(agent_config).load() # TODO: implement load
+    # TODO: load prior agent state
+    if persona and persona != agent_config.persona:
+        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing persona {agent_config.persona} with {persona}", fg=typer.colors.YELLOW)
+        agent_config.persona = persona
+        # raise ValueError(f"Cannot override {agent_config.name} existing persona {agent_config.persona} with {persona}")
+    if human and human != agent_config.human:
+        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing human {agent_config.human} with {human}", fg=typer.colors.YELLOW)
+        agent_config.human = human
+        # raise ValueError(f"Cannot override {agent_config.name} existing human {agent_config.human} with {human}")
+
+    # Allow overriding model specifics (model, model wrapper, model endpoint IP + type, context_window)
+    if model and model != agent_config.model:
+        typer.secho(f"{CLI_WARNING_PREFIX}Overriding existing model {agent_config.model} with {model}", fg=typer.colors.YELLOW)
+        agent_config.model = model
+    if context_window is not None and int(context_window) != agent_config.context_window:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing context window {agent_config.context_window} with {context_window}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.context_window = context_window
+    if model_wrapper and model_wrapper != agent_config.model_wrapper:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing model wrapper {agent_config.model_wrapper} with {model_wrapper}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.model_wrapper = model_wrapper
+    if model_endpoint and model_endpoint != agent_config.model_endpoint:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing model endpoint {agent_config.model_endpoint} with {model_endpoint}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.model_endpoint = model_endpoint
+    if model_endpoint_type and model_endpoint_type != agent_config.model_endpoint_type:
+        typer.secho(
+            f"{CLI_WARNING_PREFIX}Overriding existing model endpoint type {agent_config.model_endpoint_type} with {model_endpoint_type}",
+            fg=typer.colors.YELLOW,
+        )
+        agent_config.model_endpoint_type = model_endpoint_type
+
+    # Update the agent config with any overrides
+    agent_config.save()
+
+    # Supress llama-index noise
+    with suppress_stdout():
+        # load existing agent
+        memgpt_agent = Agent.load_agent(interface, agent_config)
+
+    return memgpt_agent
+
+
+def create_agent(
+    persona: str = None,
+    agent: str = None,
+    human: str = None,
+    preset: str = None,
+    # model flags
+    model: str = None,
+    model_wrapper: str = None,
+    model_endpoint: str = None,
+    model_endpoint_type: str = None,
+    context_window: int = None,
+) -> Agent:
+    agent_config = AgentConfig(
+        name=agent,
+        persona=persona,
+        human=human,
+        preset=preset,
+        model=model,
+        model_wrapper=model_wrapper,
+        model_endpoint_type=model_endpoint_type,
+        model_endpoint=model_endpoint,
+        context_window=context_window,
+    )
+
+    # save new agent config
+    agent_config.save()
+
+    # Supress llama-index noise
+    with suppress_stdout():
+        # TODO: allow configrable state manager (only local is supported right now)
+        persistence_manager = LocalStateManager(agent_config)  # TODO: insert dataset/pre-fill
+
+    # create agent
+    try:
+        memgpt_agent = use_preset(
+            agent_config.preset,
+            agent_config,
+            agent_config.model,
+            get_persona_text(agent_config.persona),
+            get_human_text(agent_config.human),
+            interface,
+            persistence_manager,
+        )
+    except ValueError as e:
+        typer.secho(f"Failed to create agent from provided information:\n{e}", fg=typer.colors.RED)
+        # Delete the directory of the failed agent
+        try:
+            # Path to the specific file
+            agent_config_file = agent_config.agent_config_path
+
+            # Check if the file exists
+            if os.path.isfile(agent_config_file):
+                # Delete the file
+                os.remove(agent_config_file)
+
+            # Now, delete the directory along with any remaining files in it
+            agent_save_dir = os.path.join(MEMGPT_DIR, "agents", agent_config.name)
+            shutil.rmtree(agent_save_dir)
+        except:
+            typer.secho(f"Failed to delete agent directory during cleanup:\n{e}", fg=typer.colors.RED)
+            raise
+        raise
+
+    return memgpt_agent

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -22,7 +22,7 @@ import memgpt.agent as agent
 import memgpt.system as system
 import memgpt.constants as constants
 import memgpt.errors as errors
-from memgpt.cli.cli import run, attach, version, server, open_folder, quickstart, suppress_stdout
+from memgpt.cli.cli import run, attach, version, server, open_folder, quickstart, suppress_stdout, migrate
 from memgpt.cli.cli_config import configure, list, add, delete
 from memgpt.cli.cli_load import app as load_app
 from memgpt.connectors.storage import StorageConnector, TableType
@@ -38,6 +38,7 @@ app.command(name="delete")(delete)
 app.command(name="server")(server)
 app.command(name="folder")(open_folder)
 app.command(name="quickstart")(quickstart)
+app.command(name="migrate")(migrate)
 # load data commands
 app.add_typer(load_app, name="load")
 

--- a/memgpt/migrate.py
+++ b/memgpt/migrate.py
@@ -1,0 +1,111 @@
+import os
+import json
+
+from tqdm import tqdm
+
+from memgpt.constants import MEMGPT_DIR
+from memgpt.utils import version_less_than
+
+# This is the version where the breaking change was made
+VERSION_CUTOFF = "0.2.12"
+MIGRATION_FILE_NAME = f"{VERSION_CUTOFF}_migration.json"
+
+
+def agent_is_migrateable(agent_name: str):
+    """Determine whether or not the agent folder is a migration target"""
+    agent_folder = os.path.join(MEMGPT_DIR, "agents", agent_name)
+
+    if not os.path.exists(agent_folder):
+        raise ValueError(f"Folder {agent_folder} does not exist")
+
+    agent_config_file = os.path.join(agent_folder, "config.json")
+    if not os.path.exists(agent_config_file):
+        raise ValueError(f"Agent folder {agent_folder} does not have a config file")
+
+    try:
+        with open(agent_config_file, "r") as fh:
+            agent_config = json.load(fh)
+    except Exception as e:
+        raise ValueError(f"Failed to load agent config file ({agent_config_file}), error = {e}")
+
+    if "memgpt_version" not in vars(agent_config) or version_less_than(agent_config.memgpt_version, VERSION_CUTOFF):
+        return True
+    else:
+        return False
+
+
+def write_old_agent_to_migration_json(agent_name: str, overwrite: bool = False) -> str:
+    """Take an old (pre 0.2.11) agent folder, and write out the contents to a JSON directory
+
+    Contents written to the JSON include:
+    - agent properties (system, functions, core memory, in-context messages)
+    - persistence manager properties (recall memory, archival memory)
+    """
+    agent_folder = os.path.join(MEMGPT_DIR, "agents", agent_name)
+    migration_file = os.path.join(agent_folder, MIGRATION_FILE_NAME)
+
+    if os.path.exists(migration_file):
+        if not overwrite:
+            raise ValueError(f"Migration file ({migration_file}) already exists")
+        else:
+            pass
+
+    # TODO
+
+
+def create_new_agent_from_migration_json(migration_json_file: str) -> str:
+    """Create a new agent with the same name as the old agent, and programmatically load data in"""
+    # TODO
+    pass
+
+
+def migrate_agent(agent_name: str):
+    """Write out old agents to intermediate migration JSON, then use the JSON to instantiate a new agent"""
+    try:
+        if not agent_is_migrateable(agent_name=agent_name):
+            return
+    except ValueError as e:
+        return
+
+    try:
+        migration_file = write_old_agent_to_migration_json(agent_name=agent_name, overwrite=False)
+    except ValueError as e:
+        # The migration file may have already been created
+        return
+
+    try:
+        new_agent = create_new_agent_from_migration_json(migration_json_file=migration_file)
+    except ValueError as e:
+        # The agent name may already exist
+        return
+
+    print(f"Successfully migrated agent {new_agent}")
+
+
+def migrate_all_agents():
+    """Scan over all agent folders in MEMGPT_DIR and migrate each agent."""
+    agents_dir = os.path.join(MEMGPT_DIR, "agents")
+
+    # Ensure the directory exists
+    if not os.path.exists(agents_dir):
+        raise ValueError(f"Directory {agents_dir} does not exist.")
+
+    # Get a list of all folders in agents_dir
+    agent_folders = [f for f in os.listdir(agents_dir) if os.path.isdir(os.path.join(agents_dir, f))]
+
+    # Iterate over each folder with a tqdm progress bar
+    count = 0
+    candidates = 0
+    for agent_name in tqdm(agent_folders, desc="Migrating agents"):
+        # Assuming migrate_agent is a function that takes the agent name and performs migration
+        try:
+            if agent_is_migrateable(agent_name=agent_name):
+                candidates += 1
+                migrate_agent(agent_name)
+                count += 1
+            else:
+                continue
+        except Exception as e:
+            print(f"Migrating {agent_name} failed with: {e}")
+
+    print(f"Successfully migrated {count}/{candidates} migration targets ({len(agent_folders)} agents total)")

--- a/memgpt/migrate.py
+++ b/memgpt/migrate.py
@@ -4,11 +4,11 @@ import json
 
 from tqdm import tqdm
 
-from memgpt.cli.cli import load_agent, create_agent
 from memgpt.interface import CLIInterface
 from memgpt.agent import Agent
 from memgpt.constants import MEMGPT_DIR
 from memgpt.utils import version_less_than
+from memgpt.cli.cli import load_agent, create_agent
 
 # This is the version where the breaking change was made
 VERSION_CUTOFF = "0.2.12"

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -30,6 +30,23 @@ from memgpt.openai_backcompat.openai_object import OpenAIObject
 DEBUG = False
 
 
+def version_less_than(version_a: str, version_b: str) -> bool:
+    """Compare versions to check if version_a is less than version_b."""
+    # Regular expression to match version strings of the format int.int.int
+    version_pattern = re.compile(r"^\d+\.\d+\.\d+$")
+
+    # Assert that version strings match the required format
+    if not version_pattern.match(version_a) or not version_pattern.match(version_b):
+        raise ValueError("Version strings must be in the format 'int.int.int'")
+
+    # Split the version strings into parts
+    parts_a = [int(part) for part in version_a.split(".")]
+    parts_b = [int(part) for part in version_b.split(".")]
+
+    # Compare version parts
+    return parts_a < parts_b
+
+
 def is_valid_url(url):
     try:
         result = urlparse(url)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- [ ] Add migration tool that automatically converts old agent folders into the new format
- [ ] Make migration UX nice
  - on the first run of the new refactor release, users should see a prompt asking them if they want to migrate old agents
  - for the initial release past the refactor, should also add a "Don't see old agents? Make sure you run the migration command" hint to the agent selection screen

**How to test**

- Try migrating old agent folders, manually inspect the new data to make sure it matches

**Have you tested this PR?**

WIP

**Related issues or PRs**

#708