### PR TITLE
ci: skip autogen test if no oai secret

### DIFF
--- a/tests/test_autogen_integration.py
+++ b/tests/test_autogen_integration.py
@@ -4,7 +4,9 @@ import subprocess
 import pytest
 
 
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Missing OpenAI API key")
 def test_agent_groupchat():
+
     # Define the path to the script you want to test
     script_path = "memgpt/autogen/examples/agent_groupchat.py"
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Fix failing unit tests on contributor PRs due to autogen script running w/o `OPENAI_API_KEY` set