### PR TITLE
refactor: refactor MemGPT + AutoGen integration to work with MemGPT `0.2.12`+ (DB release)

### DIFF
--- a/docs/autogen.md
+++ b/docs/autogen.md
@@ -53,6 +53,7 @@ memgpt_autogen_agent = create_memgpt_autogen_agent_from_config(
     interface_kwargs=interface_kwargs,
     default_auto_reply="...",
     skip_verify=False,  # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than send_message on the first turn
+    auto_save=False,  # NOTE: set this to True if you want the MemGPT AutoGen agent to save its internal state after each reply - you can also save manually with .save()
 )
 ```
 
@@ -62,10 +63,28 @@ Now this `memgpt_autogen_agent` can be used in standard AutoGen scripts:
 import autogen
 
 # ... assuming we have some other AutoGen agents other_agent_1 and 2
-groupchat = autogen.GroupChat(agents=[memgpt_autogen_agent, other_agent_1, other_agent_2], messages=[], max_round=12)
+groupchat = autogen.GroupChat(agents=[memgpt_autogen_agent, other_agent_1, other_agent_2], messages=[], max_round=12, speaker_selection_method="round_robin")
 ```
 
 [examples/agent_groupchat.py](https://github.com/cpacker/MemGPT/blob/main/memgpt/autogen/examples/agent_groupchat.py) contains an example of a groupchat where one of the agents is powered by MemGPT. If you are using OpenAI, you can also run the example using the [notebook](https://github.com/cpacker/MemGPT/blob/main/memgpt/autogen/examples/memgpt_coder_autogen.ipynb).
+
+### Saving and loading
+
+If you're using MemGPT AutoGen agents inside a Python script, you can save the internal state of the agent (message history, memory, etc.) by calling `.save()`:
+```python
+# You can also set auto_save = True in the creation function
+memgpt_autogen_agent.save()
+```
+
+To load an existing agent, you can use the `load_autogen_memgpt_agent` function:
+```python
+from memgpt.autogen.memgpt_agent import load_autogen_memgpt_agent
+
+# To load an AutoGen+MemGPT agent you previously created, you can use the load function:
+memgpt_autogen_agent = load_autogen_memgpt_agent(agent_config={"name": "MemGPT_agent"})
+```
+
+Because AutoGen MemGPT agents are really just MemGPT agents under-the-hood, you can interact with them via standard MemGPT interfaces such as the [MemGPT Python Client](https://memgpt.readme.io/docs/python_client) or [MemGPT API](https://memgpt.readme.io/reference/api). However, be careful when using AutoGen MemGPT agents outside of AutoGen scripts, since the context (chain of messages) may become confusing for the MemGPT agent to understand as you are mixing AutoGen groupchat conversations with regular user-agent 1-1 conversations.
 
 In the next section, we'll go through the example in depth to demonstrate how to set up MemGPT and AutoGen to run with a local LLM backend.
 

--- a/docs/python_client.md
+++ b/docs/python_client.md
@@ -4,7 +4,7 @@ excerpt: Developing using the MemGPT Python client
 category: 6580dab16cade8003f996d17
 ---
 
-The fastest way to integrate MemGPT with your own Python projects is through the `MemGPT` client class:
+The fastest way to integrate MemGPT with your own Python projects is through the `MemGPT` [client class](https://github.com/cpacker/MemGPT/blob/main/memgpt/client/client.py):
 
 ```python
 from memgpt import MemGPT

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -888,7 +888,7 @@ class Agent(object):
     #        print(f"Agent.save {new_agent_state.id} :: preupdate:\n\tmessages={new_agent_state.state['messages']}")
     #        self.ms.update_agent(agent=new_agent_state)
 
-    def update_state(self):
+    def update_state(self) -> AgentState:
         updated_state = {
             "persona": self.memory.persona,
             "human": self.memory.human,

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -316,6 +316,19 @@ class Agent(object):
         self._messages = new_messages
         self.messages_total += len(added_messages)
 
+    def append_to_messages(self, added_messages: List[dict]):
+        """An external-facing message append, where dict-like messages are first converted to Message objects"""
+        added_messages_objs = [
+            Message.dict_to_message(
+                agent_id=self.agent_state.id,
+                user_id=self.agent_state.user_id,
+                model=self.model,
+                openai_message_dict=msg,
+            )
+            for msg in added_messages
+        ]
+        self._append_to_messages(added_messages_objs)
+
     def _swap_system_message(self, new_system_message: Message):
         assert isinstance(new_system_message, Message)
         assert new_system_message.role == "system", new_system_message

--- a/memgpt/autogen/examples/agent_autoreply.py
+++ b/memgpt/autogen/examples/agent_autoreply.py
@@ -23,7 +23,7 @@ if LLM_BACKEND == "openai":
     model = "gpt-4"
 
     openai_api_key = os.getenv("OPENAI_API_KEY")
-    assert openai_api_key, "You must set OPENAI_API_KEY to run this example"
+    assert openai_api_key, "You must set OPENAI_API_KEY or set LLM_BACKEND to 'local' to run this example"
 
     # This config is for AutoGen agents that are not powered by MemGPT
     config_list = [
@@ -109,7 +109,7 @@ elif LLM_BACKEND == "local":
             "preset": DEFAULT_PRESET,
             "model": None,  # only required for Ollama, see: https://memgpt.readme.io/docs/ollama
             "context_window": 8192,  # the context window of your model (for Mistral 7B-based models, it's likely 8192)
-            "model_wrapper": "airoboros-l2-70b-2.1",  # airoboros is the default wrapper and should work for most models
+            "model_wrapper": "chatml",  # chatml is the default wrapper
             "model_endpoint_type": "lmstudio",  # can use webui, ollama, llamacpp, etc.
             "model_endpoint": "http://localhost:1234",  # the IP address of your LLM backend
         },

--- a/memgpt/autogen/examples/agent_docs.py
+++ b/memgpt/autogen/examples/agent_docs.py
@@ -17,9 +17,9 @@ import autogen
 from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config
 from memgpt.constants import LLM_MAX_TOKENS, DEFAULT_PRESET
 
-# LLM_BACKEND = "openai"
+LLM_BACKEND = "openai"
 # LLM_BACKEND = "azure"
-LLM_BACKEND = "local"
+# LLM_BACKEND = "local"
 
 if LLM_BACKEND == "openai":
     # For demo purposes let's use gpt-4
@@ -153,7 +153,13 @@ memgpt_agent = create_memgpt_autogen_agent_from_config(
     skip_verify=False,  # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than send_message on the first turn
 )
 # NOTE: you need to follow steps to load document first: see https://memgpt.readme.io/docs/autogen#part-4-attaching-documents-to-memgpt-autogen-agents
-memgpt_agent.load_and_attach(name="memgpt_research_paper", type="directory", input_dir=None, input_files=["memgpt_research_paper.pdf"])
+memgpt_agent.load_and_attach(
+    name="memgpt_research_paper",
+    type="directory",
+    input_dir=None,
+    input_files=["memgpt_research_paper.pdf"],
+    # force=True,
+)
 
 # Initialize the group chat between the agents
 groupchat = autogen.GroupChat(agents=[user_proxy, memgpt_agent], messages=[], max_round=12, speaker_selection_method="round_robin")

--- a/memgpt/autogen/examples/agent_docs.py
+++ b/memgpt/autogen/examples/agent_docs.py
@@ -17,16 +17,16 @@ import autogen
 from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config
 from memgpt.constants import LLM_MAX_TOKENS, DEFAULT_PRESET
 
-LLM_BACKEND = "openai"
+# LLM_BACKEND = "openai"
 # LLM_BACKEND = "azure"
-# LLM_BACKEND = "local"
+LLM_BACKEND = "local"
 
 if LLM_BACKEND == "openai":
     # For demo purposes let's use gpt-4
     model = "gpt-4"
 
     openai_api_key = os.getenv("OPENAI_API_KEY")
-    assert openai_api_key, "You must set OPENAI_API_KEY to run this example"
+    assert openai_api_key, "You must set OPENAI_API_KEY or set LLM_BACKEND to 'local' to run this example"
 
     # This config is for AutoGen agents that are not powered by MemGPT
     config_list = [
@@ -112,7 +112,7 @@ elif LLM_BACKEND == "local":
             "preset": DEFAULT_PRESET,
             "model": None,  # only required for Ollama, see: https://memgpt.readme.io/docs/ollama
             "context_window": 8192,  # the context window of your model (for Mistral 7B-based models, it's likely 8192)
-            "model_wrapper": "airoboros-l2-70b-2.1",  # airoboros is the default wrapper and should work for most models
+            "model_wrapper": "chatml",  # chatml is the default wrapper
             "model_endpoint_type": "lmstudio",  # can use webui, ollama, llamacpp, etc.
             "model_endpoint": "http://localhost:1234",  # the IP address of your LLM backend
         },
@@ -153,7 +153,7 @@ memgpt_agent = create_memgpt_autogen_agent_from_config(
     skip_verify=False,  # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than send_message on the first turn
 )
 # NOTE: you need to follow steps to load document first: see https://memgpt.readme.io/docs/autogen#part-4-attaching-documents-to-memgpt-autogen-agents
-memgpt_agent.load_and_attach("memgpt_research_paper", "directory")
+memgpt_agent.load_and_attach(name="memgpt_research_paper", type="directory", input_dir=None, input_files=["memgpt_research_paper.pdf"])
 
 # Initialize the group chat between the agents
 groupchat = autogen.GroupChat(agents=[user_proxy, memgpt_agent], messages=[], max_round=12, speaker_selection_method="round_robin")

--- a/memgpt/autogen/examples/agent_groupchat.py
+++ b/memgpt/autogen/examples/agent_groupchat.py
@@ -15,9 +15,9 @@ import autogen
 from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config
 from memgpt.constants import LLM_MAX_TOKENS, DEFAULT_PRESET
 
-LLM_BACKEND = "openai"
+# LLM_BACKEND = "openai"
 # LLM_BACKEND = "azure"
-# LLM_BACKEND = "local"
+LLM_BACKEND = "local"
 
 if LLM_BACKEND == "openai":
     # For demo purposes let's use gpt-4
@@ -110,7 +110,7 @@ elif LLM_BACKEND == "local":
             "preset": DEFAULT_PRESET,
             "model": None,  # only required for Ollama, see: https://memgpt.readme.io/docs/ollama
             "context_window": 8192,  # the context window of your model (for Mistral 7B-based models, it's likely 8192)
-            "model_wrapper": "airoboros-l2-70b-2.1",  # airoboros is the default wrapper and should work for most models
+            "model_wrapper": "chatml",  # chatml is the default wrapper
             "model_endpoint_type": "lmstudio",  # can use webui, ollama, llamacpp, etc.
             "model_endpoint": "http://localhost:1234",  # the IP address of your LLM backend
         },
@@ -176,7 +176,7 @@ else:
     )
 
 # Initialize the group chat between the user and two LLM agents (PM and coder)
-groupchat = autogen.GroupChat(agents=[user_proxy, pm, coder], messages=[], max_round=12)
+groupchat = autogen.GroupChat(agents=[user_proxy, pm, coder], messages=[], max_round=12, speaker_selection_method="round_robin")
 manager = autogen.GroupChatManager(groupchat=groupchat, llm_config=llm_config)
 
 # Begin the group chat with a message from the user

--- a/memgpt/autogen/examples/agent_groupchat.py
+++ b/memgpt/autogen/examples/agent_groupchat.py
@@ -24,7 +24,7 @@ if LLM_BACKEND == "openai":
     model = "gpt-4"
 
     openai_api_key = os.getenv("OPENAI_API_KEY")
-    assert openai_api_key, "You must set OPENAI_API_KEY to run this example"
+    assert openai_api_key, "You must set OPENAI_API_KEY or set LLM_BACKEND to 'local' to run this example"
 
     # This config is for AutoGen agents that are not powered by MemGPT
     config_list = [

--- a/memgpt/autogen/examples/agent_groupchat.py
+++ b/memgpt/autogen/examples/agent_groupchat.py
@@ -15,9 +15,9 @@ import autogen
 from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config, load_autogen_memgpt_agent
 from memgpt.constants import LLM_MAX_TOKENS, DEFAULT_PRESET
 
-# LLM_BACKEND = "openai"
+LLM_BACKEND = "openai"
 # LLM_BACKEND = "azure"
-LLM_BACKEND = "local"
+# LLM_BACKEND = "local"
 
 if LLM_BACKEND == "openai":
     # For demo purposes let's use gpt-4

--- a/memgpt/autogen/examples/agent_groupchat.py
+++ b/memgpt/autogen/examples/agent_groupchat.py
@@ -12,7 +12,7 @@ Begin by doing:
 
 import os
 import autogen
-from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config
+from memgpt.autogen.memgpt_agent import create_memgpt_autogen_agent_from_config, load_autogen_memgpt_agent
 from memgpt.constants import LLM_MAX_TOKENS, DEFAULT_PRESET
 
 # LLM_BACKEND = "openai"
@@ -173,7 +173,17 @@ else:
         interface_kwargs=interface_kwargs,
         default_auto_reply="...",  # Set a default auto-reply message here (non-empty auto-reply is required for LM Studio)
         skip_verify=False,  # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than send_message on the first turn
+        auto_save=False,  # Set this to True if you want the MemGPT AutoGen agent to save its internal state after each reply - you can also save manually with .save()
     )
+
+    # If you'd like to save this agent at any point, you can do:
+    # coder.save()
+
+    # You can also autosave by setting auto_save=True, in which case coder.save() will be called automatically
+
+    # To load an AutoGen+MemGPT agent you previously created, you can use the load function:
+    # coder = load_autogen_memgpt_agent(agent_config={"name": "MemGPT_coder"})
+
 
 # Initialize the group chat between the user and two LLM agents (PM and coder)
 groupchat = autogen.GroupChat(agents=[user_proxy, pm, coder], messages=[], max_round=12, speaker_selection_method="round_robin")

--- a/memgpt/autogen/examples/memgpt_coder_autogen.ipynb
+++ b/memgpt/autogen/examples/memgpt_coder_autogen.ipynb
@@ -21,7 +21,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install pyautogen"
+        "%pip install pyautogen==0.2.0"
       ]
     },
     {
@@ -94,6 +94,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "flVCXXKirZ-c",
+      "metadata": {
+        "id": "flVCXXKirZ-c"
+      },
+      "outputs": [],
       "source": [
         "# The user agent\n",
         "user_proxy = autogen.UserProxyAgent(\n",
@@ -145,16 +151,16 @@
         "        interface_kwargs=interface_kwargs,\n",
         "        default_auto_reply=\"...\",  # Set a default auto-reply message here (non-empty auto-reply is required for LM Studio)\n",
         "    )"
-      ],
-      "metadata": {
-        "id": "flVCXXKirZ-c"
-      },
-      "id": "flVCXXKirZ-c",
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "GvLSBuEhreO1",
+      "metadata": {
+        "id": "GvLSBuEhreO1"
+      },
+      "outputs": [],
       "source": [
         "# Initialize the group chat between the user and two LLM agents (PM and coder)\n",
         "groupchat = autogen.GroupChat(agents=[user_proxy, pm, coder], messages=[], max_round=12)\n",
@@ -165,16 +171,13 @@
         "    manager,\n",
         "    message=\"I want to design an app to make me one million dollars in one month. Yes, your heard that right.\",\n",
         ")"
-      ],
-      "metadata": {
-        "id": "GvLSBuEhreO1"
-      },
-      "id": "GvLSBuEhreO1",
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -191,9 +194,6 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.11.6"
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/memgpt/autogen/interface.py
+++ b/memgpt/autogen/interface.py
@@ -47,9 +47,9 @@ class AutoGenInterface(object):
     def __init__(
         self,
         message_list=None,
-        fancy=False,
+        fancy=True,  # only applies to the prints, not the appended messages
         show_user_message=False,
-        show_inner_thoughts=False,
+        show_inner_thoughts=True,
         show_function_outputs=False,
         debug=False,
     ):
@@ -65,34 +65,36 @@ class AutoGenInterface(object):
         self.message_list = []
 
     def internal_monologue(self, msg):
-        # ANSI escape code for italic is '\x1B[3m'
+        # NOTE: never gets appended
         if self.debug:
             print(f"inner thoughts :: {msg}")
         if not self.show_inner_thoughts:
             return
-        message = f"\x1B[3m{Fore.LIGHTBLACK_EX}💭 {msg}{Style.RESET_ALL}" if self.fancy else f"[inner thoughts] {msg}"
+        # ANSI escape code for italic is '\x1B[3m'
+        message = f"\x1B[3m{Fore.LIGHTBLACK_EX}💭 {msg}{Style.RESET_ALL}" if self.fancy else f"[MemGPT agent's inner thoughts] {msg}"
         print(message)
-        # self.message_list.append(message)
 
     def assistant_message(self, msg):
+        # NOTE: gets appended
         if self.debug:
             print(f"assistant :: {msg}")
-        message = f"{Fore.YELLOW}{Style.BRIGHT}🤖 {Fore.YELLOW}{msg}{Style.RESET_ALL}" if self.fancy else msg
-        self.message_list.append(message)
+        # message = f"{Fore.YELLOW}{Style.BRIGHT}🤖 {Fore.YELLOW}{msg}{Style.RESET_ALL}" if self.fancy else msg
+        self.message_list.append(msg)
 
     def memory_message(self, msg):
+        # NOTE: never gets appended
         if self.debug:
             print(f"memory :: {msg}")
         message = f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}🧠 {Fore.LIGHTMAGENTA_EX}{msg}{Style.RESET_ALL}" if self.fancy else f"[memory] {msg}"
-        # self.message_list.append(message)
         print(message)
 
     def system_message(self, msg):
+        # NOTE: gets appended
         if self.debug:
             print(f"system :: {msg}")
         message = f"{Fore.MAGENTA}{Style.BRIGHT}🖥️ [system] {Fore.MAGENTA}{msg}{Style.RESET_ALL}" if self.fancy else f"[system] {msg}"
-        self.message_list.append(message)
         print(message)
+        self.message_list.append(msg)
 
     def user_message(self, msg, raw=False):
         if self.debug:
@@ -129,6 +131,7 @@ class AutoGenInterface(object):
         else:
             message = f"{Fore.GREEN}{Style.BRIGHT}🧑 {Fore.GREEN}{msg_json}{Style.RESET_ALL}" if self.fancy else f"[user] {msg}"
 
+        # TODO should we ever be appending this?
         self.message_list.append(message)
 
     def function_message(self, msg):
@@ -139,6 +142,7 @@ class AutoGenInterface(object):
 
         if isinstance(msg, dict):
             message = f"{Fore.RED}{Style.BRIGHT}⚡ [function] {Fore.RED}{msg}{Style.RESET_ALL}"
+            # TODO should we ever be appending this?
             self.message_list.append(message)
             return
 

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -55,8 +55,6 @@ class MemGPTConversableAgent(ConversableAgent):
             raise
 
     def load(self, name: str, type: str, **kwargs):
-        raise DeprecationWarning()
-
         # call load function based on type
         if type == "directory":
             load_directory(name=name, **kwargs)
@@ -72,27 +70,17 @@ class MemGPTConversableAgent(ConversableAgent):
             raise ValueError(f"Invalid data source type {type}")
 
     def attach(self, data_source: str):
-        raise DeprecationWarning()
-
         # attach new data
-        attach(self.agent.config.name, data_source)
-
-        # update agent config
-        self.agent.config.attach_data_source(data_source)
-
-        # reload agent with new data source
-        # TODO: @charles we will need to pass in the MemGPT config here to get the DB URIs (not contained in agent)
-        self.agent.persistence_manager.archival_memory.storage = StorageConnector.get_archival_storage_connector(
-            agent_config=self.agent.config
-        )
+        attach(agent=self.agent.agent_state.name, data_source=data_source)
 
     def load_and_attach(self, name: str, type: str, force=False, **kwargs):
-        raise DeprecationWarning()
-
         # check if data source already exists
-        data_sources = StorageConnector.get_metadata_storage_connector(TableType.DATA_SOURCES).get_all()
-        data_sources = [source.name for source in data_sources]
-        if name in data_sources and not force:
+        config = MemGPTConfig.load()
+        ms = MetadataStore(config)
+        data_source_options = ms.list_sources(user_id=self.agent.agent_state.user_id)
+        data_source_options = [s.name for s in data_source_options]
+
+        if name in data_source_options and not force:
             print(f"Data source {name} already exists. Use force=True to overwrite.")
             self.attach(name)
         else:

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -80,6 +80,8 @@ class MemGPTConversableAgent(ConversableAgent):
         data_source_options = ms.list_sources(user_id=self.agent.agent_state.user_id)
         data_source_options = [s.name for s in data_source_options]
 
+        kwargs["user_id"] = self.agent.agent_state.user_id
+
         if name in data_source_options and not force:
             print(f"Data source {name} already exists. Use force=True to overwrite.")
             self.attach(name)

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -73,7 +73,7 @@ class MemGPTConversableAgent(ConversableAgent):
 
     def attach(self, data_source: str):
         # attach new data
-        attach(agent=self.agent.agent_state.name, data_source=data_source)
+        attach(agent_name=self.agent.agent_state.name, data_source=data_source)
 
     def load_and_attach(self, name: str, type: str, force=False, **kwargs):
         # check if data source already exists

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -679,7 +679,7 @@ def delete_agent(
 
     try:
         ms.delete_agent(agent_id=agent.id)
-        typer.secho(f"🕊️🪦 Successfully deleted agent '{agent_name}' (id={agent.id})", fg=typer.colors.GREEN)
+        typer.secho(f"🕊️ Successfully deleted agent '{agent_name}' (id={agent.id})", fg=typer.colors.GREEN)
     except Exception as e:
         typer.secho(f"Failed to delete agent '{agent_name}' (id={agent.id})", fg=typer.colors.RED)
         sys.exit(1)

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -120,7 +120,6 @@ def run_agent_loop(memgpt_agent, config: MemGPTConfig, first, ms: MetadataStore,
                     # TODO: alternatively, only list sources with compatible embeddings, and print warning about non-compatible sources
 
                     data_source_options = ms.list_sources(user_id=memgpt_agent.agent_state.user_id)
-                    data_source_options = [s.name for s in data_source_options]
                     if len(data_source_options) == 0:
                         typer.secho(
                             'No sources available. You must load a souce with "memgpt load ..." before running /attach.',
@@ -133,7 +132,10 @@ def run_agent_loop(memgpt_agent, config: MemGPTConfig, first, ms: MetadataStore,
                     valid_options = []
                     invalid_options = []
                     for source in data_source_options:
-                        if source.embedding_model == memgpt_agent.embedding_model and source.embedding_dim == memgpt_agent.embedding_dim:
+                        if (
+                            source.embedding_model == memgpt_agent.agent_state.embedding_config.embedding_model
+                            and source.embedding_dim == memgpt_agent.agent_state.embedding_config.embedding_dim
+                        ):
                             valid_options.append(source.name)
                         else:
                             invalid_options.append(source.name)
@@ -148,7 +150,7 @@ def run_agent_loop(memgpt_agent, config: MemGPTConfig, first, ms: MetadataStore,
                     data_source = questionary.select("Select data source", choices=valid_options).ask()
 
                     # attach new data
-                    attach(memgpt_agent.config.name, data_source)
+                    attach(memgpt_agent.agent_state.name, data_source)
 
                     continue
 

--- a/memgpt/presets/presets.py
+++ b/memgpt/presets/presets.py
@@ -11,7 +11,7 @@ preset_options = list(available_presets.keys())
 
 
 # def create_agent_from_preset(preset_name, agent_config, model, persona, human, interface, persistence_manager):
-def create_agent_from_preset(agent_state: AgentState, interface: AgentInterface):
+def create_agent_from_preset(agent_state: AgentState, interface: AgentInterface, persona_is_file: bool = True, human_is_file: bool = True):
     """Initialize a new agent from a preset (combination of system + function)"""
 
     # Input validation
@@ -25,8 +25,8 @@ def create_agent_from_preset(agent_state: AgentState, interface: AgentInterface)
         raise ValueError(f"'state' must be uninitialized (empty)")
 
     preset_name = agent_state.preset
-    persona_file = agent_state.persona
-    human_file = agent_state.human
+    persona = agent_state.persona
+    human = agent_state.human
     model = agent_state.llm_config.model
 
     from memgpt.agent import Agent
@@ -67,8 +67,8 @@ def create_agent_from_preset(agent_state: AgentState, interface: AgentInterface)
     #   functions: dict,  # schema definitions ONLY (function code linked at runtime)
     #   messages: List[dict],  # in-context messages
     agent_state.state = {
-        "persona": get_persona_text(persona_file),
-        "human": get_human_text(human_file),
+        "persona": get_persona_text(persona) if persona_is_file else persona,
+        "human": get_human_text(human) if human_is_file else human,
         "system": gpt_system.get_system_text(preset_system_prompt),
         "functions": preset_function_set_schemas,
         "messages": None,

--- a/tests/test_load_archival.py
+++ b/tests/test_load_archival.py
@@ -165,7 +165,7 @@ def test_load_directory(metadata_storage_connector, passage_storage_connector, c
 
     # attach data
     print("Attaching data...")
-    attach(agent=agent.name, data_source=name, user_id=user_id)
+    attach(agent_name=agent.name, data_source=name, user_id=user_id)
 
     # test to see if contained in storage
     assert len(passages) == conn.size()


### PR DESCRIPTION
- [x] Refactor base integration code to patch for `pymemgpt` 0.2.12
- [x] Add save + load
  - Update documentation to demonstrate save/load
- [x] Update examples / confirm they're working
   - Moved groupchat examples to round_robin, see: https://github.com/microsoft/autogen/issues/842
- [x] Update notebook (won't make a difference until release is tagged, since notebook pulled from `pip`)
- [x] Update documentation
~~- [ ] Bump `pyautogen` version to latest stable~~

---

Misc fixes:

- Patches the "OPENAI_API_KEY" required error by passing a `False` `llm_config` in the `ConversibleAgent` super init