### PR TITLE
fix: Resolved a TypeError preventing documents from loading into storage

### DIFF
--- a/memgpt/embeddings.py
+++ b/memgpt/embeddings.py
@@ -16,6 +16,12 @@ from llama_index.embeddings.huggingface_utils import format_text
 import tiktoken
 
 
+def truncate_text(text: str, max_length: int, encoding) -> str:
+    # truncate the text based on max_length and encoding
+    encoded_text = encoding.encode(text)[:max_length]
+    return encoding.decode(encoded_text)
+
+
 def check_and_split_text(text: str, embedding_model: str) -> List[str]:
     """Split text into chunks of max_length tokens or less"""
 
@@ -38,9 +44,11 @@ def check_and_split_text(text: str, embedding_model: str) -> List[str]:
 
     # truncate text if too long
     if num_tokens > max_length:
-        # TODO: split this into two pieces of text instead of truncating
         print(f"Warning: text is too long ({num_tokens} tokens), truncating to {max_length} tokens.")
-        text = format_text(text, embedding_model, max_length=max_length)
+        # First, apply any necessary formatting
+        formatted_text = format_text(text, embedding_model)
+        # Then truncate
+        text = truncate_text(formatted_text, max_length, encoding)
 
     return [text]
 


### PR DESCRIPTION
1. Resolved a TypeError preventing documents from loading into storage and added a function to truncate text

**Please describe the purpose of this pull request.**
This is a fix to a bug. An error was thrown because max_length was expected in the huggingfaceutils format_text function, causing this functionality to break. I modified the code to correctly truncate and format the text, allowing documents to load into storage correctly.

**How to test**
I tested this by using `memgpt load directory`.

**Have you tested this PR?**
Yes:

![image](https://github.com/cpacker/MemGPT/assets/17145951/574965fe-4ce3-4b1c-b6b7-b3ba808914aa)


**Related issues or PRs**
No related issues that I can see.

**Is your PR over 500 lines of code?**
No.
