### PR TITLE
fix:  Fix Misplaced Else Statement and Correct If Condition Handling in set_config_with_dict()

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -79,8 +79,8 @@ def set_config_with_dict(new_config: dict) -> bool:
                 modified = True
                 # old_config[k] = new_config[k]
                 setattr(old_config.default_embedding_config, k, new_config[k])
-        else:
-            printd(f"Skipping new config {k}: {v} == {new_config[k]}")
+            else:
+                printd(f"Skipping new config {k}: {v} == {new_config[k]}")
 
     # update llm config
     for k, v in vars(old_config.default_llm_config).items():
@@ -90,8 +90,8 @@ def set_config_with_dict(new_config: dict) -> bool:
                 modified = True
                 # old_config[k] = new_config[k]
                 setattr(old_config.default_llm_config, k, new_config[k])
-        else:
-            printd(f"Skipping new config {k}: {v} == {new_config[k]}")
+            else:
+                printd(f"Skipping new config {k}: {v} == {new_config[k]}")
 
     if modified:
         printd(f"Saving new config file.")


### PR DESCRIPTION
**Purpose:**
This pull request addresses the issue of misplaced else statement and incorrect if condition handling equal values in the set_config_with_dict() function.

**How to Test:**
1. Run the affected function `set_config_with_dict(new_config: dict)` with a test dictionary containing both matching and differing values.
2. Check the console output for logging messages regarding the replacement or skipping of configuration values.
3. Ensure that the configuration file is saved correctly with modified values when applicable.

**Testing Status:**
Yes, the latest commit on this PR has been tested. Output from test runs:
- [Describe outputs or results from tests]

**Related Issues or PRs:**
No related issues or PRs at the moment.

**Is the PR over 500 lines of code?**
No, this PR is not over 500 lines of code.

**Additional Context:**
This PR aims to improve the clarity and correctness of the codebase by fixing the logic for handling configuration updates in the set_config_with_dict() function.