### PR TITLE
fix: only attempt to mount static files dir (for chatUI) if already generated

### DIFF
--- a/memgpt/server/rest_api/static_files.py
+++ b/memgpt/server/rest_api/static_files.py
@@ -17,11 +17,13 @@ class SPAStaticFiles(StaticFiles):
 
 
 def mount_static_files(app: FastAPI):
-    app.mount(
-        "/",
-        SPAStaticFiles(
-            directory=os.path.join(os.getcwd(), "memgpt", "server", "static_files"),
-            html=True,
-        ),
-        name="spa-static-files",
-    )
+    static_files_path = os.path.join(os.getcwd(), "memgpt", "server", "static_files")
+    if os.path.exists(static_files_path):
+        app.mount(
+            "/",
+            SPAStaticFiles(
+                directory=static_files_path,
+                html=True,
+            ),
+            name="spa-static-files",
+        )


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- ChatUI serves static files to support web app
- However, if users grab `memgpt` via `pip install`, there's no chatui directory (not bundled atm)
- The current REST API code (run on `memgpt server`) assumes that the static dirs path already exists
  - So `memgpt server` is effectively broken in the current pip install

**Have you tested this this PR?**

Yes, this local diff on the pip install (0.3.1) fixes the problem:

```
% memgpt server
INFO:     Started server process [62156]
INFO:     Waiting for application startup.
Writing out openapi.json file
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8283 (Press CTRL+C to quit)
```