### PR TITLE
fix: skip empty string passages returned by llama index parsing

### DIFF
--- a/memgpt/data_sources/connectors.py
+++ b/memgpt/data_sources/connectors.py
@@ -55,6 +55,16 @@ def load_data(
 
         # generate passages
         for passage_text, passage_metadata in connector.generate_passages([document], chunk_size=embedding_config.embedding_chunk_size):
+
+            # for some reason, llama index parsers sometimes return empty strings
+            if len(passage_text) == 0:
+                typer.secho(
+                    f"Warning: Llama index parser returned empty string, skipping insert of passage with metadata '{passage_metadata}' into VectorDB. You can usually ignore this warning.",
+                    fg=typer.colors.YELLOW,
+                )
+                continue
+
+            # get embedding
             try:
                 embedding = embed_model.get_text_embedding(passage_text)
             except Exception as e:

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -157,10 +157,6 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
 
         # write the file to a temporary directory (deleted after the context manager exits)
         with tempfile.TemporaryDirectory() as tmpdirname:
-<<<<<<< HEAD
-=======
-            print("TEMPORARY DIRECTORY", tmpdirname)
->>>>>>> 25b1ac3 (fix file upload route)
             file_path = os.path.join(tmpdirname, file.filename)
             with open(file_path, "wb") as buffer:
                 buffer.write(file.file.read())

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -157,6 +157,10 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
 
         # write the file to a temporary directory (deleted after the context manager exits)
         with tempfile.TemporaryDirectory() as tmpdirname:
+<<<<<<< HEAD
+=======
+            print("TEMPORARY DIRECTORY", tmpdirname)
+>>>>>>> 25b1ac3 (fix file upload route)
             file_path = os.path.join(tmpdirname, file.filename)
             with open(file_path, "wb") as buffer:
                 buffer.write(file.file.read())


### PR DESCRIPTION
For some reason llama-index parsers return nodes with empty strings, which causes errors with computing the embedding. 