### PR TITLE
replace hard-coded embeddings with config embeddings

### DIFF
--- a/memgpt/constants.py
+++ b/memgpt/constants.py
@@ -11,12 +11,12 @@ MAX_EMBEDDING_DIM = 4096  # maximum supported embeding size - do NOT change or e
 
 # tokenizers
 EMBEDDING_TO_TOKENIZER_MAP = {
-    "text-embedding-3-small": "cl100k_base",
+    "text-embedding-ada-002": "cl100k_base",
 }
 EMBEDDING_TO_TOKENIZER_DEFAULT = "cl100k_base"
 
 
-DEFAULT_MEMGPT_MODEL = "gpt-4-0125-preview"
+DEFAULT_MEMGPT_MODEL = "gpt-4"
 DEFAULT_PERSONA = "sam_pov"
 DEFAULT_HUMAN = "basic"
 DEFAULT_PRESET = "memgpt_chat"
@@ -56,7 +56,6 @@ LLM_MAX_TOKENS = {
     "DEFAULT": 8192,
     ## OpenAI models: https://platform.openai.com/docs/models/overview
     # gpt-4
-    "gpt-4-0125-preview": 128000,
     "gpt-4-1106-preview": 128000,
     "gpt-4": 8192,
     "gpt-4-32k": 32768,

--- a/memgpt/embeddings.py
+++ b/memgpt/embeddings.py
@@ -180,7 +180,7 @@ def embedding_model(config: EmbeddingConfig, user_id: Optional[uuid.UUID] = None
         from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 
         # https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#embeddings
-        model = "text-embedding-ada-002"
+        model = config.embedding_model
         deployment = credentials.azure_embedding_deployment if credentials.azure_embedding_deployment is not None else model
         return AzureOpenAIEmbedding(
             model=model,


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
replaced text-embedding-ada-002 embeddings with model.embedding_model from config.yaml

**How to test**
Indexing a file to the vector store now uses what's written on server_config.yaml

**Related issues or PRs**
https://github.com/cpacker/MemGPT/issues/1188

**Is your PR over 500 lines of code?**
No
