### PR TITLE
feat: return source metadata with `list sources` route

### DIFF
--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -100,16 +100,7 @@ class SourceModel(SQLModel, table=True):
     embedding_config: Optional[EmbeddingConfigModel] = Field(
         None, sa_column=Column(JSON), description="The embedding configuration used by the passage."
     )
-
-
-class SourceMetadata(BaseModel):
-    num_documents: int = Field(..., description="The number of documents that are part of the source.")
-    num_passages: int = Field(..., description="The number of passages that are part of the source.")
-
-
-class SourceModelWithMetadata(BaseModel):
-    source: SourceModel = Field(..., description="The source model.")
-    metadata: SourceMetadata = Field(..., description="Metadata associated with the source model.")
+    source_metadata: Optional[dict] = Field(None, sa_column=Column(JSON), description="Metadata associated with the source.")
 
 
 class PassageModel(BaseModel):

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Literal
+from typing import List, Optional, Dict, Literal, Type
 from pydantic import BaseModel, Field, Json, ConfigDict
 import uuid
 import base64
@@ -91,7 +91,7 @@ class PersonaModel(SQLModel, table=True):
 
 class SourceModel(SQLModel, table=True):
     name: str = Field(..., description="The name of the source.")
-    description: str = Field(None, description="The description of the source.")
+    description: Optional[str] = Field(None, description="The description of the source.")
     user_id: uuid.UUID = Field(..., description="The unique identifier of the user associated with the source.")
     created_at: datetime = Field(default_factory=datetime.now, description="The unix timestamp of when the source was created.")
     id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the source.", primary_key=True)
@@ -100,6 +100,16 @@ class SourceModel(SQLModel, table=True):
     embedding_config: Optional[EmbeddingConfigModel] = Field(
         None, sa_column=Column(JSON), description="The embedding configuration used by the passage."
     )
+
+
+class SourceMetadata(BaseModel):
+    num_documents: int = Field(..., description="The number of documents that are part of the source.")
+    num_passages: int = Field(..., description="The number of passages that are part of the source.")
+
+
+class SourceModelWithMetadata(BaseModel):
+    source: SourceModel = Field(..., description="The source model.")
+    metadata: SourceMetadata = Field(..., description="Metadata associated with the source model.")
 
 
 class PassageModel(BaseModel):

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -100,7 +100,8 @@ class SourceModel(SQLModel, table=True):
     embedding_config: Optional[EmbeddingConfigModel] = Field(
         None, sa_column=Column(JSON), description="The embedding configuration used by the passage."
     )
-    source_metadata: Optional[dict] = Field(None, sa_column=Column(JSON), description="Metadata associated with the source.")
+    # NOTE: .metadata is a reserved attribute on SQLModel
+    metadata_: Optional[dict] = Field(None, sa_column=Column(JSON), description="Metadata associated with the source.")
 
 
 class PassageModel(BaseModel):

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -65,6 +65,7 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
     async def list_source(
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
+        """List all data sources created by a user."""
         # Clear the interface
         interface.clear()
 
@@ -76,6 +77,7 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
         request: CreateSourceRequest = Body(...),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
+        """Create a new data source."""
         interface.clear()
         try:
             # TODO: don't use Source and just use SourceModel once pydantic migration is complete
@@ -98,6 +100,7 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
         source_id,
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
+        """Delete a data source."""
         interface.clear()
         try:
             server.delete_source(source_id=uuid.UUID(source_id), user_id=user_id)
@@ -113,6 +116,7 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
         source_name: str = Query(..., description="The name of the source to attach."),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
+        """Attach a data source to an existing agent."""
         interface.clear()
         assert isinstance(agent_id, uuid.UUID), f"Expected agent_id to be a UUID, got {agent_id}"
         assert isinstance(user_id, uuid.UUID), f"Expected user_id to be a UUID, got {user_id}"
@@ -132,6 +136,7 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
         source_name: str = Query(..., description="The name of the source to detach."),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
+        """Detach a data source from an existing agent."""
         server.detach_source_from_agent(source_name=source_name, agent_id=agent_id, user_id=user_id)
 
     @router.post("/sources/upload", tags=["sources"], response_model=UploadFileToSourceResponse)
@@ -141,6 +146,7 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
         source_id: uuid.UUID = Query(..., description="The unique identifier of the source to attach."),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
+        """Upload a file to a data source."""
         interface.clear()
         source = server.ms.get_source(source_id=source_id, user_id=user_id)
 
@@ -158,13 +164,17 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
         source_id: uuid.UUID = Body(...),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
-        raise NotImplementedError
+        """List all passages associated with a data source."""
+        passages = server.list_data_source_passages(user_id=user_id, source_id=source_id)
+        return GetSourcePassagesResponse(passages=passages)
 
     @router.get("/sources/documents", tags=["sources"], response_model=GetSourceDocumentsResponse)
     async def list_documents(
         source_id: uuid.UUID = Body(...),
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
-        raise NotImplementedError
+        """List all documents associated with a data source."""
+        documents = server.list_data_source_documents(user_id=user_id, source_id=source_id)
+        return GetSourceDocumentsResponse(documents=documents)
 
     return router

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, Depends, Query, HTTPException, status, Uplo
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from memgpt.models.pydantic_models import SourceModel, SourceModelWithMetadata, PassageModel, DocumentModel
+from memgpt.models.pydantic_models import SourceModel, PassageModel, DocumentModel
 from memgpt.server.rest_api.auth_token import get_current_user
 from memgpt.server.rest_api.interface import QueuingInterface
 from memgpt.server.server import SyncServer
@@ -28,7 +28,7 @@ Implement the following functions:
 
 
 class ListSourcesResponse(BaseModel):
-    sources: List[SourceModelWithMetadata] = Field(..., description="List of available sources + metadata.")
+    sources: List[SourceModel] = Field(..., description="List of available sources.")
 
 
 class CreateSourceRequest(BaseModel):

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from functools import wraps
 from threading import Lock
 from typing import Union, Callable, Optional, List
+import warnings
 
 from fastapi import HTTPException
 import uvicorn
@@ -36,7 +37,7 @@ from memgpt.data_types import (
     Preset,
 )
 
-from memgpt.models.pydantic_models import SourceModelWithMetadata, SourceMetadata
+from memgpt.models.pydantic_models import SourceModelWithMetadata, SourceMetadata, PassageModel, DocumentModel
 from memgpt.interface import AgentInterface  # abstract
 
 # TODO use custom interface
@@ -1295,6 +1296,14 @@ class SyncServer(LockingServer):
         # list all attached sources to an agent
         return self.ms.list_attached_sources(agent_id)
 
+    def list_data_source_passages(self, user_id: uuid.UUID, source_id: uuid.UUID) -> List[PassageModel]:
+        warnings.warn("list_data_source_passages is not yet implemented, returning empty list.", category=UserWarning)
+        return []
+
+    def list_data_source_documents(self, user_id: uuid.UUID, source_id: uuid.UUID) -> List[DocumentModel]:
+        warnings.warn("list_data_source_documents is not yet implemented, returning empty list.", category=UserWarning)
+        return []
+
     def list_all_sources(self, user_id: uuid.UUID) -> List[SourceModelWithMetadata]:
         """List all sources (w/ extra metadata) belonging to a user"""
 
@@ -1304,16 +1313,16 @@ class SyncServer(LockingServer):
         sources_with_metadata = []
         for source in sources:
 
-            num_passages = 0
-            num_documents = 0
+            passages = self.list_data_source_passages(user_id=user_id, source_id=source.id)
+            documents = self.list_data_source_documents(user_id=user_id, source_id=source.id)
 
             sources_with_metadata.append(
                 SourceModelWithMetadata(
                     source=source,
                     # extra metadata
                     metadata=SourceMetadata(
-                        num_documents=num_documents,
-                        num_passages=num_passages,
+                        num_documents=len(passages),
+                        num_passages=len(documents),
                     ),
                 )
             )

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1330,7 +1330,7 @@ class SyncServer(LockingServer):
             documents = self.list_data_source_documents(user_id=user_id, source_id=source.id)
 
             # Overwrite metadata field, should be empty anyways
-            source.source_metadata = dict(
+            source.metadata_ = dict(
                 num_documents=len(passages),
                 num_passages=len(documents),
             )

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -35,6 +35,8 @@ from memgpt.data_types import (
     Token,
     Preset,
 )
+
+from memgpt.models.pydantic_models import SourceModelWithMetadata, SourceMetadata
 from memgpt.interface import AgentInterface  # abstract
 
 # TODO use custom interface
@@ -1292,3 +1294,28 @@ class SyncServer(LockingServer):
     def list_attached_sources(self, agent_id: uuid.UUID):
         # list all attached sources to an agent
         return self.ms.list_attached_sources(agent_id)
+
+    def list_all_sources(self, user_id: uuid.UUID) -> List[SourceModelWithMetadata]:
+        """List all sources (w/ extra metadata) belonging to a user"""
+
+        sources = self.ms.list_sources(user_id=user_id)
+
+        # Add extra metadata to the sources
+        sources_with_metadata = []
+        for source in sources:
+
+            num_passages = 0
+            num_documents = 0
+
+            sources_with_metadata.append(
+                SourceModelWithMetadata(
+                    source=source,
+                    # extra metadata
+                    metadata=SourceMetadata(
+                        num_documents=num_documents,
+                        num_passages=num_passages,
+                    ),
+                )
+            )
+
+        return sources_with_metadata


### PR DESCRIPTION
`GET http://localhost:8283/api/sources` now returns metadata along with source information.

NOTE @sarahwooders : `embedding_config` and `description` fields are currently bugged until `Source` is deprecated in favor of pydantic `SourceModel` throughout the code (punting to separate PR).

```
GET http://localhost:8283/api/sources
```
```
{
	"sources": [
		{
			"name": "custom-source",
			"description": null,
			"user_id": "00000000-0000-0000-0000-000000000000",
			"created_at": "2024-03-17T16:48:54.418499",
			"id": "01e0035f-c506-4f3b-adfc-6ed920725de2",
			"embedding_config": {
				"embedding_endpoint_type": "openai",
				"embedding_endpoint": "https://api.openai.com/v1",
				"embedding_model": "text-embedding-ada-002",
				"embedding_dim": 1536,
				"embedding_chunk_size": 300
			},
			"source_metadata": {
				"num_documents": 0,
				"num_passages": 0
			}
		},
```

**Have you tested this PR?**

~~- [ ] Replace `num_documents` / `num_passages` placeholder values with real data~~
- -> future PR