### PR TITLE
feat: during agent creation - create new presets in the DB if the preset had overrides

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -24,7 +24,7 @@ from memgpt.constants import MEMGPT_DIR, CLI_WARNING_PREFIX, JSON_ENSURE_ASCII
 from memgpt.agent import Agent, save_agent
 from memgpt.embeddings import embedding_model
 from memgpt.server.constants import WS_DEFAULT_PORT, REST_DEFAULT_PORT
-from memgpt.data_types import AgentState, LLMConfig, EmbeddingConfig, User, Passage
+from memgpt.data_types import AgentState, LLMConfig, EmbeddingConfig, User, Passage, Preset
 from memgpt.metadata import MetadataStore
 from memgpt.migrate import migrate_all_agents, migrate_all_sources
 
@@ -673,9 +673,9 @@ def run(
             # If the user overrode any parts of the preset, we need to create a new preset to refer back to
             if preset_override:
                 # Change the name and uuid
-                preset_obj = preset_obj.clone()
+                preset_obj = Preset.clone(preset_obj=preset_obj)
                 # Then write out to the database for storage
-                preset_obj = ms.create_preset(preset=preset_obj)
+                ms.create_preset(preset=preset_obj)
 
             typer.secho(f"->  🤖 Using persona profile: '{preset_obj.persona_name}'", fg=typer.colors.WHITE)
             typer.secho(f"->  🧑 Using human profile: '{preset_obj.human_name}'", fg=typer.colors.WHITE)

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -552,6 +552,21 @@ class Preset(BaseModel):
     # functions: List[str] = Field(..., description="The functions of the preset.") # TODO: convert to ID
     # sources: List[str] = Field(..., description="The sources of the preset.") # TODO: convert to ID
 
+    @staticmethod
+    def clone(preset_obj: "Preset", new_name_suffix: str = None) -> "Preset":
+        """
+        Takes a Preset object and an optional new name suffix as input,
+        creates a clone of the given Preset object with a new ID and an optional new name,
+        and returns the new Preset object.
+        """
+        new_preset = preset_obj.model_copy()
+        new_preset.id = uuid.uuid4()
+        if new_name_suffix:
+            new_preset.name = f"{preset_obj.name}_{new_name_suffix}"
+        else:
+            new_preset.name = f"{preset_obj.name}_{str(uuid.uuid4())[:8]}"
+        return new_preset
+
 
 class Function(BaseModel):
     name: str = Field(..., description="The name of the function.")

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -648,7 +648,7 @@ class MetadataStore:
             session.commit()
 
     @enforce_types
-    def get_human(self, name: str, user_id: uuid.UUID) -> str:
+    def get_human(self, name: str, user_id: uuid.UUID) -> Optional[HumanModel]:
         with self.session_maker() as session:
             results = session.query(HumanModel).filter(HumanModel.name == name).filter(HumanModel.user_id == user_id).all()
             if len(results) == 0:
@@ -657,7 +657,7 @@ class MetadataStore:
             return results[0]
 
     @enforce_types
-    def get_persona(self, name: str, user_id: uuid.UUID) -> str:
+    def get_persona(self, name: str, user_id: uuid.UUID) -> Optional[PersonaModel]:
         with self.session_maker() as session:
             results = session.query(PersonaModel).filter(PersonaModel.name == name).filter(PersonaModel.user_id == user_id).all()
             if len(results) == 0:

--- a/memgpt/server/rest_api/agents/index.py
+++ b/memgpt/server/rest_api/agents/index.py
@@ -65,8 +65,8 @@ def setup_agents_index_router(server: SyncServer, interface: QueuingInterface, p
                     # TODO turn into a pydantic model
                     name=request.config["name"],
                     preset=request.config["preset"] if "preset" in request.config else None,
-                    # persona_name=request.config["persona_name"] if "persona_name" in request.config else None,
-                    # human_name=request.config["human_name"] if "human_name" in request.config else None,
+                    persona_name=request.config["persona_name"] if "persona_name" in request.config else None,
+                    human_name=request.config["human_name"] if "human_name" in request.config else None,
                     persona=request.config["persona"] if "persona" in request.config else None,
                     human=request.config["human"] if "human" in request.config else None,
                     # llm_config=LLMConfigModel(

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -648,9 +648,9 @@ class SyncServer(LockingServer):
             # If the user overrode any parts of the preset, we need to create a new preset to refer back to
             if preset_override:
                 # Change the name and uuid
-                preset_obj = preset_obj.clone()
+                preset_obj = Preset.clone(preset_obj=preset_obj)
                 # Then write out to the database for storage
-                preset_obj = self.ms.create_preset(preset=preset_obj)
+                self.ms.create_preset(preset=preset_obj)
 
             agent = Agent(
                 interface=interface,

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -575,6 +575,8 @@ class SyncServer(LockingServer):
         preset: Optional[str] = None,
         persona: Optional[str] = None,  # NOTE: this is not the name, it's the memory init value
         human: Optional[str] = None,  # NOTE: this is not the name, it's the memory init value
+        persona_name: Optional[str] = None,
+        human_name: Optional[str] = None,
         llm_config: Optional[LLMConfig] = None,
         embedding_config: Optional[EmbeddingConfig] = None,
         interface: Union[AgentInterface, None] = None,
@@ -609,7 +611,7 @@ class SyncServer(LockingServer):
             logger.debug(f"Attempting to create agent from preset:\n{preset_obj}")
 
             # Overwrite fields in the preset if they were specified
-            if human is not None:
+            if human is not None and human != preset_obj.human:
                 preset_override = True
                 preset_obj.human = human
                 # This is a check for a common bug where users were providing filenames instead of values
@@ -632,6 +634,12 @@ class SyncServer(LockingServer):
                     )
                 except:
                     pass
+            if human_name is not None and human_name != preset_obj.human_name:
+                preset_override = True
+                preset_obj.human_name = human_name
+            if persona_name is not None and persona_name != preset_obj.persona_name:
+                preset_override = True
+                preset_obj.persona_name = persona_name
 
             llm_config = llm_config if llm_config else self.server_llm_config
             embedding_config = embedding_config if embedding_config else self.server_embedding_config


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

In both the `server` and `CLI`:

- If the preset is modified in some way (eg `preset_obj.persona = ...`) before it is used to create an agent:
  - First create a new `Preset` (using `preset_obj.name` + a random suffix, and a new `preset_obj.id`
  - Then commit the new `Preset` to the database
  - Then reassign `preset_obj` to the new `Preset` before passing it to the `Agent` constructor

**How to test**

In the UI when we create new agents, they should now show as having `persona/human_name` drawn from the custom values instead of the `Preset` defaults (`basic` / `cs_phd`).

**Have you tested this PR?**

Yes, cols reflect properly now.