### PR TITLE
feat: migrate all calls to `datetime.now()` to `datetime.now(UTC)`

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -17,6 +17,7 @@ from memgpt.system import get_login_event, package_function_response, package_su
 from memgpt.memory import CoreMemory as InContextMemory, summarize_messages, ArchivalMemory, RecallMemory
 from memgpt.llm_api_tools import create, is_context_overflow_error
 from memgpt.utils import (
+    get_utc_time,
     create_random_username,
     get_tool_call_id,
     get_local_time,
@@ -653,7 +654,7 @@ class Agent(object):
 
                     # Recreate timestamp
                     if recreate_message_timestamp:
-                        user_message.created_at = datetime.datetime.now()
+                        user_message.created_at = get_utc_time()
 
                 elif isinstance(user_message, str):
                     # Validate JSON via save/load
@@ -895,7 +896,7 @@ class Agent(object):
             return False
 
         # Check if it's been more than pause_heartbeats_minutes since pause_heartbeats_start
-        elapsed_time = datetime.datetime.now() - self.pause_heartbeats_start
+        elapsed_time = get_utc_time() - self.pause_heartbeats_start
         return elapsed_time.total_seconds() < self.pause_heartbeats_minutes * 60
 
     def rebuild_memory(self):

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -96,7 +96,7 @@ class Message(Record):
         self.agent_id = agent_id
         self.text = text
         self.model = model  # model name (e.g. gpt-4)
-        self.created_at = created_at if created_at is not None else datetime.now()
+        self.created_at = created_at if created_at is not None else get_utc_time()
 
         # openai info
         assert role in ["system", "assistant", "user", "tool"]
@@ -353,7 +353,7 @@ class Passage(Record):
         self.embedding_dim = embedding_dim
         self.embedding_model = embedding_model
 
-        self.created_at = created_at if created_at is not None else datetime.now()
+        self.created_at = created_at if created_at is not None else get_utc_time()
 
         if self.embedding is not None:
             assert self.embedding_dim, f"Must specify embedding_dim if providing an embedding"
@@ -495,7 +495,7 @@ class AgentState:
         self.llm_config = llm_config
         self.embedding_config = embedding_config
 
-        self.created_at = created_at if created_at is not None else datetime.now()
+        self.created_at = created_at if created_at is not None else get_utc_time()
 
         # state
         self.state = {} if not state else state
@@ -521,7 +521,7 @@ class Source:
 
         self.name = name
         self.user_id = user_id
-        self.created_at = created_at if created_at is not None else datetime.now()
+        self.created_at = created_at if created_at is not None else get_utc_time()
 
         # embedding info (optional)
         self.embedding_dim = embedding_dim
@@ -553,7 +553,7 @@ class Preset(BaseModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the preset.")
     user_id: Optional[uuid.UUID] = Field(None, description="The unique identifier of the user who created the preset.")
     description: Optional[str] = Field(None, description="The description of the preset.")
-    created_at: datetime = Field(default_factory=datetime.now, description="The unix timestamp of when the preset was created.")
+    created_at: datetime = Field(default_factory=get_utc_time, description="The unix timestamp of when the preset was created.")
     system: str = Field(..., description="The system prompt of the preset.")
     persona: str = Field(default=get_persona_text(DEFAULT_PERSONA), description="The persona of the preset.")
     persona_name: Optional[str] = Field(None, description="The name of the persona of the preset.")

--- a/memgpt/functions/function_sets/base.py
+++ b/memgpt/functions/function_sets/base.py
@@ -42,7 +42,7 @@ def pause_heartbeats(self: Agent, minutes: int) -> Optional[str]:
     minutes = min(MAX_PAUSE_HEARTBEATS, minutes)
 
     # Record the current time
-    self.pause_heartbeats_start = datetime.datetime.now()
+    self.pause_heartbeats_start = datetime.datetime.now(datetime.UTC)
     # And record how long the pause should go for
     self.pause_heartbeats_minutes = int(minutes)
 

--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -21,7 +21,7 @@ from memgpt.prompts.gpt_summarize import SYSTEM as SUMMARIZE_SYSTEM_MESSAGE
 from memgpt.errors import LocalLLMConnectionError, LocalLLMError
 from memgpt.constants import CLI_WARNING_PREFIX, JSON_ENSURE_ASCII
 from memgpt.models.chat_completion_response import ChatCompletionResponse, Choice, Message, ToolCall, UsageStatistics
-from memgpt.utils import get_tool_call_id
+from memgpt.utils import get_tool_call_id, get_utc_time
 
 has_shown_warning = False
 grammar_supported_backends = ["koboldcpp", "llamacpp", "webui", "webui-legacy"]
@@ -220,7 +220,7 @@ def get_chat_completion(
                 ),
             )
         ],
-        created=datetime.now().astimezone(),
+        created=get_utc_time(),
         model=model,
         # "This fingerprint represents the backend configuration that the model runs with."
         # system_fingerprint=user if user is not None else "null",

--- a/memgpt/migrate.py
+++ b/memgpt/migrate.py
@@ -21,6 +21,7 @@ from memgpt.data_types import AgentState, User, Passage, Source, Message
 from memgpt.metadata import MetadataStore
 from memgpt.utils import (
     MEMGPT_DIR,
+    get_utc_time,
     version_less_than,
     OpenAIBackcompatUnpickler,
     annotate_message_json_list_with_tool_calls,
@@ -46,7 +47,7 @@ def wipe_config_and_reconfigure(data_dir: str = MEMGPT_DIR, run_configure=True, 
         os.makedirs(os.path.join(data_dir, MIGRATION_BACKUP_FOLDER, "agents"))
 
     # Get the current timestamp in a readable format (e.g., YYYYMMDD_HHMMSS)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = get_utc_time().strftime("%Y%m%d_%H%M%S")
 
     # Construct the new backup directory name with the timestamp
     backup_filename = os.path.join(data_dir, MIGRATION_BACKUP_FOLDER, f"config_backup_{timestamp}")

--- a/memgpt/server/rest_api/openai_assistants/assistants.py
+++ b/memgpt/server/rest_api/openai_assistants/assistants.py
@@ -32,6 +32,7 @@ from memgpt.models.openai import (
 )
 from memgpt.data_types import LLMConfig, EmbeddingConfig, Message
 from memgpt.constants import DEFAULT_PRESET
+from memgpt.utils import get_utc_time
 
 router = APIRouter()
 
@@ -160,7 +161,7 @@ def setup_openai_assistant_router(server: SyncServer, interface: QueuingInterfac
             id=DEFAULT_PRESET,
             name="default_preset",
             description=request.description,
-            created_at=int(datetime.now().timestamp()),
+            created_at=int(get_utc_time().timestamp()),
             model=request.model,
             instructions=request.instructions,
             tools=request.tools,
@@ -176,7 +177,7 @@ def setup_openai_assistant_router(server: SyncServer, interface: QueuingInterfac
         # TODO: add file to assistant
         return AssistantFile(
             id=request.file_id,
-            created_at=int(datetime.now().timestamp()),
+            created_at=int(get_utc_time().timestamp()),
             assistant_id=assistant_id,
         )
 
@@ -411,7 +412,7 @@ def setup_openai_assistant_router(server: SyncServer, interface: QueuingInterfac
         agent = server._get_or_load_agent(user_id=user_id, agent_id=agent_id)
         agent.step(user_message=None)  # already has messages added
         run_id = str(uuid.uuid4())
-        create_time = int(datetime.now().timestamp())
+        create_time = int(get_utc_time().timestamp())
         return OpenAIRun(
             id=run_id,
             created_at=create_time,

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 import copy
 import re
 import json
@@ -839,7 +839,9 @@ def get_local_time(timezone=None):
 
 
 def get_utc_time() -> datetime:
-    return datetime.now(pytz.utc)
+    """Get the current UTC time"""
+    # return datetime.now(pytz.utc)
+    return datetime.now(UTC)
 
 
 def format_datetime(dt):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,7 +53,7 @@ def wipe_memgpt_home():
     """Wipes ~/.memgpt (moves to a backup), and initializes a new ~/.memgpt dir"""
 
     # Get the current timestamp in a readable format (e.g., YYYYMMDD_HHMMSS)
-    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d_%H%M%S")
 
     # Construct the new backup directory name with the timestamp
     backup_dir = f"~/.memgpt_test_backup_{timestamp}"


### PR DESCRIPTION
Standardize use of `datetime` to UTC only to avoid datetime issues with API / frontends.