### PR TITLE
fix: use `utf-8` encodings for all text files

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -160,7 +160,7 @@ def quickstart(
                 script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
                 backup_config_path = os.path.join(script_dir, "..", "configs", "memgpt_hosted.json")
                 try:
-                    with open(backup_config_path, "r") as file:
+                    with open(backup_config_path, "r", encoding="utf-8") as file:
                         backup_config = json.load(file)
                     printd("Loaded backup config file successfully.")
                     config_was_modified = set_config_with_dict(backup_config)
@@ -172,7 +172,7 @@ def quickstart(
             script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
             backup_config_path = os.path.join(script_dir, "..", "configs", "memgpt_hosted.json")
             try:
-                with open(backup_config_path, "r") as file:
+                with open(backup_config_path, "r", encoding="utf-8") as file:
                     backup_config = json.load(file)
                 printd("Loaded config file successfully.")
                 config_was_modified = set_config_with_dict(backup_config)
@@ -209,7 +209,7 @@ def quickstart(
                 script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
                 backup_config_path = os.path.join(script_dir, "..", "configs", "openai.json")
                 try:
-                    with open(backup_config_path, "r") as file:
+                    with open(backup_config_path, "r", encoding="utf-8") as file:
                         backup_config = json.load(file)
                     printd("Loaded backup config file successfully.")
                     config_was_modified = set_config_with_dict(backup_config)
@@ -221,7 +221,7 @@ def quickstart(
             script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
             backup_config_path = os.path.join(script_dir, "..", "configs", "openai.json")
             try:
-                with open(backup_config_path, "r") as file:
+                with open(backup_config_path, "r", encoding="utf-8") as file:
                     backup_config = json.load(file)
                 printd("Loaded config file successfully.")
                 config_was_modified = set_config_with_dict(backup_config)

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -761,7 +761,7 @@ def add(
     if text:
         assert filename is None, f"Cannot provide both filename and text"
         # write text to file
-        with open(os.path.join(directory, name), "w") as f:
+        with open(os.path.join(directory, name), "w", encoding="utf-8") as f:
             f.write(text)
 
 

--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -239,7 +239,7 @@ class MemGPTConfig:
         # always make sure all directories are present
         self.create_config_dir()
 
-        with open(self.config_path, "w") as f:
+        with open(self.config_path, "w", encoding="utf-8") as f:
             config.write(f)
         logger.debug(f"Saved Config:  {self.config_path}")
 
@@ -374,7 +374,7 @@ class AgentConfig:
         os.makedirs(os.path.join(MEMGPT_DIR, "agents", self.name), exist_ok=True)
         # save version
         self.memgpt_version = memgpt.__version__
-        with open(self.agent_config_path, "w") as f:
+        with open(self.agent_config_path, "w", encoding="utf-8") as f:
             json.dump(vars(self), f, indent=4)
 
     def to_agent_state(self):
@@ -399,7 +399,7 @@ class AgentConfig:
         """Load agent config from JSON file"""
         agent_config_path = os.path.join(MEMGPT_DIR, "agents", name, "config.json")
         assert os.path.exists(agent_config_path), f"Agent config file does not exist at {agent_config_path}"
-        with open(agent_config_path, "r") as f:
+        with open(agent_config_path, "r", encoding="utf-8") as f:
             agent_config = json.load(f)
         # allow compatibility accross versions
         try:

--- a/memgpt/credentials.py
+++ b/memgpt/credentials.py
@@ -103,7 +103,7 @@ class MemGPTCredentials:
 
         if not os.path.exists(MEMGPT_DIR):
             os.makedirs(MEMGPT_DIR, exist_ok=True)
-        with open(self.credentials_path, "w") as f:
+        with open(self.credentials_path, "w", encoding="utf-8") as f:
             config.write(f)
 
     @staticmethod

--- a/memgpt/functions/function_sets/extras.py
+++ b/memgpt/functions/function_sets/extras.py
@@ -60,7 +60,7 @@ def read_from_text_file(self, filename: str, line_start: int, num_lines: Optiona
 
     lines = []
     chars_read = 0
-    with open(filename, "r") as file:
+    with open(filename, "r", encoding="utf-8") as file:
         for current_line_number, line in enumerate(file, start=1):
             if line_start <= current_line_number < line_start + num_lines:
                 chars_to_add = len(line)
@@ -94,7 +94,7 @@ def append_to_text_file(self, filename: str, content: str):
     if not os.path.exists(filename):
         raise FileNotFoundError(f"The file '{filename}' does not exist.")
 
-    with open(filename, "a") as file:
+    with open(filename, "a", encoding="utf-8") as file:
         file.write(content + "\n")
 
 

--- a/memgpt/local_llm/grammars/gbnf_grammar_generator.py
+++ b/memgpt/local_llm/grammars/gbnf_grammar_generator.py
@@ -980,14 +980,14 @@ def save_gbnf_grammar_and_documentation(
         None
     """
     try:
-        with open(grammar_file_path, "w") as file:
+        with open(grammar_file_path, "w", encoding="utf-8") as file:
             file.write(grammar + get_primitive_grammar(grammar))
         print(f"Grammar successfully saved to {grammar_file_path}")
     except IOError as e:
         print(f"An error occurred while saving the grammar file: {e}")
 
     try:
-        with open(documentation_file_path, "w") as file:
+        with open(documentation_file_path, "w", encoding="utf-8") as file:
             file.write(documentation)
         print(f"Documentation successfully saved to {documentation_file_path}")
     except IOError as e:

--- a/memgpt/local_llm/settings/settings.py
+++ b/memgpt/local_llm/settings/settings.py
@@ -62,7 +62,7 @@ def get_completions_settings(defaults="simple") -> dict:
         printd(f"No completion settings file '{settings_file}', skipping...")
         # Create the file settings_file to make it easy for the user to edit
         try:
-            with open(settings_file, "w") as file:
+            with open(settings_file, "w", encoding="utf-8") as file:
                 # We don't want to dump existing default settings in case we modify
                 # the default settings in the future
                 # json.dump(settings, file, indent=4)

--- a/memgpt/local_llm/settings/settings.py
+++ b/memgpt/local_llm/settings/settings.py
@@ -44,7 +44,7 @@ def get_completions_settings(defaults="simple") -> dict:
         # Load into a dict called "settings"
         printd(f"Found completion settings file '{settings_file}', loading it...")
         try:
-            with open(settings_file, "r") as file:
+            with open(settings_file, "r", encoding="utf-8") as file:
                 user_settings = json.load(file)
             if len(user_settings) > 0:
                 printd(

--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -62,7 +62,7 @@ def load_grammar_file(grammar):
         # If the file doesn't exist, raise a FileNotFoundError
         raise FileNotFoundError(f"The grammar file {grammar_file} does not exist.")
 
-    with open(grammar_file, "r") as file:
+    with open(grammar_file, "r", encoding="utf-8") as file:
         grammar_str = file.read()
 
     return grammar_str

--- a/memgpt/migrate.py
+++ b/memgpt/migrate.py
@@ -113,7 +113,7 @@ def agent_is_migrateable(agent_name: str, data_dir: str = MEMGPT_DIR) -> bool:
         raise ValueError(f"Agent folder {agent_folder} does not have a config file")
 
     try:
-        with open(agent_config_file, "r") as fh:
+        with open(agent_config_file, "r", encoding="utf-8") as fh:
             agent_config = json.load(fh)
     except Exception as e:
         raise ValueError(f"Failed to load agent config file ({agent_config_file}), error = {e}")
@@ -265,7 +265,7 @@ def migrate_agent(agent_name: str, data_dir: str = MEMGPT_DIR, ms: Optional[Meta
     # manager.recall_memory = data["recall_memory"]
 
     agent_config_filename = os.path.join(agent_folder, "config.json")
-    with open(agent_config_filename, "r") as fh:
+    with open(agent_config_filename, "r", encoding="utf-8") as fh:
         agent_config = json.load(fh)
 
     # 2. Create a new AgentState using the agent config + agent internal state

--- a/memgpt/presets/utils.py
+++ b/memgpt/presets/utils.py
@@ -36,7 +36,7 @@ def load_yaml_file(file_path):
     :param file_path: Path to the YAML file.
     :return: Data from the YAML file.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)
 
 

--- a/memgpt/prompts/gpt_system.py
+++ b/memgpt/prompts/gpt_system.py
@@ -9,7 +9,7 @@ def get_system_text(key):
 
     # first look in prompts/system/*.txt
     if os.path.exists(file_path):
-        with open(file_path, "r") as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return file.read().strip()
     else:
         # try looking in ~/.memgpt/system_prompts/*.txt
@@ -20,7 +20,7 @@ def get_system_text(key):
         # look inside for a matching system prompt
         file_path = os.path.join(user_system_prompts_dir, filename)
         if os.path.exists(file_path):
-            with open(file_path, "r") as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 return file.read().strip()
         else:
             raise FileNotFoundError(f"No file found for key {key}, path={file_path}")

--- a/tests/test_agent_function_update.py
+++ b/tests/test_agent_function_update.py
@@ -56,7 +56,7 @@ def agent():
 
 @pytest.fixture(scope="module")
 def hello_world_function():
-    with open(os.path.join(USER_FUNCTIONS_DIR, "hello_world.py"), "w") as f:
+    with open(os.path.join(USER_FUNCTIONS_DIR, "hello_world.py"), "w", encoding="utf-8") as f:
         f.write(inspect.getsource(hello_world))
 
 


### PR DESCRIPTION
> The necessity to specify encoding="utf-8" in your open function calls largely depends on the environment in which your code is running. In Python, when opening a file for reading or writing, the default encoding used is platform dependent. For instance:
> 
> On Linux and macOS, the default encoding is typically UTF-8.
> On Windows, it's usually not UTF-8 (more commonly CP1252 or a similar Windows-specific encoding).
> If your code is expected to run in different environments, or if the files you are working with are explicitly encoded in UTF-8, it's a good practice to specify encoding="utf-8" in your open calls. This ensures consistency across different platforms and avoids potential issues with character encoding, especially when dealing with non-ASCII characters.
> 
> In summary, for both reading and writing configuration files, it's a good practice to explicitly set encoding="utf-8". This approach promotes consistency, portability, and reduces the risk of encountering encoding-related errors.