### PR TITLE
fix: out-of-order user message timestamp

### DIFF
--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -20,37 +20,13 @@ from memgpt.metadata import MetadataStore, save_agent
 import memgpt.presets.presets as presets
 import memgpt.utils as utils
 import memgpt.server.utils as server_utils
-from memgpt.persistence_manager import PersistenceManager, LocalStateManager
 from memgpt.data_types import (
-    Source,
-    Passage,
-    Document,
     User,
     AgentState,
     LLMConfig,
     EmbeddingConfig,
-    Message,
-    ToolCall,
-    LLMConfig,
-    EmbeddingConfig,
-    Message,
-    ToolCall,
 )
-from memgpt.data_types import (
-    Source,
-    Passage,
-    Document,
-    User,
-    AgentState,
-    LLMConfig,
-    EmbeddingConfig,
-    Message,
-    ToolCall,
-    LLMConfig,
-    EmbeddingConfig,
-    Message,
-    ToolCall,
-)
+
 
 # TODO use custom interface
 from memgpt.interface import CLIInterface  # for printing to terminal


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Previously the incoming user message in `step` was getting turned into a `Message` after the handling of the agent response, which cause the timestamp to be out of order:

![image](https://github.com/cpacker/MemGPT/assets/5475622/92d7fef1-200e-4760-995b-9ca4d8e640bf)