### PR TITLE
feat: add a `last_run` field to the agent state model

### DIFF
--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -58,7 +58,8 @@ class AgentStateModel(BaseModel):
     user_id: uuid.UUID = Field(..., description="The unique identifier of the user associated with the agent.")
 
     # timestamps
-    created_at: datetime = Field(default_factory=datetime.now, description="The unix timestamp of when the agent was created.")
+    # created_at: datetime = Field(default_factory=datetime.now, description="The unix timestamp of when the agent was created.")
+    created_at: int = Field(..., description="The unix timestamp of when the agent was created.")
 
     # preset information
     preset: str = Field(..., description="The preset used by the agent.")

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -58,7 +58,7 @@ class AgentStateModel(BaseModel):
     user_id: uuid.UUID = Field(..., description="The unique identifier of the user associated with the agent.")
 
     # timestamps
-    created_at: int = Field(..., description="The unix timestamp of when the agent was created.")
+    created_at: datetime = Field(default_factory=datetime.now, description="The unix timestamp of when the agent was created.")
 
     # preset information
     preset: str = Field(..., description="The preset used by the agent.")

--- a/memgpt/server/rest_api/agents/config.py
+++ b/memgpt/server/rest_api/agents/config.py
@@ -51,7 +51,7 @@ def validate_agent_name(name: str) -> str:
 def setup_agents_config_router(server: SyncServer, interface: QueuingInterface, password: str):
     get_current_user_with_server = partial(partial(get_current_user, server), password)
 
-    @router.get("/agents", tags=["agents"], response_model=GetAgentResponse)
+    @router.get("/agents/config", tags=["agents"], response_model=GetAgentResponse)
     def get_agent_config(
         agent_id: str = Query(..., description="Unique identifier of the agent whose config is requested."),
         user_id: uuid.UUID = Depends(get_current_user_with_server),

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -684,16 +684,32 @@ class SyncServer(LockingServer):
         }
         return agent_config
 
-    def list_agents(self, user_id: uuid.UUID) -> dict:
+    def list_agents(self, user_id: uuid.UUID, add_last_run: bool = True) -> dict:
         """List all available agents to a user"""
         if self.ms.get_user(user_id=user_id) is None:
             raise ValueError(f"User user_id={user_id} does not exist")
 
         agents_states = self.ms.list_agents(user_id=user_id)
+        agents_states_dicts = [self._agent_state_to_config(state) for state in agents_states]
+
+        if add_last_run:
+            # TODO add a get_message_obj_from_message_id(...) function
+            #      this would allow grabbing Message.created_by without having to load the agent object
+            for agent_state, return_dict in zip(agents_states, agents_states_dicts):
+                # Get the agent object (loaded in memory)
+                memgpt_agent = self._get_or_load_agent(user_id=user_id, agent_id=agent_state.id)
+
+                # Retrive the Message object via the recall storage or by directly access _messages
+                last_msg_obj = memgpt_agent._messages[-1]
+
+                # Update the return to include the last_run info
+                # NOTE: 'last_run' is just the timestamp on the latest message in the buffer
+                return_dict["last_run"] = last_msg_obj.created_at
+
         logger.info(f"Retrieved {len(agents_states)} agents for user {user_id}:\n{[vars(s) for s in agents_states]}")
         return {
             "num_agents": len(agents_states),
-            "agents": [self._agent_state_to_config(state) for state in agents_states],
+            "agents": agents_states_dicts,
         }
 
     def get_agent(self, user_id: uuid.UUID, agent_id: uuid.UUID):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

- add a `last_run` field to the agent state model
  - value updated lazily (on access)
  - should use the value from `messages[-1].created_at`
- ~~correct AgentStateModel's created_at to be a datetime (like the other created_at fields) instead of an int~~

~~Question for @sarahwooders - another way to do this is to keep a `last_run` field inside the `AgentState.state` that gets updated dynamically/eagerly when `Agent.step()` is called. Any preference on eager vs lazy?~~

**How to test**

Run an API call to list all agents (https://memgpt.readme.io/reference/list_agents_api_agents_get) and the `last_run` fields should exist and be valid.

**Have you tested this PR?**

`GET localhost:8283/api/agents`

```
{
	"num_agents": 6,
	"agents": [
		{
			"id": "1082d3e2-2e4d-40a7-9a2f-613934c3e19f",
			"name": "ResilientHarpsichord",
			"human": "basic",
			"persona": "sam_pov",
			"created_at": "2024-03-05T16:41:57.947029",
			"last_run": "2024-03-05T17:12:05.193843"
		},
...
```