### PR TITLE
fix: deprecate `AgentConfig` in favor of `AgentState`. 

### DIFF
--- a/memgpt/agent_store/storage.py
+++ b/memgpt/agent_store/storage.py
@@ -115,13 +115,11 @@ class StorageConnector:
             raise NotImplementedError(f"Storage type {storage_type} not implemented")
 
     @staticmethod
-    def get_archival_storage_connector(user_id, agent_id):
-        config = MemGPTConfig.load()
+    def get_archival_storage_connector(config: MemGPTConfig, user_id, agent_id):
         return StorageConnector.get_storage_connector(TableType.ARCHIVAL_MEMORY, config, user_id, agent_id)
 
     @staticmethod
-    def get_recall_storage_connector(user_id, agent_id):
-        config = MemGPTConfig.load()
+    def get_recall_storage_connector(config: MemGPTConfig, user_id, agent_id):
         return StorageConnector.get_storage_connector(TableType.RECALL_MEMORY, config, user_id, agent_id)
 
     @abstractmethod

--- a/memgpt/agent_store/storage.py
+++ b/memgpt/agent_store/storage.py
@@ -115,11 +115,13 @@ class StorageConnector:
             raise NotImplementedError(f"Storage type {storage_type} not implemented")
 
     @staticmethod
-    def get_archival_storage_connector(config: MemGPTConfig, user_id, agent_id):
+    def get_archival_storage_connector(user_id, agent_id):
+        config = MemGPTConfig.load()
         return StorageConnector.get_storage_connector(TableType.ARCHIVAL_MEMORY, config, user_id, agent_id)
 
     @staticmethod
-    def get_recall_storage_connector(config: MemGPTConfig, user_id, agent_id):
+    def get_recall_storage_connector(user_id, agent_id):
+        config = MemGPTConfig.load()
         return StorageConnector.get_storage_connector(TableType.RECALL_MEMORY, config, user_id, agent_id)
 
     @abstractmethod

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -200,6 +200,7 @@ class MemGPTAgent(ConversableAgent):
         concat_other_agent_messages=False,
         is_termination_msg: Optional[Callable[[Dict], bool]] = None,
         default_auto_reply: Optional[Union[str, Dict, None]] = "",
+        # TODO: pass in MemGPT config (needed to create DB connections)
     ):
         super().__init__(name)
         self.agent = agent
@@ -234,6 +235,7 @@ class MemGPTAgent(ConversableAgent):
         self.agent.config.attach_data_source(data_source)
 
         # reload agent with new data source
+        # TODO: @charles we will need to pass in the MemGPT config here to get the DB URIs (not contained in agent)
         self.agent.persistence_manager.archival_memory.storage = StorageConnector.get_archival_storage_connector(
             agent_config=self.agent.config
         )

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -20,8 +20,7 @@ from memgpt.cli.cli_config import configure
 import memgpt.presets.presets as presets
 import memgpt.utils as utils
 from memgpt.utils import printd, open_folder_in_explorer, suppress_stdout
-from memgpt.persistence_manager import LocalStateManager
-from memgpt.config import MemGPTConfig, AgentConfig
+from memgpt.config import MemGPTConfig
 from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX
 from memgpt.agent import Agent
 from memgpt.embeddings import embedding_model

--- a/memgpt/cli/cli_load.py
+++ b/memgpt/cli/cli_load.py
@@ -33,7 +33,6 @@ app = typer.Typer()
 
 
 def insert_passages_into_source(passages: List[Passage], source_name: str, user_id: uuid.UUID, config: MemGPTConfig):
-
     """Insert a list of passages into a source by updating storage connectors and metadata store"""
     storage = StorageConnector.get_storage_connector(TableType.PASSAGES, config, user_id)
     orig_size = storage.size()

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -4,8 +4,7 @@ from typing import Dict, List, Union
 from memgpt.data_types import AgentState
 from memgpt.cli.cli import QuickstartChoice
 from memgpt.cli.cli import set_config_with_dict, quickstart as quickstart_func, str_to_quickstart_choice
-from memgpt.config import MemGPTConfig, AgentConfig
-from memgpt.persistence_manager import PersistenceManager
+from memgpt.config import MemGPTConfig
 from memgpt.server.rest_api.interface import QueuingInterface
 from memgpt.server.server import SyncServer
 

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -29,6 +29,7 @@ class Client(object):
         self.auto_save = auto_save
 
         # make sure everything is set up properly
+        # TODO: remove this eventually? for multi-user, we can't have a shared config directory
         MemGPTConfig.create_config_dir()
 
         # If this is the first ever start, do basic initialization

--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -361,6 +361,8 @@ class MemGPTConfig:
 @dataclass
 class AgentConfig:
     """
+
+    NOTE: this is a deprecated class, use AgentState instead. This class is only used for backcompatibility.
     Configuration for a specific instance of an agent
     """
 

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -8,9 +8,6 @@ import numpy as np
 from memgpt.constants import DEFAULT_HUMAN, DEFAULT_MEMGPT_MODEL, DEFAULT_PERSONA, DEFAULT_PRESET, LLM_MAX_TOKENS
 from memgpt.utils import get_local_time, format_datetime
 
-# Defining schema objects:
-# Note: user/agent can borrow from MemGPTConfig/AgentConfig classes
-
 
 class Record:
     """

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -145,6 +145,13 @@ class LLMConfig:
         model_endpoint: Optional[str] = "https://api.openai.com/v1",
         model_wrapper: Optional[str] = None,
         context_window: Optional[int] = None,
+        # openai-only
+        openai_key: Optional[str] = None,
+        # azure-only
+        azure_key: Optional[str] = None,
+        azure_endpoint: Optional[str] = None,
+        azure_version: Optional[str] = None,
+        azure_deployment: Optional[str] = None,
     ):
         self.model = model
         self.model_endpoint_type = model_endpoint_type
@@ -157,23 +164,10 @@ class LLMConfig:
         else:
             self.context_window = context_window
 
-
-class OpenAILLMConfig(LLMConfig):
-    def __init__(self, openai_key, **kwargs):
-        super().__init__(**kwargs)
+        # openai
         self.openai_key = openai_key
 
-
-class AzureLLMConfig(LLMConfig):
-    def __init__(
-        self,
-        azure_key: Optional[str] = None,
-        azure_endpoint: Optional[str] = None,
-        azure_version: Optional[str] = None,
-        azure_deployment: Optional[str] = None,
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
+        # azure
         self.azure_key = azure_key
         self.azure_endpoint = azure_endpoint
         self.azure_version = azure_version

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -350,13 +350,14 @@ class BaseRecallMemory(RecallMemory):
 class EmbeddingArchivalMemory(ArchivalMemory):
     """Archival memory with embedding based search"""
 
-    def __init__(self, config, agent_state, top_k: Optional[int] = 100):
+    def __init__(self, agent_state, top_k: Optional[int] = 100):
         """Init function for archival memory
 
         :param archival_memory_database: name of dataset to pre-fill archival with
         :type archival_memory_database: str
         """
         from memgpt.agent_store.storage import StorageConnector
+        from memgpt.config import MemGPTConfig
 
         self.top_k = top_k
         self.agent_state = agent_state
@@ -366,7 +367,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
         self.embedding_chunk_size = agent_state.embedding_config.embedding_chunk_size
 
         # create storage backend
-        self.storage = StorageConnector.get_archival_storage_connector(config, user_id=agent_state.user_id, agent_id=agent_state.id)
+        self.storage = StorageConnector.get_archival_storage_connector(user_id=agent_state.user_id, agent_id=agent_state.id)
         # TODO: have some mechanism for cleanup otherwise will lead to OOM
         self.cache = {}
 

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -350,7 +350,7 @@ class BaseRecallMemory(RecallMemory):
 class EmbeddingArchivalMemory(ArchivalMemory):
     """Archival memory with embedding based search"""
 
-    def __init__(self, agent_state, top_k: Optional[int] = 100):
+    def __init__(self, config, agent_state, top_k: Optional[int] = 100):
         """Init function for archival memory
 
         :param archival_memory_database: name of dataset to pre-fill archival with
@@ -366,7 +366,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
         self.embedding_chunk_size = agent_state.embedding_config.embedding_chunk_size
 
         # create storage backend
-        self.storage = StorageConnector.get_archival_storage_connector(user_id=agent_state.user_id, agent_id=agent_state.id)
+        self.storage = StorageConnector.get_archival_storage_connector(config, user_id=agent_state.user_id, agent_id=agent_state.id)
         # TODO: have some mechanism for cleanup otherwise will lead to OOM
         self.cache = {}
 

--- a/memgpt/persistence_manager.py
+++ b/memgpt/persistence_manager.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 import pickle
-from memgpt.config import AgentConfig
 from memgpt.memory import (
-    DummyRecallMemory,
     BaseRecallMemory,
     EmbeddingArchivalMemory,
 )
@@ -54,44 +52,6 @@ class LocalStateManager(PersistenceManager):
         self.recall_memory = BaseRecallMemory(agent_state)
         self.agent_state = agent_state
 
-    @classmethod
-    def load(cls, agent_config: AgentConfig):
-        """ Load a LocalStateManager from a file. """ ""
-        # TODO: remove this function
-        return cls(agent_config)
-        # try:
-        #    with open(filename, "rb") as f:
-        #        data = pickle.load(f)
-        # except ModuleNotFoundError as e:
-        #    # Patch for stripped openai package
-        #    # ModuleNotFoundError: No module named 'openai.openai_object'
-        #    with open(filename, "rb") as f:
-        #        unpickler = OpenAIBackcompatUnpickler(f)
-        #        data = unpickler.load()
-        #    # print(f"Unpickled data:\n{data.keys()}")
-
-        #    from memgpt.openai_backcompat.openai_object import OpenAIObject
-
-        #    def convert_openai_objects_to_dict(obj):
-        #        if isinstance(obj, OpenAIObject):
-        #            # Convert to dict or handle as needed
-        #            # print(f"detected OpenAIObject on {obj}")
-        #            return obj.to_dict_recursive()
-        #        elif isinstance(obj, dict):
-        #            return {k: convert_openai_objects_to_dict(v) for k, v in obj.items()}
-        #        elif isinstance(obj, list):
-        #            return [convert_openai_objects_to_dict(v) for v in obj]
-        #        else:
-        #            return obj
-
-        #    data = convert_openai_objects_to_dict(data)
-        #    # print(f"Converted data:\n{data.keys()}")
-
-        # manager = cls(agent_config)
-        # manager.archival_memory = EmbeddingArchivalMemory(agent_config)
-        # manager.recall_memory = BaseRecallMemory(agent_config)
-        # return manager
-
     def save(self):
         """Ensure storage connectors save data"""
         self.archival_memory.save()
@@ -105,9 +65,6 @@ class LocalStateManager(PersistenceManager):
         self.memory = agent.memory
         # printd(f"{self.__class__.__name__}.all_messages.len = {len(self.all_messages)}")
         printd(f"{self.__class__.__name__}.messages.len = {len(self.messages)}")
-
-        # Persistence manager also handles DB-related state
-        # self.recall_memory = self.recall_memory_cls(message_database=self.all_messages)
 
     def json_to_message(self, message_json) -> Message:
         """Convert agent message JSON into Message object"""

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -7,7 +7,7 @@ from functools import wraps
 from fastapi import HTTPException
 
 from memgpt.system import package_user_message
-from memgpt.config import AgentConfig, MemGPTConfig
+from memgpt.config import MemGPTConfig
 from memgpt.agent import Agent
 import memgpt.system as system
 import memgpt.constants as constants
@@ -60,7 +60,7 @@ class Server(object):
     def create_agent(
         self,
         user_id: str,
-        agent_config: Union[dict, AgentConfig],
+        agent_config: Union[dict, AgentState],
         interface: Union[AgentInterface, None],
         persistence_manager: Union[PersistenceManager, None],
     ) -> str:

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -513,9 +513,10 @@ class SyncServer(LockingServer):
 
         return agent_config
 
-    def get_server_config(self, user_id: str) -> dict:
+    def get_server_config(self) -> dict:
         """Return the base config"""
-        base_config = vars(MemGPTConfig.load())
+        # TODO: do we need a seperate server config?
+        base_config = vars(self.config)
 
         def clean_keys(config):
             config_copy = config.copy()

--- a/tests/test_websocket_interface.py
+++ b/tests/test_websocket_interface.py
@@ -8,6 +8,7 @@ import memgpt.presets.presets as presets
 import memgpt.utils as utils
 import memgpt.system as system
 from memgpt.persistence_manager import LocalStateManager
+from memgpt.data_types import AgentState
 
 
 # def test_websockets():
@@ -68,24 +69,17 @@ async def test_websockets():
 
     # Mock the persistence manager
     # create agents with defaults
-    agent_config = AgentConfig(
+
+    # TODO: this is currently broken, need to fix
+
+    agent_state = AgentState(
         persona="sam_pov",
         human="basic",
         model="gpt-4-1106-preview",
         model_endpoint_type="openai",
         model_endpoint="https://api.openai.com/v1",
     )
-    persistence_manager = LocalStateManager(agent_config=agent_config)
-
-    memgpt_agent = presets.create_agent_from_preset(
-        agent_config.preset,
-        agent_config,
-        agent_config.model,
-        agent_config.persona,  # note: extracting the raw text, not pulling from a file
-        agent_config.human,  # note: extracting raw text, not pulling from a file
-        ws_interface,
-        persistence_manager,
-    )
+    memgpt_agent = presets.create_agent_from_preset(agent_state, ws_interface)
 
     # Mock the user message packaging
     user_message = system.package_user_message("Hello, is anyone there?")


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
With the new storage refactor, we need to remove `AgentConfig` (stored locally per-user) and replace it with `AgentState`. We also can no longer assume that there is a local `MemGPTConfig` file that we can read from, as the server will not have access to this, so I modified parts of the code to assume that the config if passed in. 

Things that needed to be removed: 
* Any usage of `AgentConfig`
* Any usage of `MemGPTConfig.load()` (unless a top-level CLI command, which is still single-user)

**How to test**
TBD

**Have you tested this PR?**
TBD

**Is your PR over 500 lines of code?**
No

