### PR TITLE
fix: patch `tool_call` bug in summarizer

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -701,14 +701,14 @@ class Agent(object):
             candidate_messages_to_summarize = candidate_messages_to_summarize[:-MESSAGE_SUMMARY_TRUNC_KEEP_N_LAST]
             token_counts = token_counts[:-MESSAGE_SUMMARY_TRUNC_KEEP_N_LAST]
 
-        if disallow_tool_as_first:
-            # We have to make sure that a "tool" call is not sitting at the front (after system message),
-            # otherwise we'll get an error from OpenAI (if using the OpenAI API)
-            while len(candidate_messages_to_summarize) > 0:
-                if candidate_messages_to_summarize[0]['role'] == 'tool':
-                    candidate_messages_to_summarize.pop(0)
-                else:
-                    break
+        # if disallow_tool_as_first:
+        #     # We have to make sure that a "tool" call is not sitting at the front (after system message),
+        #     # otherwise we'll get an error from OpenAI (if using the OpenAI API)
+        #     while len(candidate_messages_to_summarize) > 0:
+        #         if candidate_messages_to_summarize[0]["role"] in ["tool", "function"]:
+        #             candidate_messages_to_summarize.pop(0)
+        #         else:
+        #             break
 
         printd(f"MESSAGE_SUMMARY_TRUNC_TOKEN_FRAC={MESSAGE_SUMMARY_TRUNC_TOKEN_FRAC}")
         printd(f"MESSAGE_SUMMARY_TRUNC_KEEP_N_LAST={MESSAGE_SUMMARY_TRUNC_KEEP_N_LAST}")
@@ -745,8 +745,14 @@ class Agent(object):
         except IndexError:
             pass
 
+        # Make sure the cutoff isn't on a 'tool' or 'function'
+        if disallow_tool_as_first:
+            while self.messages[cutoff]["role"] in ["tool", "function"] and cutoff < len(self.messages):
+                printd(f"Selected cutoff {cutoff} was a 'tool', shifting one...")
+                cutoff += 1
+
         message_sequence_to_summarize = self.messages[1:cutoff]  # do NOT get rid of the system message
-        if len(message_sequence_to_summarize) == 1:
+        if len(message_sequence_to_summarize) <= 1:
             # This prevents a potential infinite loop of summarizing the same message over and over
             raise LLMError(
                 f"Summarize error: tried to run summarize, but couldn't find enough messages to compress [len={len(message_sequence_to_summarize)} <= 1]"

--- a/memgpt/interface.py
+++ b/memgpt/interface.py
@@ -253,11 +253,20 @@ class CLIInterface(AgentInterface):
                     args = json.loads(msg["function_call"].get("arguments"))
                     CLIInterface.assistant_message(args.get("message"))
                     # assistant_message(content)
+                elif msg.get("tool_calls"):
+                    if content is not None:
+                        CLIInterface.internal_monologue(content)
+                    function_obj = msg["tool_calls"][0].get("function")
+                    if function_obj:
+                        args = json.loads(function_obj.get("arguments"))
+                        CLIInterface.assistant_message(args.get("message"))
                 else:
                     CLIInterface.internal_monologue(content)
             elif role == "user":
                 CLIInterface.user_message(content, dump=dump)
             elif role == "function":
+                CLIInterface.function_message(content, debug=dump)
+            elif role == "tool":
                 CLIInterface.function_message(content, debug=dump)
             else:
                 print(f"Unknown role: {content}")


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- OpenAI will throw an invalid request error if a tool call (`role == 'tool'`) message  does not have a message preceding it with the tool call (`len(tool_calls) > 0`)
- When the summarizer runs, it may truncate the messages such that the order of the first three messages is `system -> user (summary) -> tool response`
- This PR adds an additional constraint to the `summarize_messages_inplace` function that makes sure the a message with `role == 'tool'` cannot be at the front of the message buffer before dispatching to the summarizer (or writing out the new truncated message list