### PR TITLE
feat: add `GET` REST API route for listing tools

### DIFF
--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -518,6 +518,13 @@ class MetadataStore:
             return [r.to_record() for r in results]
 
     @enforce_types
+    def list_tools(self, user_id: uuid.UUID) -> List[Preset]:
+        with self.session_maker() as session:
+            raise NotImplementedError
+            # results = session.query(PresetModel).filter(PresetModel.user_id == user_id).all()
+            # return [r.to_record() for r in results]
+
+    @enforce_types
     def list_agents(self, user_id: uuid.UUID) -> List[AgentState]:
         with self.session_maker() as session:
             results = session.query(AgentModel).filter(AgentModel.user_id == user_id).all()

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Literal
 from pydantic import BaseModel, Field, Json
 import uuid
 from datetime import datetime
@@ -39,7 +39,9 @@ class PresetModel(BaseModel):
 class ToolModel(BaseModel):
     # TODO move into database
     name: str = Field(..., description="The name of the function.")
-    json_schema: str = Field(..., description="The JSON schema of the function.")
+    json_schema: dict = Field(..., description="The JSON schema of the function.")
+    source_type: Optional[Literal["python"]] = Field(None, description="The type of the source code.")
+    source_code: Optional[str] = Field(..., description="The source code of the function.")
 
 
 class AgentStateModel(BaseModel):

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -36,6 +36,12 @@ class PresetModel(BaseModel):
     functions_schema: List[Dict] = Field(..., description="The functions schema of the preset.")
 
 
+class ToolModel(BaseModel):
+    # TODO move into database
+    name: str = Field(..., description="The name of the function.")
+    json_schema: str = Field(..., description="The JSON schema of the function.")
+
+
 class AgentStateModel(BaseModel):
     id: uuid.UUID = Field(..., description="The unique identifier of the agent.")
     name: str = Field(..., description="The name of the agent.")

--- a/memgpt/server/rest_api/server.py
+++ b/memgpt/server/rest_api/server.py
@@ -20,6 +20,7 @@ from memgpt.server.rest_api.models.index import setup_models_index_router
 from memgpt.server.rest_api.openai_assistants.assistants import setup_openai_assistant_router
 from memgpt.server.rest_api.personas.index import setup_personas_index_router
 from memgpt.server.rest_api.static_files import mount_static_files
+from memgpt.server.rest_api.tools.index import setup_tools_index_router
 from memgpt.server.server import SyncServer
 
 """
@@ -92,6 +93,7 @@ app.include_router(setup_agents_message_router(server, interface, password), pre
 app.include_router(setup_humans_index_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_personas_index_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_models_index_router(server, interface, password), prefix=API_PREFIX)
+app.include_router(setup_tools_index_router(server, interface, password), prefix=API_PREFIX)
 
 # /api/config endpoints
 app.include_router(setup_config_index_router(server, interface, password), prefix=API_PREFIX)

--- a/memgpt/server/rest_api/tools/index.py
+++ b/memgpt/server/rest_api/tools/index.py
@@ -1,0 +1,35 @@
+import uuid
+from functools import partial
+from typing import List
+
+from fastapi import APIRouter, Depends, Body
+from pydantic import BaseModel, Field
+
+from memgpt.models.pydantic_models import ToolModel
+from memgpt.server.rest_api.auth_token import get_current_user
+from memgpt.server.rest_api.interface import QueuingInterface
+from memgpt.server.server import SyncServer
+
+router = APIRouter()
+
+
+class ListToolsResponse(BaseModel):
+    tools: List[ToolModel] = Field(..., description="List of tools (functions).")
+
+
+def setup_tools_index_router(server: SyncServer, interface: QueuingInterface, password: str):
+    get_current_user_with_server = partial(partial(get_current_user, server), password)
+
+    @router.get("/tools", tags=["tools"], response_model=ListToolsResponse)
+    async def list_tools(
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Get a list of all tools available to agents created by a user
+        """
+        # Clear the interface
+        interface.clear()
+        tools = server.ms.list_tools(user_id=user_id)
+        return ListToolsResponse(tools=tools)
+
+    return router


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- Adds a basic `GET` REST API route to enable listing of tools (eg to fill a tool view)
- TODOs for future PRs:
  - [ ] Rewrite tool models into `SQLModel`
  - [ ] Figure out how we want to persist custom functions/tools in the database
    - How to handle source? Just as strings?
      - e.g. `model.source_code` + `model.source_type` (`== 'python'`)
    - If source is strings, how to handle the validation?

**Have you tested this PR?**

<img width="1091" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/58cb5931-ed5a-4465-b4bc-c328188e6be3">

