### PR TITLE
fix: patch SAWarning

### DIFF
--- a/memgpt/connectors/db.py
+++ b/memgpt/connectors/db.py
@@ -61,6 +61,14 @@ Base = declarative_base()
 def get_db_model(table_name: str, table_type: TableType):
     config = MemGPTConfig.load()
 
+    # Define a helper function to create or get the model class
+    def create_or_get_model(class_name, base_model, table_name):
+        if class_name in globals():
+            return globals()[class_name]
+        Model = type(class_name, (base_model,), {"__tablename__": table_name, "__table_args__": {"extend_existing": True}})
+        globals()[class_name] = Model
+        return Model
+
     if table_type == TableType.ARCHIVAL_MEMORY or table_type == TableType.PASSAGES:
         # create schema for archival memory
         class PassageModel(Base):
@@ -98,8 +106,8 @@ def get_db_model(table_name: str, table_type: TableType):
 
         """Create database model for table_name"""
         class_name = f"{table_name.capitalize()}Model"
-        Model = type(class_name, (PassageModel,), {"__tablename__": table_name, "__table_args__": {"extend_existing": True}})
-        return Model
+        return create_or_get_model(class_name, PassageModel, table_name)
+
     elif table_type == TableType.RECALL_MEMORY:
 
         class MessageModel(Base):
@@ -153,8 +161,8 @@ def get_db_model(table_name: str, table_type: TableType):
 
         """Create database model for table_name"""
         class_name = f"{table_name.capitalize()}Model"
-        Model = type(class_name, (MessageModel,), {"__tablename__": table_name, "__table_args__": {"extend_existing": True}})
-        return Model
+        return create_or_get_model(class_name, MessageModel, table_name)
+
     elif table_type == TableType.DATA_SOURCES:
 
         class SourceModel(Base):
@@ -177,8 +185,8 @@ def get_db_model(table_name: str, table_type: TableType):
 
         """Create database model for table_name"""
         class_name = f"{table_name.capitalize()}Model"
-        Model = type(class_name, (SourceModel,), {"__tablename__": table_name, "__table_args__": {"extend_existing": True}})
-        return Model
+        return create_or_get_model(class_name, SourceModel, table_name)
+
     else:
         raise ValueError(f"Table type {table_type} not implemented")
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Was getting this warning on every `memgpt run`:
```
% memgpt run

🧬 Creating new agent...
->  🤖 Using persona profile 'sam_pov'
->  🧑 Using human profile 'basic'
/Users/loaner/dev/MemGPT-2/memgpt/connectors/db.py:156: SAWarning: This declarative base already contains a class with the same class name and module name as memgpt.connectors.db.Memgpt_recall_memory_agentModel, and will be replaced in the string-lookup table.
  Model = type(class_name, (MessageModel,), {"__tablename__": table_name, "__table_args__": {"extend_existing": True}})
🎉 Created new agent 'agent_1'

Hit enter to begin (will request first MemGPT message)

/Users/loaner/dev/MemGPT-2/memgpt/connectors/db.py:180: SAWarning: This declarative base already contains a class with the same class name and module name as memgpt.connectors.db.Memgpt_sourcesModel, and will be replaced in the string-lookup table.
  Model = type(class_name, (SourceModel,), {"__tablename__": table_name, "__table_args__": {"extend_existing": True}})
💭 Logging user activity.
🤖 Welcome back, Chad!
```

With the code diff in this PR, I no longer get the warning:
```
% memgpt run

? Would you like to select an existing agent? No

🧬 Creating new agent...
->  🤖 Using persona profile 'sam_pov'
->  🧑 Using human profile 'basic'
🎉 Created new agent 'agent_2'

Hit enter to begin (will request first MemGPT message)

💭 Welcome back, Chad. Is there anything specific you'd like to discuss today?
🤖 Greetings!
> Enter your message:                          
```