### PR TITLE
ci: disable workflows on external

### DIFF
--- a/.github/workflows/rdme-docs.yml
+++ b/.github/workflows/rdme-docs.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
+        if: github.repository == 'cpacker/MemGPT'  # TODO: if the repo org ever changes, this must be updated
         uses: actions/checkout@v4
 
       - name: Run `docs` command 🚀

--- a/.github/workflows/rdme-docs.yml
+++ b/.github/workflows/rdme-docs.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   rdme-docs:
     runs-on: ubuntu-latest
+    if: github.repository == 'cpacker/MemGPT'  # TODO: if the repo org ever changes, this must be updated
     steps:
       - name: Check out repo 📚
-        if: github.repository == 'cpacker/MemGPT'  # TODO: if the repo org ever changes, this must be updated
         uses: actions/checkout@v4
 
       - name: Run `docs` command 🚀

--- a/.github/workflows/rdme-openapi.yml
+++ b/.github/workflows/rdme-openapi.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
+        if: github.repository == 'cpacker/MemGPT' # TODO: if the repo org ever changes, this must be updated
         uses: actions/checkout@v4
 
       - name: "Setup Python, Poetry and Dependencies"

--- a/.github/workflows/rdme-openapi.yml
+++ b/.github/workflows/rdme-openapi.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   rdme-openapi:
     runs-on: ubuntu-latest
+    if: github.repository == 'cpacker/MemGPT'  # TODO: if the repo org ever changes, this must be updated
     steps:
       - name: Check out repo 📚
-        if: github.repository == 'cpacker/MemGPT' # TODO: if the repo org ever changes, this must be updated
         uses: actions/checkout@v4
 
       - name: "Setup Python, Poetry and Dependencies"


### PR DESCRIPTION
Disabling readme.io workflows from running on forks, which fails commits on `main`. Extension of #924.