### PR TITLE
fix: duplicate passage across/within files causing issues in insert_many with postgres

### DIFF
--- a/memgpt/data_sources/connectors.py
+++ b/memgpt/data_sources/connectors.py
@@ -37,6 +37,7 @@ def load_data(
 
     # insert passages/documents
     passages = []
+    embedding_to_document_name = {}
     passage_count = 0
     document_count = 0
     for document_text, document_metadata in connector.generate_documents():
@@ -75,7 +76,17 @@ def load_data(
                 embedding=embedding,
             )
 
+            hashable_embedding = tuple(passage.embedding)
+            document_name = document.metadata.get("file_path", document.id)
+            if hashable_embedding in embedding_to_document_name:
+                typer.secho(
+                    f"Warning: Duplicate embedding found for passage in {document_name} (already exists in {embedding_to_document_name[hashable_embedding]}), skipping insert into VectorDB.",
+                    fg=typer.colors.YELLOW,
+                )
+                continue
+
             passages.append(passage)
+            embedding_to_document_name[hashable_embedding] = document_name
             if len(passages) >= embedding_config.embedding_chunk_size:
                 # insert passages into passage store
                 passage_store.insert_many(passages)

--- a/paper_experiments/nested_kv_task/nested_kv.py
+++ b/paper_experiments/nested_kv_task/nested_kv.py
@@ -18,6 +18,7 @@ total KV lookups are required to find the final value), and
 sample 30 different ordering configurations including both
 the initial key position and nesting key positions.
 """
+
 import math
 import json
 import argparse


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Bug Fix for https://github.com/cpacker/MemGPT/issues/1197

**How to test**
Try to load two files that would chunk to same text. Both will produce the same embedding. Insert Many will fail because of constraint violation.

**Have you tested this PR?**
Yes

**Related issues or PRs**
[Issue](https://github.com/cpacker/MemGPT/issues/1197)