### PR TITLE
fix: patch mem lim exceeded

### DIFF
--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -60,8 +60,8 @@ def get_chat_completion(
     global has_shown_warning
     grammar = None
 
-    if function_call != "auto":
-        raise ValueError(f"function_call == {function_call} not supported (auto only)")
+    if function_call is not None and function_call != "auto":
+        raise ValueError(f"function_call == {function_call} not supported (auto or None only)")
 
     available_wrappers = get_available_wrappers()
     documentation = None

--- a/memgpt/persistence_manager.py
+++ b/memgpt/persistence_manager.py
@@ -51,11 +51,11 @@ class LocalStateManager(PersistenceManager):
     def __init__(self, agent_state: AgentState):
         # Memory held in-state useful for debugging stateful versions
         self.memory = None
-        self.messages = []  # current in-context messages
+        # self.messages = []  # current in-context messages
         # self.all_messages = [] # all messages seen in current session (needed if lazily synchronizing state with DB)
         self.archival_memory = EmbeddingArchivalMemory(agent_state)
         self.recall_memory = BaseRecallMemory(agent_state)
-        self.agent_state = agent_state
+        # self.agent_state = agent_state
 
     def save(self):
         """Ensure storage connectors save data"""
@@ -66,7 +66,7 @@ class LocalStateManager(PersistenceManager):
         """Connect persistent state manager to agent"""
         printd(f"Initializing {self.__class__.__name__} with agent object")
         # self.all_messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
-        self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
+        # self.messages = [{"timestamp": get_local_time(), "message": msg} for msg in agent.messages.copy()]
         self.memory = agent.memory
         # printd(f"{self.__class__.__name__}.all_messages.len = {len(self.all_messages)}")
         printd(f"{self.__class__.__name__}.messages.len = {len(self.messages)}")
@@ -122,14 +122,15 @@ class LocalStateManager(PersistenceManager):
 
     def trim_messages(self, num):
         # printd(f"InMemoryStateManager.trim_messages")
-        self.messages = [self.messages[0]] + self.messages[num:]
+        # self.messages = [self.messages[0]] + self.messages[num:]
+        pass
 
     def prepend_to_messages(self, added_messages: List[Message]):
         # first tag with timestamps
         # added_messages = [{"timestamp": get_local_time(), "message": msg} for msg in added_messages]
 
         printd(f"{self.__class__.__name__}.prepend_to_message")
-        self.messages = [self.messages[0]] + added_messages + self.messages[1:]
+        # self.messages = [self.messages[0]] + added_messages + self.messages[1:]
 
         # add to recall memory
         self.recall_memory.insert_many([m for m in added_messages])
@@ -139,7 +140,7 @@ class LocalStateManager(PersistenceManager):
         # added_messages = [{"timestamp": get_local_time(), "message": msg} for msg in added_messages]
 
         printd(f"{self.__class__.__name__}.append_to_messages")
-        self.messages = self.messages + added_messages
+        # self.messages = self.messages + added_messages
 
         # add to recall memory
         self.recall_memory.insert_many([m for m in added_messages])
@@ -149,7 +150,7 @@ class LocalStateManager(PersistenceManager):
         # new_system_message = {"timestamp": get_local_time(), "message": new_system_message}
 
         printd(f"{self.__class__.__name__}.swap_system_message")
-        self.messages[0] = new_system_message
+        # self.messages[0] = new_system_message
 
         # add to recall memory
         self.recall_memory.insert(new_system_message)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,0 +1,67 @@
+import os
+import uuid
+
+from memgpt import MemGPT
+from memgpt.config import MemGPTConfig
+from memgpt import constants
+import memgpt.functions.function_sets.base as base_functions
+from .utils import wipe_config
+
+
+# test_agent_id = "test_agent"
+client = None
+agent_obj = None
+
+
+def create_test_agent():
+    """Create a test agent that we can call functions on"""
+    wipe_config()
+    global client
+    if os.getenv("OPENAI_API_KEY"):
+        client = MemGPT(quickstart="openai")
+    else:
+        client = MemGPT(quickstart="memgpt_hosted")
+
+    agent_state = client.create_agent(
+        agent_config={
+            # "name": test_agent_id,
+            "persona": constants.DEFAULT_PERSONA,
+            "human": constants.DEFAULT_HUMAN,
+        }
+    )
+
+    global agent_obj
+    config = MemGPTConfig.load()
+    user_id = uuid.UUID(config.anon_clientid)
+    agent_obj = client.server._get_or_load_agent(user_id=user_id, agent_id=agent_state.id)
+
+
+def test_summarize():
+    """Test summarization via sending the summarize CLI command or via a direct call to the agent object"""
+    assert agent_obj is not None, "Run create_agent test first"
+    assert client is not None, "Run create_agent test first"
+
+    # First send a few messages (5)
+    response = client.user_message(
+        agent_id=agent_obj.agent_state.id, message="Hey, how's it going? What do you think about this whole shindig"
+    )
+    assert response is not None and len(response) > 0
+    print(f"test_summarize: response={response}")
+
+    response = client.user_message(agent_id=agent_obj.agent_state.id, message="Any thoughts on the meaning of life?")
+    assert response is not None and len(response) > 0
+    print(f"test_summarize: response={response}")
+
+    response = client.user_message(agent_id=agent_obj.agent_state.id, message="Does the number 42 ring a bell?")
+    assert response is not None and len(response) > 0
+    print(f"test_summarize: response={response}")
+
+    response = client.user_message(
+        agent_id=agent_obj.agent_state.id, message="Would you be surprised to learn that you're actually conversing with an AI right now?"
+    )
+    assert response is not None and len(response) > 0
+    print(f"test_summarize: response={response}")
+
+    agent_obj.summarize_messages_inplace()
+    print(f"Summarization succeeded: messages[1] = \n{agent_obj.messages[1]}")
+    # response = client.run_command(agent_id=agent_obj.agent_state.id, command="summarize")

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -38,6 +38,9 @@ def create_test_agent():
 
 def test_summarize():
     """Test summarization via sending the summarize CLI command or via a direct call to the agent object"""
+    global client
+    global agent_obj
+
     if agent_obj is None:
         create_test_agent()
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -25,11 +25,12 @@ def create_test_agent():
         client = MemGPT(quickstart="memgpt_hosted")
 
     user = client.server.create_user({"id": test_user_id})
+    client.user_id = user.id
     assert user is not None
 
     agent_state = client.create_agent(
         agent_config={
-            "user_id": test_user_id,
+            "user_id": user.id,
             "name": test_agent_name,
             "persona": constants.DEFAULT_PERSONA,
             "human": constants.DEFAULT_HUMAN,

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -9,6 +9,8 @@ from .utils import wipe_config
 
 
 # test_agent_id = "test_agent"
+test_agent_name = f"test_client_{str(uuid.uuid4())}"
+test_user_id = uuid.uuid4()
 client = None
 agent_obj = None
 
@@ -22,9 +24,13 @@ def create_test_agent():
     else:
         client = MemGPT(quickstart="memgpt_hosted")
 
+    user = client.server.create_user({"id": test_user_id})
+    assert user is not None
+
     agent_state = client.create_agent(
         agent_config={
-            # "name": test_agent_id,
+            "user_id": test_user_id,
+            "name": test_agent_name,
             "persona": constants.DEFAULT_PERSONA,
             "human": constants.DEFAULT_HUMAN,
         }
@@ -32,8 +38,7 @@ def create_test_agent():
 
     global agent_obj
     config = MemGPTConfig.load()
-    user_id = uuid.UUID(config.anon_clientid)
-    agent_obj = client.server._get_or_load_agent(user_id=user_id, agent_id=agent_state.id)
+    agent_obj = client.server._get_or_load_agent(user_id=test_user_id, agent_id=agent_state.id)
 
 
 def test_summarize():

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -38,6 +38,9 @@ def create_test_agent():
 
 def test_summarize():
     """Test summarization via sending the summarize CLI command or via a direct call to the agent object"""
+    if agent_obj is None:
+        create_test_agent()
+
     assert agent_obj is not None, "Run create_agent test first"
     assert client is not None, "Run create_agent test first"
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- Fix `ValueError: function_call == None not supported (auto only)` bug (#967)
  - Solution: just allow both `None` or `auto` instead of just `auto`
- Fix issue with persistence manager's `.message` attribute not matching the agent's (at least in length) (#957)
  - Solution: remove persistence manager's `.message` attribute and associated accesses
  - It's not needed for anything anymore
  - TODO: eventually strip persistence manager class and access recall/archival directly
    - TODO since there are quite a few accesses to persistence manager that will need to be modified

**How to test**

New test `test_summarize`, run on a local machine

**Have you tested this PR?**

Yes, using LM Studio + LLM w/ 4k context
