### PR TITLE
feat: add agent rename and agent delete to server + REST

### DIFF
--- a/memgpt/server/rest_api/agents/config.py
+++ b/memgpt/server/rest_api/agents/config.py
@@ -54,8 +54,6 @@ def setup_agents_config_router(server: SyncServer, interface: QueuingInterface):
 
         This changes the name of the agent in the database but does NOT edit the agent's persona.
         """
-        request = AgentConfigRequest(user_id=user_id, agent_id=agent_id)
-
         # TODO remove once chatui adds user selection / pulls user from config
         request.user_id = None if request.user_id == "null" else request.user_id
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- [x] added `/agents/rename PATCH` route to update an agent's name
- [x] added `/agents DELETE` route
  - TODO make `ms.delete_agent` a soft delete in separate PR?

**How to test**

1. `memgpt server`
2. insomnia / postman

**Have you tested this PR?**

## PATCH

<img width="1170" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/18d8a0a5-636d-4a01-a39a-784e27b92350">

```
		{
			"id": "e919049d-5a52-43cd-b703-0c16e74c4f3f",
			"name": "LoyalRacquet",
			"human": "basic",
			"persona": "sam_pov",
			"created_at": "2024-01-20T17:07:54.911105"
		},
```

<img width="947" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/917cd6b1-ffae-426c-8a14-a6309b2c9bc3">

<img width="1066" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/4dca817c-c03a-4ffc-a97d-a48741d562f7">

<img width="1196" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/721ac968-c309-4b7d-8cc5-e3eec0135977">

## DELETE

<img width="1089" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/7b3a8be0-2820-4f78-80b1-ae62b2719aa1">

<img width="1241" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/d770fb8f-48da-419b-be9b-9d18c2f9f6a0">

**Related issues or PRs**

Closes #881 