### PR TITLE
build: Upgrade all github actions to use checkout@v4

### DIFF
--- a/.github/workflows/black_format.yml
+++ b/.github/workflows/black_format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/poetry-publish-nightly.yml
+++ b/.github/workflows/poetry-publish-nightly.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: print latest_commit
         run: echo ${{ github.sha }}
       - id: should_run
@@ -28,7 +28,7 @@ jobs:
     needs: check-date
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/rdme-docs.yml
+++ b/.github/workflows/rdme-docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run `docs` command 🚀
         uses: readmeio/rdme@v8

--- a/.github/workflows/rdme-openapi.yml
+++ b/.github/workflows/rdme-openapi.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Upgrade all checkout actions to use v4, to align with the change made in #843 

**How to test**
n/a

**Have you tested this PR?**
n/a

**Related issues or PRs**
#843 

**Is your PR over 500 lines of code?**
n/a

**Additional context**
n/a
