### PR TITLE
build: Add a warn-only pyright Github action

### DIFF
--- a/.github/workflows/pyright_types.yml
+++ b/.github/workflows/pyright_types.yml
@@ -1,0 +1,41 @@
+name: "Python/Pyright types check"
+on:
+  push:
+    branches: [ main ]
+    paths: ["**.py"]
+  pull_request:
+    branches: [ main ]
+    paths: ["**.py"]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pyright:
+    name: "Warn-only Pyright types check"
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: "Setup Python, Poetry and Dependencies"
+        uses: packetcoders/action-setup-cache-python-poetry@main
+        with:
+          python-version: ${{matrix.python-version}}
+          poetry-version: "1.7.1"
+          install-args: "-E dev"  # TODO: change this to --group dev when PR #842 lands
+
+      - name: "Run Pyright"  # TODO: remove "|| true" once all type errors have been fixed
+        run: |
+          poetry run pyright \
+            --pythonversion ${{matrix.python-version}} \
+            --outputjson \
+            --level error \
+            --project . || true
+
+# This could be updated to only run on files that have changed by using:
+# git diff-tree --no-commit-id --name-only -r --name-only "$GITHUB_SHA" | grep ".py"

--- a/.github/workflows/pyright_types.yml
+++ b/.github/workflows/pyright_types.yml
@@ -1,4 +1,4 @@
-name: "Python/Pyright types check"
+name: "Python Static Analysis"
 on:
   push:
     branches: [ main ]
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   pyright:
-    name: "Warn-only Pyright types check"
+    name: "Pyright types check"
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -29,13 +29,11 @@ jobs:
           poetry-version: "1.7.1"
           install-args: "-E dev"  # TODO: change this to --group dev when PR #842 lands
 
-      - name: "Run Pyright"  # TODO: remove "|| true" once all type errors have been fixed
-        run: |
-          poetry run pyright \
-            --pythonversion ${{matrix.python-version}} \
-            --outputjson \
-            --level error \
-            --project . || true
+      - name: "Add Poetry venv to PATH"
+        run: 'echo "$(poetry env info --path)/bin" >> $GITHUB_PATH'
 
-# This could be updated to only run on files that have changed by using:
-# git diff-tree --no-commit-id --name-only -r --name-only "$GITHUB_SHA" | grep ".py"
+      - name: "Run Pyright"
+        uses: jakebailey/pyright-action@v2
+        with:
+          python-version: ${{matrix.python-version}}
+          level: "error"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1496,13 +1496,13 @@ tests = ["pandas (>=1.4)", "pytest", "pytest-asyncio", "pytest-mock", "requests"
 
 [[package]]
 name = "llama-index"
-version = "0.9.33"
+version = "0.9.34"
 description = "Interface between LLMs and your data"
 optional = false
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "llama_index-0.9.33-py3-none-any.whl", hash = "sha256:23291335df361631b8c92f47285303173b52dca9b12364c0ad32b73dd9d14639"},
-    {file = "llama_index-0.9.33.tar.gz", hash = "sha256:1d740bb04c2a98e5e9ddb1d9006ec4c30228a6912d9eb572dcda32048c9f2b66"},
+    {file = "llama_index-0.9.34-py3-none-any.whl", hash = "sha256:8ced1e0dcdd40929b645e93e9056b7e1700de378d8724a4c05b4fe6b49597e25"},
+    {file = "llama_index-0.9.34.tar.gz", hash = "sha256:152554f4042425875517e35afca4d98641fa5fda79a3f0fe8dd0f7a9783f6d0d"},
 ]
 
 [package.dependencies]
@@ -2572,13 +2572,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "posthog"
-version = "3.3.1"
+version = "3.3.2"
 description = "Integrate PostHog into any python application."
 optional = false
 python-versions = "*"
 files = [
-    {file = "posthog-3.3.1-py2.py3-none-any.whl", hash = "sha256:5f53b232acb680a0389e372db5f786061a18386b8b5324bddcc64eff9fdb319b"},
-    {file = "posthog-3.3.1.tar.gz", hash = "sha256:252cb6ab5cbe7ff002753f34fb647721b3af75034b4a5a631317ebf3db58fe59"},
+    {file = "posthog-3.3.2-py2.py3-none-any.whl", hash = "sha256:14fb43ea95c40b353db59c49af2c09ff15188aa2963f48091fc7912fa9375263"},
+    {file = "posthog-3.3.2.tar.gz", hash = "sha256:734bf89f3c372605a8bbf2b07f600885287209145d747b09ccd004c59834750e"},
 ]
 
 [package.dependencies]
@@ -3072,6 +3072,24 @@ files = [
     {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
     {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
 ]
+
+[[package]]
+name = "pyright"
+version = "1.1.347"
+description = "Command line wrapper for pyright"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.347-py3-none-any.whl", hash = "sha256:14dd31b594aa3ec464894f66b8a2d206ebef1501e52789eb88cf2a79b0907fbe"},
+    {file = "pyright-1.1.347.tar.gz", hash = "sha256:17ea09322f60080f82abc4e622e43d1a5ebaa407ba86963b15b2bc01cca256e0"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pytest"
@@ -4850,7 +4868,7 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [extras]
 autogen = ["pyautogen"]
-dev = ["black", "datasets", "pexpect", "pre-commit", "pytest", "pytest-asyncio"]
+dev = ["black", "datasets", "pexpect", "pre-commit", "pyright", "pytest", "pytest-asyncio"]
 local = ["huggingface-hub", "torch", "transformers"]
 postgres = ["pg8000", "pgvector"]
 server = ["fastapi", "uvicorn", "websockets"]
@@ -4858,4 +4876,4 @@ server = ["fastapi", "uvicorn", "websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.12,>=3.9"
-content-hash = "08816def96c57cd170699da079d53f7c665d534a8f9da06f974905c4d2fbfa10"
+content-hash = "2ac71b23a51de4fc02d3061c535d8e6d599ef1800596713b864ef050a67e3a38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,12 @@ html2text = "^2020.1.16"
 docx2txt = "^0.8"
 sqlalchemy = "^2.0.25"
 pexpect = {version = "^4.9.0", optional = true}
+pyright = {version = "^1.1.347", optional = true}
 
 [tool.poetry.extras]
 local = ["torch", "huggingface-hub", "transformers"]
 postgres = ["pgvector", "pg8000"]
-dev = ["pytest", "pytest-asyncio", "pexpect", "black", "pre-commit", "datasets"]
+dev = ["pytest", "pytest-asyncio", "pexpect", "black", "pre-commit", "datasets", "pyright"]
 server = ["websockets", "fastapi", "uvicorn"]
 autogen = ["pyautogen"]
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Adds a purely informational Pyright type check. There are many errors right now, and Github lacks a "warn" state for jobs, so this will return "success" state, even though it's failing.

Once the errors have all been resolved, the `|| true` can be removed, and it will start reporting real error state.

**How to test**
n/a

**Have you tested this PR?**
I don't have a good way to test this until it lands in `main`. I'll send a follow-up change if needed after it lands.

**Related issues or PRs**
#855

**Is your PR over 500 lines of code?**
n/a

**Additional context**
Part of this change is minor point-release updates to posthog and llama_index in the `.lock` file. This change was automatically made by `poetry`. I reviewed theses changes in both projects, and I do not expect any compatibility issues.
