### PR TITLE
build: Update the pytest script to cache poetry artifacts, so tests finish faster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,18 +23,16 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build and run container
       run: bash db/run_postgres.sh
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - name: "Setup Python, Poetry and Dependencies"
+      uses: packetcoders/action-setup-cache-python-poetry@main
       with:
         python-version: "3.11"
-
-    - name: Install poetry
-      run: pip install poetry
+        poetry-version: "1.7.1"
 
     - name: Set Poetry config
       run: |
@@ -49,20 +47,13 @@ jobs:
       run: |
         poetry install --all-extras
 
-    - name: Set Poetry config
-      env:
-        PGVECTOR_TEST_DB_URL: postgresql+pg8000://memgpt:memgpt@localhost:8888/memgpt
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      run: |
-        poetry config virtualenvs.in-project false
-        poetry config virtualenvs.path ~/.virtualenvs
-
     - name: Run tests with pytest
       env:
         PGVECTOR_TEST_DB_URL: postgresql+pg8000://memgpt:memgpt@localhost:8888/memgpt
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         PGVECTOR_TEST_DB_URL=postgresql+pg8000://memgpt:memgpt@localhost:8888/memgpt OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} poetry run pytest -s -vv -k "not test_storage" tests
+
     - name: Run storage tests
       env:
         PGVECTOR_TEST_DB_URL: postgresql+pg8000://memgpt:memgpt@localhost:8888/memgpt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,6 @@ jobs:
         poetry config virtualenvs.path ~/.virtualenvs
 
     - name: Install dependencies using Poetry
-      env:
-        PGVECTOR_TEST_DB_URL: postgresql+pg8000://memgpt:memgpt@localhost:8888/memgpt
-
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         poetry install --all-extras
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

This change adds a 3rd party action, from here:
https://github.com/marketplace/actions/setup-and-cache-python-poetry

This change will reduce test runtime, because python packages will not need to be downloaded every time this test runs. This will also improve the reliability of tests, because tests will continue working if Pypi becomes unavailable.

**How to test**
n/a

**Have you tested this PR?**
n/a

**Related issues or PRs**
n/a

**Is your PR over 500 lines of code?**
n/a

**Additional context**
I am happy to update this to *not* use a 3rd party action if you prefer.
