### PR TITLE
fix: patch test_cli

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -264,6 +264,8 @@ def create_default_user_or_exit(config: MemGPTConfig, ms: MetadataStore):
             sys.exit(1)
         else:
             return user
+    else:
+        return user
 
 
 def server(


### PR DESCRIPTION
Fixes error in `create_default_user_or_exit` (null return type)