### PR TITLE
feat: local auth config

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -162,7 +162,7 @@ def quickstart(
         api_key = os.getenv("OPENAI_API_KEY")
         while api_key is None or len(api_key) == 0:
             # Ask for API key as input
-            api_key = questionary.text("Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):").ask()
+            api_key = questionary.password("Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):").ask()
         credentials.openai_key = api_key
         credentials.save()
 

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -539,7 +539,7 @@ def configure_archival_storage(config: MemGPTConfig, credentials: MemGPTCredenti
     # TODO: allow configuring embedding model
 
 
-def configure_recall_storage(config: MemGPTConfig):
+def configure_recall_storage(config: MemGPTConfig, credentials: MemGPTCredentials):
     # Configure recall storage backend
     recall_storage_options = ["sqlite", "postgres"]
     recall_storage_type = questionary.select(
@@ -627,13 +627,6 @@ def configure():
         persona=default_persona,
         human=default_human,
         agent=default_agent,
-        # credentials
-        openai_key=openai_key,
-        azure_key=azure_creds["azure_key"],
-        azure_endpoint=azure_creds["azure_endpoint"],
-        azure_version=azure_creds["azure_version"],
-        azure_deployment=azure_creds["azure_deployment"],  # OK if None
-        azure_embedding_deployment=azure_creds["azure_embedding_deployment"],  # OK if None
         # storage
         archival_storage_type=archival_storage_type,
         archival_storage_uri=archival_storage_uri,

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -79,7 +79,7 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
             if openai_api_key is None:
                 while openai_api_key is None or len(openai_api_key) == 0:
                     # Ask for API key as input
-                    openai_api_key = questionary.text(
+                    openai_api_key = questionary.password(
                         "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):"
                     ).ask()
                     if openai_api_key is None:
@@ -92,7 +92,7 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
             default_input = (
                 shorten_key_middle(credentials.openai_key) if credentials.openai_key.startswith("sk-") else credentials.openai_key
             )
-            openai_api_key = questionary.text(
+            openai_api_key = questionary.password(
                 "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):",
                 default=default_input,
             ).ask()
@@ -373,7 +373,7 @@ def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCreden
                 # if we still can't find it, ask for it as input
                 while openai_api_key is None or len(openai_api_key) == 0:
                     # Ask for API key as input
-                    openai_api_key = questionary.text(
+                    openai_api_key = questionary.password(
                         "Enter your OpenAI API key (starts with 'sk-', see https://platform.openai.com/api-keys):"
                     ).ask()
                     if openai_api_key is None:

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -404,7 +404,7 @@ def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCreden
                     if openai_api_key is None:
                         raise KeyboardInterrupt
                 credentials.openai_key = openai_api_key
-                config.save()
+                credentials.save()
 
         embedding_endpoint_type = "openai"
         embedding_endpoint = "https://api.openai.com/v1"

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -172,7 +172,7 @@ class Message(Record):
                 if "tool_call_id" in openai_message_dict:
                     assert openai_message_dict["tool_call_id"] is None, openai_message_dict
 
-            if "tool_calls" in openai_message_dict:
+            if "tool_calls" in openai_message_dict and openai_message_dict["tool_calls"] is not None:
                 assert openai_message_dict["role"] == "assistant", openai_message_dict
 
                 tool_calls = [


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- Allow setting up local authentication / auth for local LLMs in the configuration (`memgpt configure` / `memgpt run`)
- Various patches to `memgpt configure` that weren't caught in the prior PR

**How to test**

`memgpt configure`

or

`rm -rf ~/.memgpt; memgpt run`

**Have you tested this PR?**

<img width="1018" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/c65fc2a3-a0af-49fe-9756-239d6a3fa20d">

Leads to the following `~/.memgpt/credentials`:
```
[openai]
auth_type = bearer_token
key = sk-...

[azure]
auth_type = api_key

[openllm]
auth_type = bearer_token
key = sk-...
```

<img width="1013" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/ce817079-0619-4194-bc0a-fdf31f532231">

Leads to:
```
[openai]
auth_type = bearer_token
key = sk-...

[azure]
auth_type = api_key
```