### PR TITLE
feat: add archival memory GET, POST, DEL to REST API

### DIFF
--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -101,7 +101,7 @@ def load_all_function_sets(merge: bool = True) -> dict:
                 function_set = load_function_set(module)
                 # Add the metadata tags
                 for k, v in function_set.items():
-                    print(function_set)
+                    # print(function_set)
                     v["tags"] = tags
                 schemas_and_functions[module_name] = function_set
             except ValueError as e:

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import datetime
-from typing import Optional, List, Tuple
+import uuid
+from typing import Optional, List, Tuple, Union
 
 from memgpt.constants import MESSAGE_SUMMARY_WARNING_FRAC
 from memgpt.utils import get_local_time, printd, count_tokens, validate_date_format, extract_date_from_timestamp
@@ -388,7 +389,7 @@ class EmbeddingArchivalMemory(ArchivalMemory):
         """Save the index to disk"""
         self.storage.save()
 
-    def insert(self, memory_string):
+    def insert(self, memory_string, return_ids=False) -> Union[bool, List[uuid.UUID]]:
         """Embed and save memory string"""
 
         if not isinstance(memory_string, str):
@@ -412,9 +413,17 @@ class EmbeddingArchivalMemory(ArchivalMemory):
                         )
                 passages.append(self.create_passage(text, embedding))
 
+            # grab the return IDs before the list gets modified
+            ids = [str(p.id) for p in passages]
+
             # insert passages
             self.storage.insert_many(passages)
-            return True
+
+            if return_ids:
+                return ids
+            else:
+                return True
+
         except Exception as e:
             print("Archival insert error", e)
             raise e

--- a/memgpt/server/rest_api/agents/memory.py
+++ b/memgpt/server/rest_api/agents/memory.py
@@ -150,7 +150,7 @@ def setup_agents_memory_router(server: SyncServer, interface: QueuingInterface, 
     @router.delete("/agents/{agent_id}/archival", tags=["agents"])
     def delete_agent_archival_memory(
         agent_id: uuid.UUID,
-        id: int = Query(..., description="Unique ID of the memory to be deleted."),
+        id: str = Query(..., description="Unique ID of the memory to be deleted."),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
         """

--- a/memgpt/server/rest_api/agents/memory.py
+++ b/memgpt/server/rest_api/agents/memory.py
@@ -111,9 +111,9 @@ def setup_agents_memory_router(server: SyncServer, interface: QueuingInterface, 
     @router.get("/agents/{agent_id}/archival", tags=["agents"], response_model=GetAgentArchivalMemoryResponse)
     def get_agent_archival_memory(
         agent_id: uuid.UUID,
-        after: Optional[int] = Query(..., description="Unique ID of the memory to start the query range at."),
-        before: Optional[int] = Query(..., description="Unique ID of the memory to end the query range at."),
-        limit: Optional[int] = Query(..., description="How many results to include in the response."),
+        after: Optional[int] = Query(None, description="Unique ID of the memory to start the query range at."),
+        before: Optional[int] = Query(None, description="Unique ID of the memory to end the query range at."),
+        limit: Optional[int] = Query(None, description="How many results to include in the response."),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
         """

--- a/memgpt/server/rest_api/agents/memory.py
+++ b/memgpt/server/rest_api/agents/memory.py
@@ -1,7 +1,9 @@
 import uuid
 from functools import partial
+from typing import List
 
-from fastapi import APIRouter, Depends, Body
+from fastapi import APIRouter, Depends, Body, HTTPException, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from memgpt.server.rest_api.auth_token import get_current_user
@@ -32,6 +34,30 @@ class UpdateAgentMemoryRequest(BaseModel):
 class UpdateAgentMemoryResponse(BaseModel):
     old_core_memory: CoreMemory = Field(..., description="The previous state of the agent's core memory.")
     new_core_memory: CoreMemory = Field(..., description="The updated state of the agent's core memory.")
+
+
+class ArchivalMemoryObject(BaseModel):
+    # TODO move to models/pydantic_models, or inherent from data_types Record
+    id: int = Field(..., description="Unique identifier for the memory object inside the archival memory store.")
+    contents: str = Field(..., description="The memory contents.")
+
+
+class GetAgentArchivalMemoryResponse(BaseModel):
+    # TODO make paginated
+    archival_memory: List[ArchivalMemoryObject] = Field(..., description="A list of all memory objects in archival memory.")
+
+
+class InsertAgentArchivalMemoryRequest(BaseModel):
+    agent_id: str = Field(..., description="The unique identifier of the agent.")
+    content: str = Field(None, description="The memory contents to insert into archival memory.")
+
+
+class InsertAgentArchivalMemoryResponse(BaseModel):
+    id: int = Field(..., description="Unique identifier for the new archival memory object.")
+
+
+class DeleteAgentArchivalMemoryRequest(BaseModel):
+    id: int = Field(..., description="Unique identifier for the new archival memory object.")
 
 
 def setup_agents_memory_router(server: SyncServer, interface: QueuingInterface, password: str):
@@ -69,5 +95,55 @@ def setup_agents_memory_router(server: SyncServer, interface: QueuingInterface, 
         new_memory_contents = {"persona": request.persona, "human": request.human}
         response = server.update_agent_core_memory(user_id=user_id, agent_id=agent_id, new_memory_contents=new_memory_contents)
         return UpdateAgentMemoryResponse(**response)
+
+    @router.get("/agents/{agent_id}/archival", tags=["agents"], response_model=GetAgentArchivalMemoryResponse)
+    def get_agent_archival_memory(
+        agent_id: uuid.UUID,
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Retrieve the memory state of a specific agent.
+
+        This endpoint fetches the current memory state of the agent identified by the user ID and agent ID.
+        """
+        interface.clear()
+        # memory = server.get_agent_memory(user_id=user_id, agent_id=agent_id)
+        memory = {}
+        return GetAgentArchivalMemoryResponse(**memory)
+
+    @router.post("/agents/{agent_id}/archival", tags=["agents"], response_model=InsertAgentArchivalMemoryResponse)
+    def insert_agent_archival_memory(
+        agent_id: uuid.UUID,
+        request: InsertAgentArchivalMemoryRequest = Body(...),
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Retrieve the memory state of a specific agent.
+
+        This endpoint fetches the current memory state of the agent identified by the user ID and agent ID.
+        """
+        interface.clear()
+        memory = server.get_agent_memory(user_id=user_id, agent_id=agent_id)
+        return InsertAgentArchivalMemoryResponse(**memory)
+
+    @router.delete("/agents/{agent_id}/archival", tags=["agents"])
+    def insert_agent_archival_memory(
+        agent_id: uuid.UUID,
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Retrieve the memory state of a specific agent.
+
+        This endpoint fetches the current memory state of the agent identified by the user ID and agent ID.
+        """
+        interface.clear()
+        try:
+            # server.delete_agent(user_id=user_id, agent_id=agent_id)
+            # TODO
+            return JSONResponse(status_code=status.HTTP_200_OK, content={"message": f"Agent agent_id={agent_id} successfully deleted"})
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"{e}")
 
     return router

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -829,6 +829,20 @@ class SyncServer(LockingServer):
         json_records = [vars(record) for record in records]
         return cursor, json_records
 
+    def get_archival_memories(self, user_id: uuid.UUID, agent_id: uuid.UUID) -> list:
+        # TODO type the list return
+        # TODO implement
+        return []
+
+    def insert_archival_memory(self, user_id: uuid.UUID, agent_id: uuid.UUID, memory_contents: str) -> uuid.UUID:
+        # TOOD implement
+        memory_id = uuid.uuid4()
+        return memory_id
+
+    def delete_archival_memory(self, user_id: uuid.UUID, agent_id: uuid.UUID, memory_id: uuid.UUID):
+        # TODO implement
+        return
+
     def get_agent_recall_cursor(
         self,
         user_id: uuid.UUID,

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -861,8 +861,17 @@ class SyncServer(LockingServer):
         return [str(p_id) for p_id in passage_ids]
 
     def delete_archival_memory(self, user_id: uuid.UUID, agent_id: uuid.UUID, memory_id: uuid.UUID):
-        # TODO implement
-        return
+        if self.ms.get_user(user_id=user_id) is None:
+            raise ValueError(f"User user_id={user_id} does not exist")
+        if self.ms.get_agent(agent_id=agent_id, user_id=user_id) is None:
+            raise ValueError(f"Agent agent_id={agent_id} does not exist")
+
+        # Get the agent object (loaded in memory)
+        memgpt_agent = self._get_or_load_agent(user_id=user_id, agent_id=agent_id)
+
+        # Delete by ID
+        # TODO check if it exists first, and throw error if not
+        memgpt_agent.persistence_manager.archival_memory.storage.delete({"id": memory_id})
 
     def get_agent_recall_cursor(
         self,


### PR DESCRIPTION
Add API routes for archival memory to allow for displaying + editing archival memory contents inside the chat UI.

**Please describe the purpose of this pull request.**

Adds the following API routes:
- [ ] `get_agent_archival_memory` (NOTE: punting to later PR)
  - paginated query of archival memory contents
  - **TODO currently untested**, does not work on chroma
- [x] `get_agent_archival_memory_all`
  - unpaginated query of archival memory contents (returns ALL contents)
- [x] `insert_agent_archival_memory`
  - insert a string into archival memory
  - returns a list of record IDs (list because the input may be chunked)
- [x] `delete_agent_archival_memory`
  - delete an entry from archival memory

**How to test**

Note @sarahwooders this should really be rolled into a unit test but alas...

Example testing the routes:
- create new agent (empty archival)
- ask agent question about archival memory contents (gets answer wrong)
  - <img width="757" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/8bef0237-88c9-4935-9b4c-3126acee4ed0">
- list contents of archival memory (empty)
  - <img width="788" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/f89ec451-8344-4746-9aa0-3396bd089c66">
- insert into archival memory (via POST API)
  - <img width="905" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/b34e53a0-4c3c-44e4-bd51-692f3af90828">
- list contents of archival memory (non-empty)
  - <img width="963" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/2dbd12a0-c736-4dda-9bf5-e8c9f25fe492">
- ask agent question about archival memory contents (gets answer correct)
  - <img width="652" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/d70d703e-27a9-44ee-a824-d5d68f5fd114">
- delete archival memory content
  - <img width="1008" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/512b40e0-daf2-4c68-8d84-f32594fe3c66">
- list contents of archival memory (now empty again)
  - <img width="793" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/40d9ce56-2e3b-49e0-ad42-2aca777e06e8">