### PR TITLE
fix: allow multiple tools to be called by LLM and rewrite request

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -370,7 +370,10 @@ class Agent(object):
             if response_message.function_call:
                 raise DeprecationWarning(response_message)
             if response_message.tool_calls is not None and len(response_message.tool_calls) > 1:
-                raise NotImplementedError(f">1 tool call not supported")
+                # raise NotImplementedError(f">1 tool call not supported")
+                # TODO eventually support sequential tool calling
+                printd(f">1 tool call not supported, using index=0 only\n{response_message.tool_calls}")
+                response_message.tool_calls = [response_message.tool_calls[0]]
             assert response_message.tool_calls is not None and len(response_message.tool_calls) > 0
 
             # The content if then internal monologue, not chat


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

When using certain backends (eg OpenAI), multiple tools may be called by the LLM inference backend. Currently the main function execution loop doesn't support multiple calls per iteration (though this should be added in the future).

We currently raise an error when this happens, this PR revises the error to a debug print statement and just grabs the `tool_calls[0]` tool.
