### PR TITLE
fix: patch vllm/local endpoint model GET bug

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -224,7 +224,7 @@ def get_model_options(
         else:
             # Attempt to do OpenAI endpoint style model fetching
             # TODO support local auth
-            fetched_model_options_response = openai_get_model_list(url=model_endpoint, api_key=None)
+            fetched_model_options_response = openai_get_model_list(url=model_endpoint, api_key=None, fix_url=True)
             model_options = [obj["id"] for obj in fetched_model_options_response["data"]]
             # NOTE no filtering of local model options
 

--- a/memgpt/llm_api_tools.py
+++ b/memgpt/llm_api_tools.py
@@ -2,7 +2,7 @@ import random
 import time
 import requests
 import time
-from typing import Union
+from typing import Union, Optional
 import urllib
 
 from memgpt.credentials import MemGPTCredentials
@@ -81,9 +81,16 @@ def clean_azure_endpoint(raw_endpoint_name):
     return endpoint_address
 
 
-def openai_get_model_list(url: str, api_key: Union[str, None]) -> dict:
+def openai_get_model_list(url: str, api_key: Union[str, None], fix_url: Optional[bool] = False) -> dict:
     """https://platform.openai.com/docs/api-reference/models/list"""
     from memgpt.utils import printd
+
+    # In some cases we may want to double-check the URL and do basic correction, eg:
+    # In MemGPT config the address for vLLM is w/o a /v1 suffix for simplicity
+    # However if we're treating the server as an OpenAI proxy we want the /v1 suffix on our model hit
+    if fix_url:
+        if not url.endswith("/v1"):
+            url = smart_urljoin(url, "v1")
 
     url = smart_urljoin(url, "models")
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Model listing during CLI was broken for local endpoints because for our local model GETs (to generate the list): we assume the server supports the OpenAI-proxy style of `GET _/v1/models`, however we don't store local model endpoints with the `/v1` suffix since many of the local LLM inference servers don't use it.

This fixes the issue by appending a `/v1` in the model GET call if it doesn't exist (since on this call we're assuming OpenAI proxy anyways).

Working as intended:
<img width="510" alt="image" src="https://github.com/cpacker/MemGPT/assets/5475622/3a273917-5204-45ce-9a86-871a4c56f09e">
