### PR TITLE
feat: add list of sources (in dict format) to response object

### DIFF
--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -728,7 +728,7 @@ class SyncServer(LockingServer):
 
             # Add information about attached sources
             sources_ids = self.ms.list_attached_sources(agent_id=agent_state.id)
-            sources = [self.ms.get_source(source_id=s_id) for s_id in sources_ids] 
+            sources = [self.ms.get_source(source_id=s_id) for s_id in sources_ids]
             return_dict["sources"] = [vars(s) for s in sources]
 
         logger.info(f"Retrieved {len(agents_states)} agents for user {user_id}:\n{[vars(s) for s in agents_states]}")

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -695,6 +695,7 @@ class SyncServer(LockingServer):
         # TODO add a get_message_obj_from_message_id(...) function
         #      this would allow grabbing Message.created_by without having to load the agent object
         all_available_tools = self.ms.list_tools(user_id=user_id)
+
         for agent_state, return_dict in zip(agents_states, agents_states_dicts):
 
             # Get the agent object (loaded in memory)
@@ -724,6 +725,11 @@ class SyncServer(LockingServer):
             # Retrieve the Message object via the recall storage or by directly access _messages
             last_msg_obj = memgpt_agent._messages[-1]
             return_dict["last_run"] = last_msg_obj.created_at
+
+            # Add information about attached sources
+            sources_ids = self.ms.list_attached_sources(agent_id=agent_state.id)
+            sources = [self.ms.get_source(source_id=s_id) for s_id in sources_ids] 
+            return_dict["sources"] = [vars(s) for s in sources]
 
         logger.info(f"Retrieved {len(agents_states)} agents for user {user_id}:\n{[vars(s) for s in agents_states]}")
         return {


### PR DESCRIPTION
**How to test**

Before attaching source:

`GET localhost:8283/api/agents`
```
		{
			"id": "3e2f5107-eadb-49c5-a256-75522eb8d526",
			"name": "NobleJewelry",
                         ...
			"last_run": "2024-03-10T18:35:37.032838",
			"sources": []
		},
```

Attaching a source:

```sh
% memgpt load directory --name memgpt_research_paper --input-files=memgpt_research_paper.pdf
% memgpt run

? Would you like to select an existing agent? Yes
? Select agent: NobleJewelry

🔁 Using existing agent NobleJewelry

Hit enter to begin (will request first MemGPT message)

💭 User logged in, initializing conversation sequence.
🤖 Hey there! Welcome to your personalized digital companion. I'm Sam and I am ready to assist you. Don't worry; I'm more human than human.
> Enter your message: /attach
? Select data source memgpt_research_paper
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  8.73it/s]
> Enter your message: /exit
Finished.
```

After attaching source:

`GET localhost:8283/api/agents`
```
		{
			"id": "3e2f5107-eadb-49c5-a256-75522eb8d526",
			"name": "NobleJewelry",
                         ...
			"last_run": "2024-03-10T18:35:37.032838",
			"sources": [
				{
					"id": "42608b4d-9f0c-4b40-b3bb-50e7ad56c5b1",
					"name": "memgpt_research_paper",
					"user_id": "00000000-0000-0000-0000-a61b692e9d3d",
					"created_at": "2024-03-11T13:19:22.823059",
					"embedding_dim": 1024,
					"embedding_model": "BAAI/bge-large-en-v1.5"
				}
			]
```
