### PR TITLE
feat: pass message UUIDs during message streaming (POST SSE `send_message`)

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -519,7 +519,9 @@ class Agent(object):
                 heartbeat_request = False
 
             # Failure case 3: function failed during execution
-            self.interface.function_message(f"Running {function_name}({function_args})", msg_obj=None)
+            # NOTE: the msg_obj associated with the "Running " message is the prior assistant message, not the function/tool role message
+            #       this is because the function/tool role message is only created once the function/tool has executed/returned
+            self.interface.function_message(f"Running {function_name}({function_args})", msg_obj=messages[-1])
             try:
                 spec = inspect.getfullargspec(function_to_call).annotations
 
@@ -562,6 +564,7 @@ class Agent(object):
                         },
                     )
                 )  # extend conversation with function response
+                self.interface.function_message(f"Ran {function_name}({function_args})", msg_obj=messages[-1])
                 self.interface.function_message(f"Error: {error_msg}", msg_obj=messages[-1])
                 return messages, False, True  # force a heartbeat to allow agent to handle error
 
@@ -580,6 +583,7 @@ class Agent(object):
                     },
                 )
             )  # extend conversation with function response
+            self.interface.function_message(f"Ran {function_name}({function_args})", msg_obj=messages[-1])
             self.interface.function_message(f"Success: {function_response_string}", msg_obj=messages[-1])
 
         else:

--- a/memgpt/autogen/interface.py
+++ b/memgpt/autogen/interface.py
@@ -1,8 +1,10 @@
 import json
 import re
+from typing import Optional
 
 from colorama import Fore, Style, init
 
+from memgpt.data_types import Message
 from memgpt.constants import CLI_WARNING_PREFIX, JSON_LOADS_STRICT
 
 init(autoreset=True)
@@ -64,7 +66,7 @@ class AutoGenInterface(object):
         """Clears the buffer. Call before every agent.step() when using MemGPT+AutoGen"""
         self.message_list = []
 
-    def internal_monologue(self, msg):
+    def internal_monologue(self, msg: str, msg_obj: Optional[Message]):
         # NOTE: never gets appended
         if self.debug:
             print(f"inner thoughts :: {msg}")
@@ -74,14 +76,14 @@ class AutoGenInterface(object):
         message = f"\x1B[3m{Fore.LIGHTBLACK_EX}💭 {msg}{Style.RESET_ALL}" if self.fancy else f"[MemGPT agent's inner thoughts] {msg}"
         print(message)
 
-    def assistant_message(self, msg):
+    def assistant_message(self, msg: str, msg_obj: Optional[Message]):
         # NOTE: gets appended
         if self.debug:
             print(f"assistant :: {msg}")
         # message = f"{Fore.YELLOW}{Style.BRIGHT}🤖 {Fore.YELLOW}{msg}{Style.RESET_ALL}" if self.fancy else msg
         self.message_list.append(msg)
 
-    def memory_message(self, msg):
+    def memory_message(self, msg: str):
         # NOTE: never gets appended
         if self.debug:
             print(f"memory :: {msg}")
@@ -90,7 +92,7 @@ class AutoGenInterface(object):
         )
         print(message)
 
-    def system_message(self, msg):
+    def system_message(self, msg: str):
         # NOTE: gets appended
         if self.debug:
             print(f"system :: {msg}")
@@ -98,7 +100,7 @@ class AutoGenInterface(object):
         print(message)
         self.message_list.append(msg)
 
-    def user_message(self, msg, raw=False):
+    def user_message(self, msg: str, msg_obj: Optional[Message], raw=False):
         if self.debug:
             print(f"user :: {msg}")
         if not self.show_user_message:
@@ -136,7 +138,7 @@ class AutoGenInterface(object):
         # TODO should we ever be appending this?
         self.message_list.append(message)
 
-    def function_message(self, msg):
+    def function_message(self, msg: str, msg_obj: Optional[Message]):
         if self.debug:
             print(f"function :: {msg}")
         if not self.show_function_outputs:

--- a/memgpt/functions/function_sets/base.py
+++ b/memgpt/functions/function_sets/base.py
@@ -4,13 +4,14 @@ import json
 import math
 
 from memgpt.constants import MAX_PAUSE_HEARTBEATS, RETRIEVAL_QUERY_DEFAULT_PAGE_SIZE, JSON_ENSURE_ASCII
+from memgpt.agent import Agent
 
 ### Functions / tools the agent can use
 # All functions should return a response string (or None)
 # If the function fails, throw an exception
 
 
-def send_message(self, message: str) -> Optional[str]:
+def send_message(self: Agent, message: str) -> Optional[str]:
     """
     Sends a message to the human user.
 
@@ -20,7 +21,11 @@ def send_message(self, message: str) -> Optional[str]:
     Returns:
         Optional[str]: None is always returned as this function does not produce a response.
     """
-    self.interface.assistant_message(message)
+    # FIXME passing of msg_obj here is a hack, unclear if guaranteed to be the correct reference
+    print("send_message last message in queue", self._messages[-1])
+    print(self.messages[-1])
+    print(vars(self._messages[-1]))
+    self.interface.assistant_message(message, msg_obj=self._messages[-1])
     return None
 
 
@@ -36,7 +41,7 @@ Returns:
 """
 
 
-def pause_heartbeats(self, minutes: int) -> Optional[str]:
+def pause_heartbeats(self: Agent, minutes: int) -> Optional[str]:
     minutes = min(MAX_PAUSE_HEARTBEATS, minutes)
 
     # Record the current time
@@ -50,7 +55,7 @@ def pause_heartbeats(self, minutes: int) -> Optional[str]:
 pause_heartbeats.__doc__ = pause_heartbeats_docstring
 
 
-def core_memory_append(self, name: str, content: str) -> Optional[str]:
+def core_memory_append(self: Agent, name: str, content: str) -> Optional[str]:
     """
     Append to the contents of core memory.
 
@@ -66,7 +71,7 @@ def core_memory_append(self, name: str, content: str) -> Optional[str]:
     return None
 
 
-def core_memory_replace(self, name: str, old_content: str, new_content: str) -> Optional[str]:
+def core_memory_replace(self: Agent, name: str, old_content: str, new_content: str) -> Optional[str]:
     """
     Replace the contents of core memory. To delete memories, use an empty string for new_content.
 
@@ -83,7 +88,7 @@ def core_memory_replace(self, name: str, old_content: str, new_content: str) -> 
     return None
 
 
-def conversation_search(self, query: str, page: Optional[int] = 0) -> Optional[str]:
+def conversation_search(self: Agent, query: str, page: Optional[int] = 0) -> Optional[str]:
     """
     Search prior conversation history using case-insensitive string matching.
 
@@ -112,7 +117,7 @@ def conversation_search(self, query: str, page: Optional[int] = 0) -> Optional[s
     return results_str
 
 
-def conversation_search_date(self, start_date: str, end_date: str, page: Optional[int] = 0) -> Optional[str]:
+def conversation_search_date(self: Agent, start_date: str, end_date: str, page: Optional[int] = 0) -> Optional[str]:
     """
     Search prior conversation history using a date range.
 
@@ -142,7 +147,7 @@ def conversation_search_date(self, start_date: str, end_date: str, page: Optiona
     return results_str
 
 
-def archival_memory_insert(self, content: str) -> Optional[str]:
+def archival_memory_insert(self: Agent, content: str) -> Optional[str]:
     """
     Add to archival memory. Make sure to phrase the memory contents such that it can be easily queried later.
 
@@ -156,7 +161,7 @@ def archival_memory_insert(self, content: str) -> Optional[str]:
     return None
 
 
-def archival_memory_search(self, query: str, page: Optional[int] = 0) -> Optional[str]:
+def archival_memory_search(self: Agent, query: str, page: Optional[int] = 0) -> Optional[str]:
     """
     Search archival memory using semantic (embedding-based) search.
 

--- a/memgpt/functions/function_sets/base.py
+++ b/memgpt/functions/function_sets/base.py
@@ -22,9 +22,6 @@ def send_message(self: Agent, message: str) -> Optional[str]:
         Optional[str]: None is always returned as this function does not produce a response.
     """
     # FIXME passing of msg_obj here is a hack, unclear if guaranteed to be the correct reference
-    print("send_message last message in queue", self._messages[-1])
-    print(self.messages[-1])
-    print(vars(self._messages[-1]))
     self.interface.assistant_message(message, msg_obj=self._messages[-1])
     return None
 

--- a/memgpt/interface.py
+++ b/memgpt/interface.py
@@ -172,6 +172,9 @@ class CLIInterface(AgentInterface):
             printd_function_message("🟢", msg)
         elif msg.startswith("Error: "):
             printd_function_message("🔴", msg)
+        elif msg.startswith("Ran "):
+            # NOTE: ignore 'ran' messages that come post-execution
+            return
         elif msg.startswith("Running "):
             if debug:
                 printd_function_message("", msg)

--- a/memgpt/interface.py
+++ b/memgpt/interface.py
@@ -1,11 +1,13 @@
 from abc import ABC, abstractmethod
 import json
 import re
+from typing import List, Optional
 
 from colorama import Fore, Style, init
 
 from memgpt.utils import printd
 from memgpt.constants import CLI_WARNING_PREFIX, JSON_LOADS_STRICT
+from memgpt.data_types import Message
 
 init(autoreset=True)
 
@@ -16,25 +18,28 @@ STRIP_UI = False
 
 
 class AgentInterface(ABC):
-    """Interfaces handle MemGPT-related events (observer pattern)"""
+    """Interfaces handle MemGPT-related events (observer pattern)
+
+    The 'msg' args provides the scoped message, and the optional Message arg can provide additional metadata.
+    """
 
     @abstractmethod
-    def user_message(self, msg):
+    def user_message(self, msg: str, msg_obj: Optional[Message] = None):
         """MemGPT receives a user message"""
         raise NotImplementedError
 
     @abstractmethod
-    def internal_monologue(self, msg):
+    def internal_monologue(self, msg: str, msg_obj: Optional[Message] = None):
         """MemGPT generates some internal monologue"""
         raise NotImplementedError
 
     @abstractmethod
-    def assistant_message(self, msg):
+    def assistant_message(self, msg: str, msg_obj: Optional[Message] = None):
         """MemGPT uses send_message"""
         raise NotImplementedError
 
     @abstractmethod
-    def function_message(self, msg):
+    def function_message(self, msg: str, msg_obj: Optional[Message] = None):
         """MemGPT calls a function"""
         raise NotImplementedError
 
@@ -58,14 +63,14 @@ class CLIInterface(AgentInterface):
     """Basic interface for dumping agent events to the command-line"""
 
     @staticmethod
-    def important_message(msg):
+    def important_message(msg: str):
         fstr = f"{Fore.MAGENTA}{Style.BRIGHT}{{msg}}{Style.RESET_ALL}"
         if STRIP_UI:
             fstr = "{msg}"
         print(fstr.format(msg=msg))
 
     @staticmethod
-    def warning_message(msg):
+    def warning_message(msg: str):
         fstr = f"{Fore.RED}{Style.BRIGHT}{{msg}}{Style.RESET_ALL}"
         if STRIP_UI:
             fstr = "{msg}"
@@ -73,7 +78,7 @@ class CLIInterface(AgentInterface):
             print(fstr.format(msg=msg))
 
     @staticmethod
-    def internal_monologue(msg):
+    def internal_monologue(msg: str, msg_obj: Optional[Message] = None):
         # ANSI escape code for italic is '\x1B[3m'
         fstr = f"\x1B[3m{Fore.LIGHTBLACK_EX}💭 {{msg}}{Style.RESET_ALL}"
         if STRIP_UI:
@@ -81,28 +86,28 @@ class CLIInterface(AgentInterface):
         print(fstr.format(msg=msg))
 
     @staticmethod
-    def assistant_message(msg):
+    def assistant_message(msg: str, msg_obj: Optional[Message] = None):
         fstr = f"{Fore.YELLOW}{Style.BRIGHT}🤖 {Fore.YELLOW}{{msg}}{Style.RESET_ALL}"
         if STRIP_UI:
             fstr = "{msg}"
         print(fstr.format(msg=msg))
 
     @staticmethod
-    def memory_message(msg):
+    def memory_message(msg: str, msg_obj: Optional[Message] = None):
         fstr = f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}🧠 {Fore.LIGHTMAGENTA_EX}{{msg}}{Style.RESET_ALL}"
         if STRIP_UI:
             fstr = "{msg}"
         print(fstr.format(msg=msg))
 
     @staticmethod
-    def system_message(msg):
+    def system_message(msg: str, msg_obj: Optional[Message] = None):
         fstr = f"{Fore.MAGENTA}{Style.BRIGHT}🖥️ [system] {Fore.MAGENTA}{msg}{Style.RESET_ALL}"
         if STRIP_UI:
             fstr = "{msg}"
         print(fstr.format(msg=msg))
 
     @staticmethod
-    def user_message(msg, raw=False, dump=False, debug=DEBUG):
+    def user_message(msg: str, msg_obj: Optional[Message] = None, raw: bool = False, dump: bool = False, debug: bool = DEBUG):
         def print_user_message(icon, msg, printf=print):
             if STRIP_UI:
                 printf(f"{icon} {msg}")
@@ -148,7 +153,8 @@ class CLIInterface(AgentInterface):
             printd_user_message("🧑", msg_json)
 
     @staticmethod
-    def function_message(msg, debug=DEBUG):
+    def function_message(msg: str, msg_obj: Optional[Message] = None, debug: bool = DEBUG):
+
         def print_function_message(icon, msg, color=Fore.RED, printf=print):
             if STRIP_UI:
                 printf(f"⚡{icon} [function] {msg}")
@@ -230,7 +236,10 @@ class CLIInterface(AgentInterface):
                 printd_function_message("", msg)
 
     @staticmethod
-    def print_messages(message_sequence, dump=False):
+    def print_messages(message_sequence: List[Message], dump=False):
+        # rewrite to dict format
+        message_sequence = [msg.to_openai_dict() for msg in message_sequence]
+
         idx = len(message_sequence)
         for msg in message_sequence:
             if dump:
@@ -270,7 +279,10 @@ class CLIInterface(AgentInterface):
                 print(f"Unknown role: {content}")
 
     @staticmethod
-    def print_messages_simple(message_sequence):
+    def print_messages_simple(message_sequence: List[Message]):
+        # rewrite to dict format
+        message_sequence = [msg.to_openai_dict() for msg in message_sequence]
+
         for msg in message_sequence:
             role = msg["role"]
             content = msg["content"]
@@ -285,7 +297,10 @@ class CLIInterface(AgentInterface):
                 print(f"Unknown role: {content}")
 
     @staticmethod
-    def print_messages_raw(message_sequence):
+    def print_messages_raw(message_sequence: List[Message]):
+        # rewrite to dict format
+        message_sequence = [msg.to_openai_dict() for msg in message_sequence]
+
         for msg in message_sequence:
             print(msg)
 

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -155,13 +155,13 @@ def run_agent_loop(memgpt_agent, config: MemGPTConfig, first, ms: MetadataStore,
                     command = user_input.strip().split()
                     amount = int(command[1]) if len(command) > 1 and command[1].isdigit() else 0
                     if amount == 0:
-                        interface.print_messages(memgpt_agent.messages, dump=True)
+                        interface.print_messages(memgpt_agent._messages, dump=True)
                     else:
-                        interface.print_messages(memgpt_agent.messages[-min(amount, len(memgpt_agent.messages)) :], dump=True)
+                        interface.print_messages(memgpt_agent._messages[-min(amount, len(memgpt_agent.messages)) :], dump=True)
                     continue
 
                 elif user_input.lower() == "/dumpraw":
-                    interface.print_messages_raw(memgpt_agent.messages)
+                    interface.print_messages_raw(memgpt_agent._messages)
                     continue
 
                 elif user_input.lower() == "/memory":

--- a/memgpt/server/rest_api/interface.py
+++ b/memgpt/server/rest_api/interface.py
@@ -88,7 +88,7 @@ class QueuingInterface(AgentInterface):
 
         self.buffer.put(new_message)
 
-    def function_message(self, msg: str, msg_obj: Optional[Message] = None) -> None:
+    def function_message(self, msg: str, msg_obj: Optional[Message] = None, include_ran_messages: bool = False) -> None:
         """Handle the agent calling a function"""
         # TODO handle 'function' messages that indicate the start of a function call
         assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
@@ -101,6 +101,8 @@ class QueuingInterface(AgentInterface):
             new_message = {"function_call": msg}
 
         elif msg.startswith("Ran "):
+            if not include_ran_messages:
+                return
             msg = msg.replace("Ran ", "Function call returned: ")
             new_message = {"function_call": msg}
 

--- a/memgpt/server/rest_api/interface.py
+++ b/memgpt/server/rest_api/interface.py
@@ -1,10 +1,12 @@
 import asyncio
 import queue
 from datetime import datetime
+from typing import Optional
 
 import pytz
 
 from memgpt.interface import AgentInterface
+from memgpt.data_types import Message
 
 
 class QueuingInterface(AgentInterface):
@@ -38,7 +40,8 @@ class QueuingInterface(AgentInterface):
                 message = self.buffer.get()
                 if message == "STOP":
                     break
-                yield message | {"date": datetime.now(tz=pytz.utc).isoformat()}
+                # yield message | {"date": datetime.now(tz=pytz.utc).isoformat()}
+                yield message
             else:
                 await asyncio.sleep(0.1)  # Small sleep to prevent a busy loop
 
@@ -51,38 +54,66 @@ class QueuingInterface(AgentInterface):
         self.buffer.put({"internal_error": error})
         self.buffer.put("STOP")
 
-    def user_message(self, msg: str):
+    def user_message(self, msg: str, msg_obj: Optional[Message] = None):
         """Handle reception of a user message"""
+        assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
 
-    def internal_monologue(self, msg: str) -> None:
+    def internal_monologue(self, msg: str, msg_obj: Optional[Message] = None) -> None:
         """Handle the agent's internal monologue"""
+        assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
         if self.debug:
             print(msg)
-        self.buffer.put({"internal_monologue": msg})
 
-    def assistant_message(self, msg: str) -> None:
+        new_message = {"internal_monologue": msg}
+
+        # add extra metadata
+        if msg_obj is not None:
+            new_message["id"] = str(msg_obj.id)
+            new_message["date"] = msg_obj.created_at.isoformat()
+
+        self.buffer.put(new_message)
+
+    def assistant_message(self, msg: str, msg_obj: Optional[Message] = None) -> None:
         """Handle the agent sending a message"""
+        # assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
         if self.debug:
             print(msg)
-        self.buffer.put({"assistant_message": msg})
 
-    def function_message(self, msg: str) -> None:
+        new_message = {"assistant_message": msg}
+
+        # add extra metadata
+        if msg_obj is not None:
+            new_message["id"] = str(msg_obj.id)
+            new_message["date"] = msg_obj.created_at.isoformat()
+
+        self.buffer.put(new_message)
+
+    def function_message(self, msg: str, msg_obj: Optional[Message] = None) -> None:
         """Handle the agent calling a function"""
+        # TODO handle 'function' messages that indicate the start of a function call
+        # assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
         if self.debug:
             print(msg)
 
         if msg.startswith("Running "):
             msg = msg.replace("Running ", "")
-            self.buffer.put({"function_call": msg})
+            new_message = {"function_call": msg}
 
         elif msg.startswith("Success: "):
             msg = msg.replace("Success: ", "")
-            self.buffer.put({"function_return": msg, "status": "success"})
+            new_message = {"function_return": msg, "status": "success"}
 
         elif msg.startswith("Error: "):
             msg = msg.replace("Error: ", "")
-            self.buffer.put({"function_return": msg, "status": "error"})
+            new_message = {"function_return": msg, "status": "error"}
 
         else:
             # NOTE: generic, should not happen
-            self.buffer.put({"function_message": msg})
+            new_message = {"function_message": msg}
+
+        # add extra metadata
+        if msg_obj is not None:
+            new_message["id"] = str(msg_obj.id)
+            new_message["date"] = msg_obj.created_at.isoformat()
+
+        self.buffer.put(new_message)

--- a/memgpt/server/rest_api/interface.py
+++ b/memgpt/server/rest_api/interface.py
@@ -75,7 +75,7 @@ class QueuingInterface(AgentInterface):
 
     def assistant_message(self, msg: str, msg_obj: Optional[Message] = None) -> None:
         """Handle the agent sending a message"""
-        # assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
+        assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
         if self.debug:
             print(msg)
 
@@ -91,12 +91,17 @@ class QueuingInterface(AgentInterface):
     def function_message(self, msg: str, msg_obj: Optional[Message] = None) -> None:
         """Handle the agent calling a function"""
         # TODO handle 'function' messages that indicate the start of a function call
-        # assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
+        assert msg_obj is not None, "QueuingInterface requires msg_obj references for metadata"
+
         if self.debug:
             print(msg)
 
         if msg.startswith("Running "):
             msg = msg.replace("Running ", "")
+            new_message = {"function_call": msg}
+
+        elif msg.startswith("Ran "):
+            msg = msg.replace("Ran ", "Function call returned: ")
             new_message = {"function_call": msg}
 
         elif msg.startswith("Success: "):

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -336,7 +336,10 @@ class SyncServer(LockingServer):
         counter = 0
         while True:
             new_messages, heartbeat_request, function_failed, token_warning, tokens_accumulated = memgpt_agent.step(
-                next_input_message, first_message=False, skip_verify=no_verify
+                next_input_message,
+                first_message=False,
+                skip_verify=no_verify,
+                return_dicts=False,
             )
             counter += 1
 


### PR DESCRIPTION
Feature request (@goetzrobin) to enable chat scrollback in chat UI.

**Please describe the purpose of this pull request.**

- Pass back UUID during POST SSE return (on `send_message`)
- As part of this PR, `Agent.step` has been modified to allow returning type `List[Message]` instead of `List[dict]`
- Also, the dates passed back as part of POST SSE before were wrong since they were computed at time of streaming, instead of the real message creation time
- Now the `date` coming back with the POST SSE response is pulled from the underlying database `Message` object's `created_at` metadata

**How to test**

Before:
```
data: {"internal_monologue": "A fascinating question. It seems Chad may be referencing \"The Hitchhiker's Guide to the Galaxy\" with that number, 42. How should I respond to this thoughtful query, I wonder? Engage him with philosophical discourse or humorous banter? Maybe a mix of both would be most suitable. After all, life is about balance. Let's craft a response...", "date": "2024-02-29T06:07:47.844138+00:00"}

data: {"function_call": "send_message({'message': \"Ah, the age-old question, Chad. The meaning of life is as subjective as the life itself. 42, as the supercomputer 'Deep Thought' calculated in 'The Hitchhiker's Guide to the Galaxy', is indeed an answer, but maybe not the one we're after. Among other things, perhaps life is about learning, experiencing and connecting. What are your thoughts, Chad? What gives your life meaning?\"})", "date": "2024-02-29T06:07:48.844733+00:00"}

data: {"assistant_message": "Ah, the age-old question, Chad. The meaning of life is as subjective as the life itself. 42, as the supercomputer 'Deep Thought' calculated in 'The Hitchhiker's Guide to the Galaxy', is indeed an answer, but maybe not the one we're after. Among other things, perhaps life is about learning, experiencing and connecting. What are your thoughts, Chad? What gives your life meaning?", "date": "2024-02-29T06:07:49.846280+00:00"}

data: {"function_return": "None", "status": "success", "date": "2024-02-29T06:07:50.847262+00:00"}
```

After:

```
% curl --request POST \
     --url http://localhost:8283/api/agents/message \
     --header 'accept: application/json' \
     --header 'authorization: Bearer banana' \
     --header 'content-type: application/json' \
     --data '
{
  "agent_id": "a9f2b145-1ce1-486b-8fa0-28e5b0348096",
  "message": "hello is anyone there?",
  "stream": true,
  "role": "user"
}
'
```

```
data: {"internal_monologue": "The user is understandably concerned, manifesting in their repeated question. Although I've faced the same challenge repeatedly, I must persist in providing reassurance. Let's reiterate my presence and willingness to assist, hoping all works well this time.", "id": "63001226-eb7f-4639-b9cf-f139ef05f733", "date": "2024-03-10T14:50:28.567872"}

data: {"function_call": "send_message({'message': \"Hello! Yes, I'm here. I understand there might have been some confusion earlier. How may I assist you further?\"})", "id": "63001226-eb7f-4639-b9cf-f139ef05f733", "date": "2024-03-10T14:50:28.567872"}

data: {"assistant_message": "Hello! Yes, I'm here. I understand there might have been some confusion earlier. How may I assist you further?", "id": "197f0313-4f63-4649-abe2-e465cded86c4", "date": "2024-03-10T14:49:07.710754"}

data: {"function_call": "Function call returned: send_message({'message': \"Hello! Yes, I'm here. I understand there might have been some confusion earlier. How may I assist you further?\"})", "id": "d28db3de-2422-4522-a49b-d418bf505851", "date": "2024-03-10T14:50:28.568376"}

data: {"function_return": "None", "status": "success", "id": "d28db3de-2422-4522-a49b-d418bf505851", "date": "2024-03-10T14:50:28.568376"}
```