### PR TITLE
fix: fallback to `MemGPTConfig` URI for postgres if no environment variables 

### DIFF
--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -307,13 +307,15 @@ class MetadataStore:
             # construct URI from enviornment variables
             if os.getenv("MEMGPT_PGURI"):
                 self.uri = os.getenv("MEMGPT_PGURI")
-            else:
+            elif os.getenv("MEMGPT_PG_DB"):
                 db = os.getenv("MEMGPT_PG_DB", "memgpt")
                 user = os.getenv("MEMGPT_PG_USER", "memgpt")
                 password = os.getenv("MEMGPT_PG_PASSWORD", "memgpt")
                 port = os.getenv("MEMGPT_PG_PORT", "5432")
                 url = os.getenv("MEMGPT_PG_URL", "localhost")
                 self.uri = f"postgresql+pg8000://{user}:{password}@{url}:{port}/{db}"
+            else:
+                self.uri = config.metadata_storage_uri
         elif config.metadata_storage_type == "sqlite":
             path = os.path.join(config.metadata_storage_path, "sqlite.db")
             self.uri = f"sqlite:///{path}"

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -157,10 +157,6 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
 
         # write the file to a temporary directory (deleted after the context manager exits)
         with tempfile.TemporaryDirectory() as tmpdirname:
-<<<<<<< HEAD
-=======
-            print("TEMPORARY DIRECTORY", tmpdirname)
->>>>>>> 25b1ac3 (fix file upload route)
             file_path = os.path.join(tmpdirname, file.filename)
             with open(file_path, "wb") as buffer:
                 buffer.write(file.file.read())

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -157,6 +157,10 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
 
         # write the file to a temporary directory (deleted after the context manager exits)
         with tempfile.TemporaryDirectory() as tmpdirname:
+<<<<<<< HEAD
+=======
+            print("TEMPORARY DIRECTORY", tmpdirname)
+>>>>>>> 25b1ac3 (fix file upload route)
             file_path = os.path.join(tmpdirname, file.filename)
             with open(file_path, "wb") as buffer:
                 buffer.write(file.file.read())


### PR DESCRIPTION
We will eventually use environment variables for the postgres URI, but need to continue using the config for backcompat. 