### PR TITLE
docs: Fix client README in-depth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ agent_config = AgentConfig(
 # Create the agent according to AgentConfig we set up. If an agent with
 # the same name already exists it will simply return, unless you set
 # throw_if_exists to 'True'
-agent_id = client.create_agent(agent_config=agent_config)
+agent_state = client.create_agent(agent_config=agent_config)
 
 # Create a helper that sends a message and prints the assistant response only
 def send_message(message: str):
@@ -200,7 +200,7 @@ def send_message(message: str):
     sends a message and prints the assistant output only.
     :param message: the message to send
     """
-    response = client.user_message(agent_id=agent_id, message=message)
+    response = client.user_message(agent_id=agent_state.id, message=message)
     for r in response:
         # Can also handle other types "function_call", "function_return", "function_message"
         if "assistant_message" in r:

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ client = MemGPT(
 # In this case, assume we wrote a custom persona file "my_persona.txt", located at ~/.memgpt/personas/my_persona.txt
 # Same for a custom user file "my_user.txt", located at ~/.memgpt/humans/my_user.txt
 agent_config = AgentConfig(
-    name="CustomAgent",
-    persona="my_persona",
-    human="my_user",
+    "name": "CustomAgent",
+    "persona": "my_persona",
+    "human": "my_user",
 )
 
 # Create the agent according to AgentConfig we set up. If an agent with


### PR DESCRIPTION
the basic example was fixed but the in-depth was still using the old syntax
