### PR TITLE
feat: enable adding presets via the CLI 

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -532,6 +532,8 @@ def run(
     # read user id from config
     ms = MetadataStore(config)
     user = create_default_user_or_exit(config, ms)
+    human = human if human else config.human
+    persona = persona if persona else config.persona
 
     # determine agent to use, if not provided
     if not yes and not agent:
@@ -657,8 +659,8 @@ def run(
                     sys.exit(1)
 
             # Overwrite fields in the preset if they were specified
-            preset_obj.human = utils.get_human_text(human) if human else utils.get_human_text(config.human)
-            preset_obj.persona = utils.get_persona_text(persona) if persona else utils.get_persona_text(config.persona)
+            preset_obj.human = ms.get_human(human, user.id).text
+            preset_obj.persona = ms.get_persona(persona, user.id).text
 
             typer.secho(f"->  🤖 Using persona profile '{preset_obj.persona}'", fg=typer.colors.WHITE)
             typer.secho(f"->  🧑 Using human profile '{preset_obj.human}'", fg=typer.colors.WHITE)

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -7,7 +7,8 @@ from typing import Annotated
 
 import questionary
 import typer
-from prettytable import PrettyTable
+from prettytable import PrettyTable, SINGLE_BORDER
+from prettytable.colortable import ColorTable, Themes
 from tqdm import tqdm
 
 from memgpt import utils
@@ -24,7 +25,8 @@ from memgpt.server.utils import shorten_key_middle
 from memgpt.data_types import User, LLMConfig, EmbeddingConfig, Source
 from memgpt.metadata import MetadataStore
 from memgpt.server.utils import shorten_key_middle
-from memgpt.models.pydantic_models import HumanModel, PersonaModel
+from memgpt.models.pydantic_models import HumanModel, PersonaModel, PresetModel
+from memgpt.presets.presets import create_preset_from_file
 
 app = typer.Typer()
 
@@ -733,9 +735,9 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
     config = MemGPTConfig.load()
     ms = MetadataStore(config)
     user_id = uuid.UUID(config.anon_clientid)
+    table = ColorTable(theme=Themes.OCEAN)
     if arg == ListChoice.agents:
         """List all agents"""
-        table = PrettyTable()
         table.field_names = ["Name", "LLM Model", "Embedding Model", "Embedding Dim", "Persona", "Human", "Data Source", "Create Time"]
         for agent in tqdm(ms.list_agents(user_id=user_id)):
             source_ids = ms.list_attached_sources(agent_id=agent.id)
@@ -758,23 +760,20 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
         print(table)
     elif arg == ListChoice.humans:
         """List all humans"""
-        table = PrettyTable()
         table.field_names = ["Name", "Text"]
         for human in ms.list_humans(user_id=user_id):
-            table.add_row([human.name, human.text])
+            table.add_row([human.name, human.text.replace("\n", "")[:100]])
         print(table)
     elif arg == ListChoice.personas:
         """List all personas"""
-        table = PrettyTable()
         table.field_names = ["Name", "Text"]
         for persona in ms.list_personas(user_id=user_id):
-            table.add_row([persona.name, persona.text])
+            table.add_row([persona.name, persona.text.replace("\n", "")[:100]])
         print(table)
     elif arg == ListChoice.sources:
         """List all data sources"""
 
         # create table
-        table = PrettyTable()
         table.field_names = ["Name", "Embedding Model", "Embedding Dim", "Created At", "Agents"]
         # TODO: eventually look accross all storage connections
         # TODO: add data source stats
@@ -794,7 +793,6 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
         print(table)
     elif arg == ListChoice.presets:
         """List all available presets"""
-        table = PrettyTable()
         table.field_names = ["Name", "Description", "Sources", "Functions"]
         for preset in ms.list_presets(user_id=user_id):
             sources = ms.get_preset_sources(preset_id=preset.id)
@@ -823,10 +821,17 @@ def add(
     config = MemGPTConfig.load()
     user_id = uuid.UUID(config.anon_clientid)
     ms = MetadataStore(config)
+    if filename:  # read from file
+        assert text is None, "Cannot specify both text and filename"
+        with open(filename, "r") as f:
+            text = f.read()
     if option == "persona":
         ms.add_persona(PersonaModel(name=name, text=text, user_id=user_id))
     elif option == "human":
         ms.add_human(HumanModel(name=name, text=text, user_id=user_id))
+    elif option == "preset":
+        assert filename, "Must specify filename for preset"
+        create_preset_from_file(filename, name, user_id, ms)
     else:
         raise ValueError(f"Unknown kind {option}")
 
@@ -876,6 +881,8 @@ def delete(option: str, name: str):
             ms.delete_human(name=name, user_id=user_id)
         elif option == "persona":
             ms.delete_persona(name=name, user_id=user_id)
+        elif option == "preset":
+            ms.delete_preset(name=name, user_id=user_id)
         else:
             raise ValueError(f"Option {option} not implemented")
 

--- a/memgpt/data_sources/connectors.py
+++ b/memgpt/data_sources/connectors.py
@@ -139,17 +139,17 @@ class DirectoryConnector(DataConnector):
                 yield node.text, None
 
 
-class WebConnector(DataConnector):
-    # TODO
-
-    def __init__(self):
-        pass
+class WebConnector(DirectoryConnector):
+    def __init__(self, urls: List[str] = None, html_to_text: bool = True):
+        self.urls = urls
+        self.html_to_text = html_to_text
 
     def generate_documents(self) -> Iterator[Tuple[str, Dict]]:  # -> Iterator[Document]:
-        pass
+        from llama_index.readers.web import SimpleWebPageReader
 
-    def generate_passages(self, documents: List[Document], chunk_size: int = 1024) -> Iterator[Tuple[str, Dict]]:  # -> Iterator[Passage]:
-        pass
+        documents = SimpleWebPageReader(html_to_text=self.html_to_text).load_data(self.urls)
+        for document in documents:
+            yield document.text, {"url": document.id_}
 
 
 class VectorDBConnector(DataConnector):

--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -65,6 +65,7 @@ def load_all_function_sets(merge: bool = True) -> dict:
             if dir_path == USER_FUNCTIONS_DIR:
                 # For user scripts, adjust the module name appropriately
                 module_full_path = os.path.join(dir_path, file)
+                print(f"Loading user function set from '{module_full_path}'")
                 try:
                     spec = importlib.util.spec_from_file_location(module_name, module_full_path)
                     module = importlib.util.module_from_spec(spec)

--- a/memgpt/presets/presets.py
+++ b/memgpt/presets/presets.py
@@ -2,7 +2,7 @@ from typing import List
 import os
 from memgpt.data_types import AgentState, Preset
 from memgpt.interface import AgentInterface
-from memgpt.presets.utils import load_all_presets, is_valid_yaml_format
+from memgpt.presets.utils import load_all_presets, is_valid_yaml_format, load_yaml_file
 from memgpt.utils import get_human_text, get_persona_text, printd, list_human_files, list_persona_files
 from memgpt.prompts import gpt_system
 from memgpt.functions.functions import load_all_function_sets
@@ -34,6 +34,28 @@ def add_default_humans_and_personas(user_id: uuid.UUID, ms: MetadataStore):
             continue
         human = HumanModel(name=name, text=text, user_id=user_id)
         ms.add_human(human)
+
+
+def create_preset_from_file(filename: str, name: str, user_id: uuid.UUID, ms: MetadataStore) -> Preset:
+    preset_config = load_yaml_file(filename)
+    preset_system_prompt = preset_config["system_prompt"]
+    preset_function_set_names = preset_config["functions"]
+    functions_schema = generate_functions_json(preset_function_set_names)
+
+    if ms.get_preset(user_id=user_id, preset_name=name) is not None:
+        printd(f"Preset '{name}' already exists for user '{user_id}'")
+        return ms.get_preset(user_id=user_id, preset_name=name)
+
+    preset = Preset(
+        user_id=user_id,
+        name=name,
+        system=gpt_system.get_system_text(preset_system_prompt),
+        persona=get_persona_text(DEFAULT_PERSONA),
+        human=get_human_text(DEFAULT_HUMAN),
+        functions_schema=functions_schema,
+    )
+    ms.create_preset(preset)
+    return preset
 
 
 def add_default_presets(user_id: uuid.UUID, ms: MetadataStore):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
* Presets are now stored in the DB, not in files, so this PR updates the CLI to allow adding a preset via specifying a preset YAML file. 
* Also minor bugfixes with reading persona information from the DB instead of local files on `memgpt run`. 


**How to test**
```
> memgpt load preset -f custom_preset.yaml --name my_preset
> memgpt list presets
> memgpt delete preset my_preset 
```

**Have you tested this PR?**
Yes
