### PR TITLE
feat: added groq support via local option w/ auth

### DIFF
--- a/memgpt/local_llm/chat_completion_proxy.py
+++ b/memgpt/local_llm/chat_completion_proxy.py
@@ -13,6 +13,7 @@ from memgpt.local_llm.llamacpp.api import get_llamacpp_completion
 from memgpt.local_llm.koboldcpp.api import get_koboldcpp_completion
 from memgpt.local_llm.ollama.api import get_ollama_completion
 from memgpt.local_llm.vllm.api import get_vllm_completion
+from memgpt.local_llm.groq.api import get_groq_completion
 from memgpt.local_llm.llm_chat_completion_wrappers import simple_summary_wrapper
 from memgpt.local_llm.constants import DEFAULT_WRAPPER
 from memgpt.local_llm.utils import get_available_wrappers, count_tokens
@@ -155,6 +156,8 @@ def get_chat_completion(
             result, usage = get_ollama_completion(endpoint, auth_type, auth_key, model, prompt, context_window)
         elif endpoint_type == "vllm":
             result, usage = get_vllm_completion(endpoint, auth_type, auth_key, model, prompt, context_window, user)
+        elif endpoint_type == "groq":
+            result, usage = get_groq_completion(endpoint, auth_type, auth_key, model, prompt, context_window)
         else:
             raise LocalLLMError(
                 f"Invalid endpoint type {endpoint_type}, please set variable depending on your backend (webui, lmstudio, llamacpp, koboldcpp)"

--- a/memgpt/local_llm/constants.py
+++ b/memgpt/local_llm/constants.py
@@ -2,6 +2,7 @@
 from memgpt.local_llm.llm_chat_completion_wrappers.chatml import ChatMLInnerMonologueWrapper, ChatMLOuterInnerMonologueWrapper
 
 DEFAULT_ENDPOINTS = {
+    # Local
     "koboldcpp": "http://localhost:5001",
     "llamacpp": "http://localhost:8080",
     "lmstudio": "http://localhost:1234",
@@ -10,6 +11,9 @@ DEFAULT_ENDPOINTS = {
     "webui-legacy": "http://localhost:5000",
     "webui": "http://localhost:5000",
     "vllm": "http://localhost:8000",
+    # APIs
+    "openai": "https://api.openai.com",
+    "groq": "https://api.groq.com/openai",
 }
 
 DEFAULT_OLLAMA_MODEL = "dolphin2.2-mistral:7b-q6_K"

--- a/memgpt/local_llm/groq/api.py
+++ b/memgpt/local_llm/groq/api.py
@@ -1,0 +1,79 @@
+from urllib.parse import urljoin
+import requests
+from typing import Tuple
+
+from memgpt.local_llm.settings.settings import get_completions_settings
+from memgpt.local_llm.utils import post_json_auth_request
+from memgpt.utils import count_tokens
+
+
+API_CHAT_SUFFIX = "/v1/chat/completions"
+# LMSTUDIO_API_COMPLETIONS_SUFFIX = "/v1/completions"
+
+
+def get_groq_completion(endpoint: str, auth_type: str, auth_key: str, model: str, prompt: str, context_window: int) -> Tuple[str, dict]:
+    """TODO no support for function calling OR raw completions, so we need to route the request into /chat/completions instead"""
+    from memgpt.utils import printd
+
+    prompt_tokens = count_tokens(prompt)
+    if prompt_tokens > context_window:
+        raise Exception(f"Request exceeds maximum context length ({prompt_tokens} > {context_window} tokens)")
+
+    settings = get_completions_settings()
+    settings.update(
+        {
+            # see https://console.groq.com/docs/text-chat, supports:
+            # "temperature": ,
+            # "max_tokens": ,
+            # "top_p",
+            # "stream",
+            # "stop",
+        }
+    )
+
+    URI = urljoin(endpoint.strip("/") + "/", API_CHAT_SUFFIX.strip("/"))
+
+    # Settings for the generation, includes the prompt + stop tokens, max length, etc
+    request = settings
+    request["model"] = model
+    request["max_tokens"] = context_window
+    # NOTE: Hack for chat/completion-only endpoints: put the entire completion string inside the first message
+    message_structure = [{"role": "user", "content": prompt}]
+    request["messages"] = message_structure
+
+    if not endpoint.startswith(("http://", "https://")):
+        raise ValueError(f"Provided OPENAI_API_BASE value ({endpoint}) must begin with http:// or https://")
+
+    try:
+        response = post_json_auth_request(uri=URI, json_payload=request, auth_type=auth_type, auth_key=auth_key)
+        if response.status_code == 200:
+            result_full = response.json()
+            printd(f"JSON API response:\n{result_full}")
+            result = result_full["choices"][0]["message"]["content"]
+            usage = result_full.get("usage", None)
+        else:
+            # Example error: msg={"error":"Context length exceeded. Tokens in context: 8000, Context length: 8000"}
+            if "context length" in str(response.text).lower():
+                # "exceeds context length" is what appears in the LM Studio error message
+                # raise an alternate exception that matches OpenAI's message, which is "maximum context length"
+                raise Exception(f"Request exceeds maximum context length (code={response.status_code}, msg={response.text}, URI={URI})")
+            else:
+                raise Exception(
+                    f"API call got non-200 response code (code={response.status_code}, msg={response.text}) for address: {URI}."
+                    + f" Make sure that the inference server is running and reachable at {URI}."
+                )
+    except:
+        # TODO handle gracefully
+        raise
+
+    # Pass usage statistics back to main thread
+    # These are used to compute memory warning messages
+    completion_tokens = usage.get("completion_tokens", None) if usage is not None else None
+    total_tokens = prompt_tokens + completion_tokens if completion_tokens is not None else None
+    usage = {
+        "prompt_tokens": prompt_tokens,  # can grab from usage dict, but it's usually wrong (set to 0)
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
+
+    return result, usage

--- a/paper_experiments/nested_kv_task/nested_kv.py
+++ b/paper_experiments/nested_kv_task/nested_kv.py
@@ -18,6 +18,7 @@ total KV lookups are required to find the final value), and
 sample 30 different ordering configurations including both
 the initial key position and nesting key positions.
 """
+
 import math
 import json
 import argparse

--- a/tests/test_json_parsers.py
+++ b/tests/test_json_parsers.py
@@ -4,6 +4,14 @@ from memgpt.constants import JSON_LOADS_STRICT
 import memgpt.local_llm.json_parser as json_parser
 
 
+EXAMPLE_ESCAPED_UNDERSCORES = """{
+  "function":"send\_message",
+  "params": {
+    "inner\_thoughts": "User is asking for information about themselves. Retrieving data from core memory.",
+    "message": "I know that you are Chad. Is there something specific you would like to know or talk about regarding yourself?"
+"""
+
+
 EXAMPLE_MISSING_CLOSING_BRACE = """{
   "function": "send_message",
   "params": {
@@ -72,6 +80,7 @@ def test_json_parsers():
     """Try various broken JSON and check that the parsers can fix it"""
 
     test_strings = [
+        EXAMPLE_ESCAPED_UNDERSCORES,
         EXAMPLE_MISSING_CLOSING_BRACE,
         EXAMPLE_BAD_TOKEN_END,
         EXAMPLE_DOUBLE_JSON,


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Adds Groq API support.

Note: Groq API doesn't support either function calling OR a raw `/completions` (not `/chat/completions`) API route. Because of this, we need to package our MemGPT prompt into a dummy user message inside the `/chat/completions` payload - this is very similar to how the `lmstudio-legacy` option works.

TODO in the future once Groq's API either allows function calling (and it stable / works well) and/or adds support for raw `/completions` endpoints, we should deprecate this code into `groq-legacy` similar to `lmstudio-legacy`.

**How to test**

```
(pymemgpt-PCQPn4ce-py3.10) (base) loaner@MacBook-Pro-55 MemGPT-2 % memgpt configure
Loading config from /Users/loaner/.memgpt/config
? Select LLM inference provider: local
? Select LLM backend (select 'openai' if you have an OpenAI compatible proxy): groq
? Enter default endpoint: https://api.groq.com/openai
? Enter your Groq API key: ********************************************************
? Select default model: mixtral-8x7b-32768
? Select default model wrapper (recommended: chatml): chatml
? Select your model's context window (for Mistral 7B models, this is probably 8k / 8192): 32768
? Select embedding provider: openai
? Select default preset: memgpt_chat
? Select default persona: sam_pov
? Select default human: basic
? Select storage backend for archival data: chroma
? Select chroma backend: persistent
? Select storage backend for recall data: sqlite
📖 Saving config to /Users/loaner/.memgpt/config

(pymemgpt-PCQPn4ce-py3.10) (base) loaner@MacBook-Pro-55 MemGPT-2 % memgpt run
Loading config from /Users/loaner/.memgpt/config

? Would you like to select an existing agent? No

🧬 Creating new agent...
->  🤖 Using persona profile: 'sam_pov'
->  🧑 Using human profile: 'basic'
Loading config from /Users/loaner/.memgpt/config
Loading config from /Users/loaner/.memgpt/config
🎉 Created new agent 'DecisiveSeashell' (id=d4666cde-aa82-44b2-bffd-bb0587bee324)

Hit enter to begin (will request first MemGPT message)

💭 User logged in. Welcome, Chad. Initiating persona protocols.
🤖 Hello Chad, I'm Sam. It's nice to meet you.
> Enter your message:
```