### PR TITLE
fix: 'dict' object has no attribute 'name'

### DIFF
--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -83,9 +83,9 @@ class Client(object):
             return self.server.create_agent(user_id=self.user_id, agent_config=agent_config, persistence_manager=persistence_manager)
 
         if throw_if_exists:
-            raise ValueError(f"Agent {agent_config.name} already exists")
+            raise ValueError(f"Agent {agent_name} already exists")
 
-        return agent_config.name
+        return agent_name
 
     def get_agent_config(self, agent_id: str) -> Dict:
         self.interface.clear()


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Bug: when `throw_if_exists` is `True` and an agent exists and agent_config is a dict, then `'dict' object has no attribute 'name'` is thrown. This is fixed simply use existing `agent_name`.
