### PR TITLE
fix(server): handle null key string in utils (check_null_key)

### DIFF
--- a/memgpt/server/utils.py
+++ b/memgpt/server/utils.py
@@ -37,6 +37,8 @@ def shorten_key_middle(key_string, chars_each_side=3):
     Returns:
     str: The shortened key string with an ellipsis in the middle.
     """
+    if not key_string:
+        return key_string
     key_length = len(key_string)
     if key_length <= 2 * chars_each_side:
         return "..."  # Return ellipsis if the key is too short


### PR DESCRIPTION
Ensure that the `shorten_key` function in `utils.py` returns the key string itself when it is null or empty, preventing further processing that could lead to errors.

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?
to fix a bug

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?
use server endpoint GET `/config` if one of the 'key' values is not set (e.g. 'azure_key')

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.
I tested the endpoint, the result was the system's config

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.
no

**Additional context**
Add any other context or screenshots about the PR here.
