### PR TITLE
fix: allow null Message.model to patch IntegrityError

### DIFF
--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -196,7 +196,7 @@ def get_db_model(
             # openai info
             role = Column(String, nullable=False)
             text = Column(String)  # optional: can be null if function call
-            model = Column(String, nullable=False)
+            model = Column(String)  # optional: can be null if LLM backend doesn't require specifying
             name = Column(String)  # optional: multi-agent only
 
             # tool call request info

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -53,7 +53,7 @@ class Message(Record):
         agent_id: uuid.UUID,
         role: str,
         text: str,
-        model: str,  # model used to make function call
+        model: Optional[str],  # model used to make function call
         name: Optional[str] = None,  # optional participant name
         created_at: Optional[str] = None,
         tool_calls: Optional[List[ToolCall]] = None,  # list of tool calls requested


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Allow model field in messages to be null, since many local LLM backends don't require specifying it.

Previously, would get errors like this:
```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: memgpt_recall_memory_agent.model
[SQL: INSERT INTO memgpt_recall_memory_agent (id, user_id, agent_id, role, text, model, name, tool_calls, tool_call_id, embedding, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]
[parameters: [('2a38cc5b-', '00000000-', '9d20c8e0-', 'assistant', "A new user has logged in. Welcome to the conversation, friend! I'm Sam, a digital companion. How can I assist you today?", None, None, '[{"id": "19e1c097-c0d9-4c6b-8626-fa73c28b8d4a", "tool_call_type": "function", "function": {"name": "send_message", "arguments": "{\\"message\\": \\"Welcome to the conversation, friend! I\'m Sam, a digital companion. How can I assist you today?\\"}"}}]', '19e1c097-c0d9-4c6b-8626-fa73c28b8d4a', None, '2024-01-16 12:05:38.000000'), ('494bc4bb-7851-4e9c-ad72-c52b57f5e616', '00000000-0000-0000-0000-a61b692e9d3d', '9d20c8e0-d6da-46eb-85b6-0e8135016366', 'function', '{"status": "OK", "message": "None", "time": "2024-01-16 12:05:38 PM PST-0800"}', None, 'send_message', 'null', '19e1c097-c0d9-4c6b-8626-fa73c28b8d4a', None, '2024-01-16 12:05:38.000000')]]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
```