### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/memgpt/__init__.py
+++ b/memgpt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 from memgpt.client.client import create_client
 from memgpt.client.admin import Admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymemgpt"
-version = "0.3.3"
+version = "0.3.4"
 packages = [
     {include = "memgpt"}
 ]


### PR DESCRIPTION
Should bump+tag after #1058 merge (can even do before, since the `AgentState.state` bug seems to already be fixed in `main`, making #1058 more of a refactor than a fix)