### PR TITLE
fix: Enhancements in CommonVector and test_server for Handling Data

### DIFF
--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -52,9 +52,6 @@ class CommonUUID(TypeDecorator):
             return uuid.UUID(value)
 
 
-import base64
-
-
 class CommonVector(TypeDecorator):
     """Common type for representing vectors in SQLite"""
 

--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -1,4 +1,5 @@
 import os
+import base64
 from sqlalchemy import create_engine, Column, String, BIGINT, select, inspect, text, JSON, BLOB, BINARY, ARRAY, DateTime
 from sqlalchemy import func, or_, and_
 from sqlalchemy import desc, asc

--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -51,7 +51,9 @@ class CommonUUID(TypeDecorator):
         else:
             return uuid.UUID(value)
 
+
 import base64
+
 
 class CommonVector(TypeDecorator):
     """Common type for representing vectors in SQLite"""
@@ -75,7 +77,7 @@ class CommonVector(TypeDecorator):
         if not value:
             return value
         # Check database type and deserialize accordingly
-        if dialect.name == 'sqlite':
+        if dialect.name == "sqlite":
             # Decode from base64 and convert back to numpy array
             value = base64.b64decode(value)
         # For PostgreSQL, value is already in bytes

--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -74,12 +74,17 @@ class CommonVector(TypeDecorator):
         if not value:
             return value
 
-        if isinstance(value, str):
-            # Convert the string of floats to a numpy array
-            # Split the string by commas, convert each part to a float, and then create a numpy array
-            value = np.array([float(x) for x in value.strip("[]").split(",")])
+        # Convert value to string if it's bytes
+        if isinstance(value, bytes):
+            value = value.decode()
 
-        return value
+        # Convert string representation of list to numpy array
+        try:
+            # Remove brackets and split by comma, then convert each element to float
+            float_values = [float(x.strip()) for x in value.strip("[]").split(",")]
+            return np.array(float_values)
+        except ValueError as e:
+            raise ValueError(f"Could not convert database value to numpy array: {e}")
 
 
 # Custom serialization / de-serialization for JSON columns

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -208,8 +208,11 @@ class MetadataStore:
         else:
             raise ValueError(f"Invalid metadata storage type: {config.metadata_storage_type}")
 
-        # TODO: check to see if table(s) need to be greated or not
+        # Ensure valid URI
+        if not self.uri:
+            raise ValueError("Database URI is not provided or is invalid.")
 
+        # Check if tables need to be created
         self.engine = create_engine(self.uri)
         Base.metadata.create_all(
             self.engine, tables=[UserModel.__table__, AgentModel.__table__, SourceModel.__table__, AgentSourceMappingModel.__table__]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import uuid
 import os
 import memgpt.utils as utils
+from dotenv import load_dotenv
 
 utils.DEBUG = True
 from memgpt.config import MemGPTConfig
@@ -12,13 +13,17 @@ from .utils import wipe_config, wipe_memgpt_home
 
 
 def test_server():
+    load_dotenv()
     wipe_memgpt_home()
+    
+    # Use os.getenv with a fallback to os.environ.get
+    db_url = os.getenv("PGVECTOR_TEST_DB_URL") or os.environ.get("PGVECTOR_TEST_DB_URL")
 
     if os.getenv("OPENAI_API_KEY"):
         config = MemGPTConfig(
-            archival_storage_uri=os.getenv("PGVECTOR_TEST_DB_URL"),
-            recall_storage_uri=os.getenv("PGVECTOR_TEST_DB_URL"),
-            metadata_storage_uri=os.getenv("PGVECTOR_TEST_DB_URL"),
+            archival_storage_uri=db_url,
+            recall_storage_uri=db_url,
+            metadata_storage_uri=db_url,
             archival_storage_type="postgres",
             recall_storage_type="postgres",
             metadata_storage_type="postgres",
@@ -40,9 +45,9 @@ def test_server():
         )
     else:  # hosted
         config = MemGPTConfig(
-            archival_storage_uri=os.getenv("PGVECTOR_TEST_DB_URL"),
-            recall_storage_uri=os.getenv("PGVECTOR_TEST_DB_URL"),
-            metadata_storage_uri=os.getenv("PGVECTOR_TEST_DB_URL"),
+            archival_storage_uri=db_url,
+            recall_storage_uri=db_url,
+            metadata_storage_uri=db_url,
             archival_storage_type="postgres",
             recall_storage_type="postgres",
             metadata_storage_type="postgres",
@@ -61,6 +66,7 @@ def test_server():
             ),
         )
         credentials = MemGPTCredentials()
+
     config.save()
     credentials.save()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,7 @@ from .utils import wipe_config, wipe_memgpt_home
 def test_server():
     load_dotenv()
     wipe_memgpt_home()
-    
+
     # Use os.getenv with a fallback to os.environ.get
     db_url = os.getenv("PGVECTOR_TEST_DB_URL") or os.environ.get("PGVECTOR_TEST_DB_URL")
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR updates the `CommonVector` class in the `memgpt/agent_store/db.py` module to handle vector data serialization and deserialization in a way that is compatible with both SQLite and PostgreSQL databases. It also refines the `test_server` function in `tests/test_server.py` for improved environment variable management. These changes address issues where pytests were failing due to type incompatibilities in different database environments.

Principle Changes:
* Enhanced `process_bind_param` and `process_result_value` in `CommonVector` to support cross-database compatibility. Embeddings are now serialized to base64 strings, ensuring uniform handling in SQLite and PostgreSQL.
* Introduced conditional logic in `process_result_value` to correctly process data based on the database type.
* Added a fallback mechanism for environment variable retrieval in the `test_server` function to facilitate the use of a .env file.

**How to test**
1. Execute unit tests to confirm no regressions have been introduced.
2. Perform manual testing with `memgpt` under various configurations, particularly testing the archival and retrieval of data in both SQLite and PostgreSQL databases.

**Have you tested this PR?**
Yes, the changes have been thoroughly tested. All unit tests pass successfully, and manual testing confirms the functionality of data handling across different database systems.

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
No, it is under 500 lines.

**Additional context**

Pytest results after changes:
![image](https://github.com/cpacker/MemGPT/assets/17145951/a20c4fa7-bcab-49a2-8e1e-fe83d9aa698b)
