### PR TITLE
fix: Automatically create `User` from `MemGPTConfig.anon_clientid` from client if does not exist

### DIFF
--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -73,13 +73,12 @@ class Client(object):
 
         # create user if does not exist
         ms = MetadataStore(config)
-        print("METADATA USER ID", self.user_id)
-        user = User(id=self.user_id)
-        if ms.get_user(user_id):
+        self.user = User(id=self.user_id)
+        if ms.get_user(self.user_id):
             # update user
-            ms.update_user(user)
+            ms.update_user(self.user)
         else:
-            ms.create_user(user)
+            ms.create_user(self.user)
 
         self.interface = QueuingInterface(debug=debug)
         self.server = SyncServer(default_interface=self.interface)

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -2,12 +2,13 @@ import os
 import uuid
 from typing import Dict, List, Union, Optional, Tuple
 
-from memgpt.data_types import AgentState
+from memgpt.data_types import AgentState, User
 from memgpt.cli.cli import QuickstartChoice
 from memgpt.cli.cli import set_config_with_dict, quickstart as quickstart_func, str_to_quickstart_choice
 from memgpt.config import MemGPTConfig
 from memgpt.server.rest_api.interface import QueuingInterface
 from memgpt.server.server import SyncServer
+from memgpt.metadata import MetadataStore
 
 
 class Client(object):
@@ -58,9 +59,10 @@ class Client(object):
         if config is not None:
             set_config_with_dict(config)
 
+        # determine user_id
+        config = MemGPTConfig.load()
         if user_id is None:
             # the default user_id
-            config = MemGPTConfig.load()
             self.user_id = uuid.UUID(config.anon_clientid)
         elif isinstance(user_id, str):
             self.user_id = uuid.UUID(user_id)
@@ -68,6 +70,17 @@ class Client(object):
             self.user_id = user_id
         else:
             raise TypeError(user_id)
+
+        # create user if does not exist
+        ms = MetadataStore(config)
+        print("METADATA USER ID", self.user_id)
+        user = User(id=self.user_id)
+        if ms.get_user(user_id):
+            # update user
+            ms.update_user(user)
+        else:
+            ms.create_user(user)
+
         self.interface = QueuingInterface(debug=debug)
         self.server = SyncServer(default_interface=self.interface)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,6 +109,5 @@ def test_save_load():
 
 
 if __name__ == "__main__":
-    # test_create_user()
     test_create_agent()
     test_user_message()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,18 +17,6 @@ test_agent_state_post_message = None
 test_user_id = uuid.uuid4()
 
 
-# def test_create_user():
-#    wipe_config()
-#    global client
-#    if os.getenv("OPENAI_API_KEY"):
-#        client = MemGPT(quickstart="openai", user_id=test_user_id)
-#    else:
-#        client = MemGPT(quickstart="memgpt_hosted", user_id=test_user_id)
-#
-#    user = client.server.create_user({"id": test_user_id})
-#    assert user is not None
-
-
 def test_create_agent():
     wipe_config()
     global client
@@ -39,9 +27,9 @@ def test_create_agent():
 
     config = MemGPTConfig.load()
 
-    ## ensure user exists
-    # if not client.server.get_user(user_id=test_user_id):
-    #    raise ValueError("Run test_create_user first")
+    # ensure user exists
+    if not client.server.get_user(user_id=test_user_id):
+        raise ValueError("User failed to be created")
 
     global test_agent_state
     test_agent_state = client.create_agent(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,16 +17,16 @@ test_agent_state_post_message = None
 test_user_id = uuid.uuid4()
 
 
-def test_create_user():
-    wipe_config()
-    global client
-    if os.getenv("OPENAI_API_KEY"):
-        client = MemGPT(quickstart="openai", user_id=test_user_id)
-    else:
-        client = MemGPT(quickstart="memgpt_hosted", user_id=test_user_id)
-
-    user = client.server.create_user({"id": test_user_id})
-    assert user is not None
+# def test_create_user():
+#    wipe_config()
+#    global client
+#    if os.getenv("OPENAI_API_KEY"):
+#        client = MemGPT(quickstart="openai", user_id=test_user_id)
+#    else:
+#        client = MemGPT(quickstart="memgpt_hosted", user_id=test_user_id)
+#
+#    user = client.server.create_user({"id": test_user_id})
+#    assert user is not None
 
 
 def test_create_agent():
@@ -39,9 +39,9 @@ def test_create_agent():
 
     config = MemGPTConfig.load()
 
-    # ensure user exists
-    if not client.server.get_user(user_id=test_user_id):
-        raise ValueError("Run test_create_user first")
+    ## ensure user exists
+    # if not client.server.get_user(user_id=test_user_id):
+    #    raise ValueError("Run test_create_user first")
 
     global test_agent_state
     test_agent_state = client.create_agent(
@@ -121,6 +121,6 @@ def test_save_load():
 
 
 if __name__ == "__main__":
-    test_create_user()
+    # test_create_user()
     test_create_agent()
     test_user_message()

--- a/tests/test_different_embedding_size.py
+++ b/tests/test_different_embedding_size.py
@@ -51,9 +51,6 @@ def test_create_user():
     # create client
     client = MemGPT(quickstart="openai", user_id=test_user_id)
 
-    # create user
-    user = client.server.create_user({"id": test_user_id})
-
     # openai: create agent
     openai_agent = client.create_agent(
         {
@@ -66,8 +63,8 @@ def test_create_user():
     ), f"openai_agent.embedding_config.embedding_endpoint_type={openai_agent.embedding_config.embedding_endpoint_type}"
 
     # openai: add passages
-    passages, openai_embeddings = generate_passages(user, openai_agent)
-    openai_agent_run = client.server._get_or_load_agent(user_id=user.id, agent_id=openai_agent.id)
+    passages, openai_embeddings = generate_passages(client.user, openai_agent)
+    openai_agent_run = client.server._get_or_load_agent(user_id=client.user.id, agent_id=openai_agent.id)
     openai_agent_run.persistence_manager.archival_memory.storage.insert_many(passages)
 
     # hosted: create agent
@@ -89,13 +86,13 @@ def test_create_user():
     ), f"hosted_agent.embedding_config.embedding_endpoint_type={hosted_agent.embedding_config.embedding_endpoint_type}"
 
     # hosted: add passages
-    passages, hosted_embeddings = generate_passages(user, hosted_agent)
-    hosted_agent_run = client.server._get_or_load_agent(user_id=user.id, agent_id=hosted_agent.id)
+    passages, hosted_embeddings = generate_passages(client.user, hosted_agent)
+    hosted_agent_run = client.server._get_or_load_agent(user_id=client.user.id, agent_id=hosted_agent.id)
     hosted_agent_run.persistence_manager.archival_memory.storage.insert_many(passages)
 
     # test passage dimentionality
     config = MemGPTConfig.load()
-    storage = StorageConnector.get_storage_connector(TableType.PASSAGES, config, user.id)
+    storage = StorageConnector.get_storage_connector(TableType.PASSAGES, config, client.user.id)
     storage.filters = {}  # clear filters to be able to get all passages
     passages = storage.get_all()
     for passage in passages:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Currently if using the MemGPT client, if you haven't already run `memgpt configure` (which creates a `User` entry in the DB), then there will be an error. This makes it so that if a user corresponding to `config.anon_clientid` does not exist in the DB, the client will automatically create one. 

**Related issues or PRs**
https://github.com/cpacker/MemGPT/issues/948

**Is your PR over 500 lines of code?**
No
