### PR TITLE
fix: silence pydantic warning about protected namespace

### DIFF
--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Dict, Literal
-from pydantic import BaseModel, Field, Json
+from pydantic import BaseModel, Field, Json, ConfigDict
 import uuid
 from datetime import datetime
 from sqlmodel import Field, SQLModel
@@ -14,6 +14,9 @@ class LLMConfigModel(BaseModel):
     model_endpoint: Optional[str] = "https://api.openai.com/v1"
     model_wrapper: Optional[str] = None
     context_window: Optional[int] = None
+
+    # FIXME hack to silence pydantic protected namespace warning
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class EmbeddingConfigModel(BaseModel):


### PR DESCRIPTION
@sarahwooders we probably want to change the fields to not start with `model_`, but this works for now

Based on instructions here: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces

Warning in reference in this:
```
$ memgpt server

/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_endpoint_type" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_endpoint" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-PCQPn4ce-py3.10/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_wrapper" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
```