### PR TITLE
fix: Fix function documentation in wrapper

### DIFF
--- a/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
@@ -101,6 +101,8 @@ class ChatMLInnerMonologueWrapper(LLMChatCompletionWrapper):
         prompt += system_message
         prompt += "\n"
         if function_documentation is not None:
+            prompt += f"Please select the most suitable function and parameters from the list of available functions below, based on the ongoing conversation. Provide your response in JSON format."
+            prompt += f"\nAvailable functions:"
             prompt += function_documentation
         else:
             prompt += self._compile_function_block(functions)

--- a/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/chatml.py
@@ -102,7 +102,7 @@ class ChatMLInnerMonologueWrapper(LLMChatCompletionWrapper):
         prompt += "\n"
         if function_documentation is not None:
             prompt += f"Please select the most suitable function and parameters from the list of available functions below, based on the ongoing conversation. Provide your response in JSON format."
-            prompt += f"\nAvailable functions:"
+            prompt += f"\nAvailable functions:\n"
             prompt += function_documentation
         else:
             prompt += self._compile_function_block(functions)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fixes the issue that the two lines above the function documentation don't get added to the system message when using grammar and chatml.

**How to test**
Check the system message in debug mode.

**Have you tested this PR?**
Yes.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Is your PR over 500 lines of code?**
No, it are just two lines.

