### PR TITLE
tombedor.update more sessions

### DIFF
--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -256,7 +256,8 @@ class SQLStorageConnector(StorageConnector):
         filters = self.get_filters(filters)
         while True:
             # Retrieve a chunk of records with the given page_size
-            db_record_chunk = self.session.query(self.db_model).filter(*filters).offset(offset).limit(page_size).all()
+            with self.session_maker() as session:
+                db_record_chunk = session.query(self.db_model).filter(*filters).offset(offset).limit(page_size).all()
 
             # If the chunk is empty, we've retrieved all records
             if not db_record_chunk:
@@ -281,35 +282,36 @@ class SQLStorageConnector(StorageConnector):
         filters = self.get_filters(filters)
 
         # generate query
-        query = self.session.query(self.db_model).filter(*filters)
-        # query = query.order_by(asc(self.db_model.id))
+        with self.session_maker() as session:
+            query = session.query(self.db_model).filter(*filters)
+            # query = query.order_by(asc(self.db_model.id))
 
-        # records are sorted by the order_by field first, and then by the ID if two fields are the same
-        if reverse:
-            query = query.order_by(desc(getattr(self.db_model, order_by)), asc(self.db_model.id))
-        else:
-            query = query.order_by(asc(getattr(self.db_model, order_by)), asc(self.db_model.id))
-
-        # cursor logic: filter records based on before/after ID
-        if after:
-            after_value = getattr(self.get(id=after), order_by)
-            if reverse:  # if reverse, then we want to get records that are less than the after_value
-                sort_exp = getattr(self.db_model, order_by) < after_value
-            else:  # otherwise, we want to get records that are greater than the after_value
-                sort_exp = getattr(self.db_model, order_by) > after_value
-            query = query.filter(
-                or_(sort_exp, and_(getattr(self.db_model, order_by) == after_value, self.db_model.id > after))  # tiebreaker case
-            )
-        if before:
-            before_value = getattr(self.get(id=before), order_by)
+            # records are sorted by the order_by field first, and then by the ID if two fields are the same
             if reverse:
-                sort_exp = getattr(self.db_model, order_by) > before_value
+                query = query.order_by(desc(getattr(self.db_model, order_by)), asc(self.db_model.id))
             else:
-                sort_exp = getattr(self.db_model, order_by) < before_value
-            query = query.filter(or_(sort_exp, and_(getattr(self.db_model, order_by) == before_value, self.db_model.id < before)))
+                query = query.order_by(asc(getattr(self.db_model, order_by)), asc(self.db_model.id))
 
-        # get records
-        db_record_chunk = query.limit(limit).all()
+            # cursor logic: filter records based on before/after ID
+            if after:
+                after_value = getattr(self.get(id=after), order_by)
+                if reverse:  # if reverse, then we want to get records that are less than the after_value
+                    sort_exp = getattr(self.db_model, order_by) < after_value
+                else:  # otherwise, we want to get records that are greater than the after_value
+                    sort_exp = getattr(self.db_model, order_by) > after_value
+                query = query.filter(
+                    or_(sort_exp, and_(getattr(self.db_model, order_by) == after_value, self.db_model.id > after))  # tiebreaker case
+                )
+            if before:
+                before_value = getattr(self.get(id=before), order_by)
+                if reverse:
+                    sort_exp = getattr(self.db_model, order_by) > before_value
+                else:
+                    sort_exp = getattr(self.db_model, order_by) < before_value
+                query = query.filter(or_(sort_exp, and_(getattr(self.db_model, order_by) == before_value, self.db_model.id < before)))
+
+            # get records
+            db_record_chunk = query.limit(limit).all()
         if not db_record_chunk:
             return None
         records = [record.to_record() for record in db_record_chunk]
@@ -321,14 +323,16 @@ class SQLStorageConnector(StorageConnector):
 
     def get_all(self, filters: Optional[Dict] = {}, limit=None) -> List[Record]:
         filters = self.get_filters(filters)
-        if limit:
-            db_records = self.session.query(self.db_model).filter(*filters).limit(limit).all()
-        else:
-            db_records = self.session.query(self.db_model).filter(*filters).all()
+        with self.session_maker() as session:
+            if limit:
+                db_records = session.query(self.db_model).filter(*filters).limit(limit).all()
+            else:
+                db_records = session.query(self.db_model).filter(*filters).all()
         return [record.to_record() for record in db_records]
 
     def get(self, id: uuid.UUID) -> Optional[Record]:
-        db_record = self.session.get(self.db_model, id)
+        with self.session_maker() as session:
+            db_record = session.get(self.db_model, id)
         if db_record is None:
             return None
         return db_record.to_record()
@@ -336,19 +340,22 @@ class SQLStorageConnector(StorageConnector):
     def size(self, filters: Optional[Dict] = {}) -> int:
         # return size of table
         filters = self.get_filters(filters)
-        return self.session.query(self.db_model).filter(*filters).count()
+        with self.session_maker() as session:
+            return session.query(self.db_model).filter(*filters).count()
 
     def insert(self, record: Record):
         db_record = self.db_model(**vars(record))
-        self.session.add(db_record)
-        self.session.commit()
+        with self.session_maker() as session:
+            session.add(db_record)
+            session.commit()
 
     def insert_many(self, records: List[Record], show_progress=False):
         iterable = tqdm(records) if show_progress else records
-        for record in iterable:
-            db_record = self.db_model(**vars(record))
-            self.session.add(db_record)
-        self.session.commit()
+        with self.session_maker() as session:
+            for record in iterable:
+                db_record = self.db_model(**vars(record))
+                session.add(db_record)
+            session.commit()
 
     def query(self, query: str, query_vec: List[float], top_k: int = 10, filters: Optional[Dict] = {}) -> List[Record]:
         raise NotImplementedError("Vector query not implemented for SQLStorageConnector")
@@ -358,47 +365,53 @@ class SQLStorageConnector(StorageConnector):
 
     def list_data_sources(self):
         assert self.table_type == TableType.ARCHIVAL_MEMORY, f"list_data_sources only implemented for ARCHIVAL_MEMORY"
-        unique_data_sources = self.session.query(self.db_model.data_source).filter(*self.filters).distinct().all()
+        with self.session_maker() as session:
+            unique_data_sources = session.query(self.db_model.data_source).filter(*self.filters).distinct().all()
         return unique_data_sources
 
     def query_date(self, start_date, end_date, offset=0, limit=None):
         filters = self.get_filters({})
-        query = (
-            self.session.query(self.db_model)
-            .filter(*filters)
-            .filter(self.db_model.created_at >= start_date)
-            .filter(self.db_model.created_at <= end_date)
-            .offset(offset)
-        )
-        if limit:
-            query = query.limit(limit)
-        results = query.all()
+        with self.session_maker() as session:
+            query = (
+                session.query(self.db_model)
+                .filter(*filters)
+                .filter(self.db_model.created_at >= start_date)
+                .filter(self.db_model.created_at <= end_date)
+                .offset(offset)
+            )
+            if limit:
+                query = query.limit(limit)
+            results = query.all()
         return [result.to_record() for result in results]
 
     def query_text(self, query, offset=0, limit=None):
         # todo: make fuzz https://stackoverflow.com/questions/42388956/create-a-full-text-search-index-with-sqlalchemy-on-postgresql/42390204#42390204
         filters = self.get_filters({})
-        query = (
-            self.session.query(self.db_model)
-            .filter(*filters)
-            .filter(func.lower(self.db_model.text).contains(func.lower(query)))
-            .offset(offset)
-        )
-        if limit:
-            query = query.limit(limit)
-        results = query.all()
+        with self.session_maker() as session:
+            query = (
+                session.query(self.db_model)
+                .filter(*filters)
+                .filter(func.lower(self.db_model.text).contains(func.lower(query)))
+                .offset(offset)
+            )
+            if limit:
+                query = query.limit(limit)
+            results = query.all()
         # return [self.type(**vars(result)) for result in results]
         return [result.to_record() for result in results]
 
+    # Should be used only in tests!
     def delete_table(self):
         close_all_sessions()
-        self.db_model.__table__.drop(self.session.bind)
-        self.session.commit()
+        with self.session_maker() as session:
+            self.db_model.__table__.drop(session.bind)
+            session.commit()
 
     def delete(self, filters: Optional[Dict] = {}):
         filters = self.get_filters(filters)
-        self.session.query(self.db_model).filter(*filters).delete()
-        self.session.commit()
+        with self.session_maker() as session:
+            session.query(self.db_model).filter(*filters).delete()
+            session.commit()
 
 
 class PostgresStorageConnector(SQLStorageConnector):
@@ -436,14 +449,15 @@ class PostgresStorageConnector(SQLStorageConnector):
         Base.metadata.create_all(self.engine, tables=[self.db_model.__table__])  # Create the table if it doesn't exist
 
         session_maker = sessionmaker(bind=self.engine)
-        self.session = session_maker()
-        self.session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))  # Enables the vector extension
+        with self.session_maker() as session:
+            session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))  # Enables the vector extension
 
     def query(self, query: str, query_vec: List[float], top_k: int = 10, filters: Optional[Dict] = {}) -> List[Record]:
         filters = self.get_filters(filters)
-        results = self.session.scalars(
-            select(self.db_model).filter(*filters).order_by(self.db_model.embedding.l2_distance(query_vec)).limit(top_k)
-        ).all()
+        with self.session_maker() as session:
+            results = session.scalars(
+                select(self.db_model).filter(*filters).order_by(self.db_model.embedding.l2_distance(query_vec)).limit(top_k)
+            ).all()
 
         # Convert the results into Passage objects
         records = [result.to_record() for result in results]
@@ -471,8 +485,7 @@ class SQLLiteStorageConnector(SQLStorageConnector):
         self.db_model = get_db_model(config, self.table_name, table_type, user_id, agent_id, dialect="sqlite")
         self.engine = create_engine(f"sqlite:///{self.path}")
         Base.metadata.create_all(self.engine, tables=[self.db_model.__table__])  # Create the table if it doesn't exist
-        session_maker = sessionmaker(bind=self.engine)
-        self.session = session_maker()
+        self.session_maker = sessionmaker(bind=self.engine)
 
         import sqlite3
 

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -1,13 +1,10 @@
 """ This module contains the data types used by MemGPT. Each data type must include a function to create a DB model. """
 import uuid
 from datetime import datetime
-from abc import abstractmethod
 from typing import Optional, List, Dict
 import numpy as np
 
-from memgpt.constants import DEFAULT_HUMAN, DEFAULT_MEMGPT_MODEL, DEFAULT_PERSONA, DEFAULT_PRESET, LLM_MAX_TOKENS, MAX_EMBEDDING_DIM
-from memgpt.utils import get_local_time, format_datetime
-from memgpt.models import chat_completion_response
+from memgpt.constants import DEFAULT_HUMAN, DEFAULT_PERSONA, DEFAULT_PRESET, LLM_MAX_TOKENS, MAX_EMBEDDING_DIM
 
 
 class Record:
@@ -241,7 +238,7 @@ class Message(Record):
                 openai_message["name"] = self.name
 
         elif self.role == "assistant":
-            assert all([v is not None for v in [self.text, self.role]]), vars(self)
+            # assert all([v is not None for v in [self.text, self.role]]), vars(self)
             openai_message = {
                 "content": self.text,
                 "role": self.role,

--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -6,6 +6,7 @@ import sys
 
 from memgpt.functions.schema_generator import generate_schema
 from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX
+from memgpt.utils import printd
 
 USER_FUNCTIONS_DIR = os.path.join(MEMGPT_DIR, "functions")
 
@@ -17,6 +18,11 @@ def load_function_set(module):
     function_dict = {}
 
     for attr_name in dir(module):
+        if attr_name.startswith("_"):
+            # Skip private functions
+            printd(f"Skipping {attr_name} because it starts with _, private function")
+            continue
+
         # Get the attribute
         attr = getattr(module, attr_name)
 


### PR DESCRIPTION
- build: Upgrade all github actions to use checkout@v4 (#844)
- build: Update all actions to use cached poetry builds (#846)
- feat: Get in-context `Message.id` values from server  (#851)
- refactor: remove User LLM/embed. defaults, add credentials file, add authentication option for custom LLM backends (#835)
- feat: local auth config (#854)
- docs: Update README.md for Chat UI (#856)
- fix: Remove `psycopg` dependency (#853)
- feat: Helper script for clearing out test database for postgres (#863)
- build: Rename Github actions to improve clarity (#862)
- chore: Update`pyproject.toml` and `README` (#866)
- feat: Store embeddings padded to size `4096` to allow DB storage of varying size embeddings  (#852)
- fix: minor fixes to allow tests to pass without OPENAI_API_KEY set (#871)
- build: Add a warn-only pyright Github action (#861)
- fix: close db sessions in metadata manager (#869)
- fix: patch typo, ci: disable pyright on main (#872)
- feat: Next iteration of ChatUI (#847)
- fix: patch server test (wasn't run on community PRs) (#873)
- ci: allow pyright to fail for the time being as a warning (#874)
- fix: patch test_cli (#875)
- fix: another patch for test_cli (#876)
- fix: Correct misspelled 'occurred' in printed error messages (#868)
- fix: various fixes + make sure to save agent on creation to avoid missing agent_state.state entries (#877)
- fix: Add tests for migration code and bugfix for pulling LLM/embedding configs from user instead of config (#878)
- fix: Remove the hard-coded database URI in the test helper to use an env var (#865)
- feat: Benchmark Command: `memgpt benchmark` (#816)
- fix: patch benchmark command (#879)
- docs: Update contributing_code.md (#883)
- feat: add agent rename and agent delete to server + REST (#882)
- docs: Update contributing_code.md (#884)
- docs: Update config.py (#885)
- docs: Update config.py (#886)
- do not load private functions
- allow null function calls
- fix: update remaining sqlalchemy sessions
