### PR TITLE
feat: add metadata to GET tools route

### DIFF
--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import os
 import sys
+from types import ModuleType
 
 
 from memgpt.functions.schema_generator import generate_schema
@@ -12,7 +13,7 @@ USER_FUNCTIONS_DIR = os.path.join(MEMGPT_DIR, "functions")
 sys.path.append(USER_FUNCTIONS_DIR)
 
 
-def load_function_set(module):
+def load_function_set(module: ModuleType) -> dict:
     """Load the functions and generate schema for them, given a module object"""
     function_dict = {}
 
@@ -36,7 +37,7 @@ def load_function_set(module):
     return function_dict
 
 
-def load_all_function_sets(merge=True):
+def load_all_function_sets(merge: bool = True) -> dict:
     # functions/examples/*.py
     scripts_dir = os.path.dirname(os.path.abspath(__file__))  # Get the directory of the current script
     function_sets_dir = os.path.join(scripts_dir, "function_sets")  # Path to the function_sets directory
@@ -59,6 +60,7 @@ def load_all_function_sets(merge=True):
     schemas_and_functions = {}
     for dir_path, module_files in [(function_sets_dir, example_module_files), (USER_FUNCTIONS_DIR, user_module_files)]:
         for file in module_files:
+            tags = []
             module_name = file[:-3]  # Remove '.py' from filename
             if dir_path == USER_FUNCTIONS_DIR:
                 # For user scripts, adjust the module name appropriately
@@ -86,6 +88,7 @@ def load_all_function_sets(merge=True):
             else:
                 # For built-in scripts, use the existing method
                 full_module_name = f"memgpt.functions.function_sets.{module_name}"
+                tags.append(f"memgpt-{module_name}")
                 try:
                     module = importlib.import_module(full_module_name)
                 except Exception as e:
@@ -96,6 +99,10 @@ def load_all_function_sets(merge=True):
             try:
                 # Load the function set
                 function_set = load_function_set(module)
+                # Add the metadata tags
+                for k, v in function_set.items():
+                    print(function_set)
+                    v["tags"] = tags
                 schemas_and_functions[module_name] = function_set
             except ValueError as e:
                 print(f"Error loading function set '{module_name}': {e}")

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -528,6 +528,7 @@ class MetadataStore:
                 ToolModel(
                     name=k,
                     json_schema=v["json_schema"],
+                    tags=v["tags"],
                     source_type="python",
                     source_code=python_inspect.getsource(v["python_function"]),
                 )

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -40,6 +40,7 @@ class ToolModel(BaseModel):
     # TODO move into database
     name: str = Field(..., description="The name of the function.")
     json_schema: dict = Field(..., description="The JSON schema of the function.")
+    tags: List[str] = Field(..., description="Metadata tags.")
     source_type: Optional[Literal["python"]] = Field(None, description="The type of the source code.")
     source_code: Optional[str] = Field(..., description="The source code of the function.")
 

--- a/memgpt/server/rest_api/tools/index.py
+++ b/memgpt/server/rest_api/tools/index.py
@@ -21,7 +21,7 @@ def setup_tools_index_router(server: SyncServer, interface: QueuingInterface, pa
     get_current_user_with_server = partial(partial(get_current_user, server), password)
 
     @router.get("/tools", tags=["tools"], response_model=ListToolsResponse)
-    async def list_tools(
+    async def list_all_tools(
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
         """


### PR DESCRIPTION
This PR adds a metadata tag to the GET tools route so that the chat UI can highlight core MemGPT functions (vs other functions) without having to rely on hardcoded string matching.

**Please describe the purpose of this pull request.**

- add a metadata tags field to the tool model, return tags memgpt-base and memgpt-extras on the batteries-included functions so that it can be reflected in the chat ui
- rename API function to 'list all tools' instead of 'list tools'

**How to test**

GET `/tools` route now provides a metadata tag (empty if not from base or extras modules):
```
{
	"tools": [
		{
			"name": "append_to_text_file",
			"json_schema": {
				"name": "append_to_text_file",
				"description": "Append to a text file.",
				"parameters": {
					"type": "object",
					"properties": {
						"filename": {
							"type": "string",
							"description": "The name of the file to append to."
						},
						"content": {
							"type": "string",
							"description": "Content to append to the file."
						},
						"request_heartbeat": {
							"type": "boolean",
							"description": "Request an immediate heartbeat after function execution. Set to 'true' if you want to send a follow-up message or run a follow-up function."
						}
					},
					"required": [
						"filename",
						"content",
						"request_heartbeat"
					]
				}
			},
			"tags": [
				"memgpt-extras"
			],
			"source_type": "python",
			"source_code": "def append_to_text_file(self, filename: str, content: str):\n    \"\"\"\n    Append to a text file.\n\n    Args:\n        filename (str): The name of the file to append to.\n        content (str): Content to append to the file.\n\n    Returns:\n        Optional[str]: None is always returned as this function does not produce a response.\n    \"\"\"\n    if not os.path.exists(filename):\n        raise FileNotFoundError(f\"The file '{filename}' does not exist.\")\n\n    with open(filename, \"a\", encoding=\"utf-8\") as file:\n        file.write(content + \"\\n\")\n"
		},
```