### PR TITLE
feat: return information on attached agents when getting list of sources from API

### DIFF
--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1367,6 +1367,7 @@ class SyncServer(LockingServer):
             source.metadata_ = dict(
                 num_documents=len(passages),
                 num_passages=len(documents),
+                attached_agents=[],
             )
 
             sources_with_metadata.append(source)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1362,12 +1362,21 @@ class SyncServer(LockingServer):
 
             passages = self.list_data_source_passages(user_id=user_id, source_id=source.id)
             documents = self.list_data_source_documents(user_id=user_id, source_id=source.id)
+            agent_ids = self.ms.list_attached_agents(source_id=source.id)
+            # add the agent name information
+            attached_agents = [
+                {
+                    "id": a_id,
+                    "name": self.ms.get_agent(user_id=user_id, agent_id=a_id).name,
+                }
+                for a_id in agent_ids
+            ]
 
             # Overwrite metadata field, should be empty anyways
             source.metadata_ = dict(
                 num_documents=len(passages),
                 num_passages=len(documents),
-                attached_agents=[],
+                attached_agents=attached_agents,
             )
 
             sources_with_metadata.append(source)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1366,7 +1366,7 @@ class SyncServer(LockingServer):
             # add the agent name information
             attached_agents = [
                 {
-                    "id": a_id,
+                    "id": str(a_id),
                     "name": self.ms.get_agent(user_id=user_id, agent_id=a_id).name,
                 }
                 for a_id in agent_ids


### PR DESCRIPTION
GET sources now returns extra metadata:

```python
{
  "attached_agents": [
    {"id": "XXX", "name": "YYY"},
    {"id": "XXX", "name": "YYY"},
  ]
}
```

```
,
		{
			"name": "custom-source3",
			"description": null,
			"user_id": "00000000-0000-0000-0000-000000000000",
			"created_at": "2024-03-18T16:33:56.517006",
			"id": "374a1aea-543f-4103-82e4-39ab24812209",
			"embedding_config": {
				"embedding_endpoint_type": "openai",
				"embedding_endpoint": "https://api.openai.com/v1",
				"embedding_model": "text-embedding-ada-002",
				"embedding_dim": 1536,
				"embedding_chunk_size": 300
			},
			"metadata_": {
				"num_documents": 0,
				"num_passages": 0,
				"attached_agents": []
			}
		}
	]
```
