### PR TITLE
fix: errors on getting default config values on fresh install 

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -64,10 +64,12 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
     model_endpoint_type, model_endpoint = None, None
 
     # get default
-    default_model_endpoint_type = config.default_llm_config.model_endpoint_type
-    if config.default_llm_config.model_endpoint_type is not None and config.default_llm_config.model_endpoint_type not in [
-        provider for provider in LLM_API_PROVIDER_OPTIONS if provider != "local"
-    ]:  # local model
+    default_model_endpoint_type = config.default_llm_config.model_endpoint_type if config.default_embedding_config else None
+    if (
+        config.default_llm_config
+        and config.default_llm_config.model_endpoint_type is not None
+        and config.default_llm_config.model_endpoint_type not in [provider for provider in LLM_API_PROVIDER_OPTIONS if provider != "local"]
+    ):  # local model
         default_model_endpoint_type = "local"
 
     provider = questionary.select(
@@ -231,7 +233,7 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
         backend_options = builtins.list(DEFAULT_ENDPOINTS.keys())
         # assert backend_options_old == backend_options, (backend_options_old, backend_options)
         default_model_endpoint_type = None
-        if config.default_llm_config.model_endpoint_type in backend_options:
+        if config.default_llm_config and config.default_llm_config.model_endpoint_type in backend_options:
             # set from previous config
             default_model_endpoint_type = config.default_llm_config.model_endpoint_type
         model_endpoint_type = questionary.select(
@@ -257,7 +259,7 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
                     model_endpoint = questionary.text("Enter default endpoint:", default=default_model_endpoint).ask()
                     if model_endpoint is None:
                         raise KeyboardInterrupt
-            elif config.default_llm_config.model_endpoint:
+            elif config.default_llm_config and config.default_llm_config.model_endpoint:
                 model_endpoint = questionary.text("Enter default endpoint:", default=config.default_llm_config.model_endpoint).ask()
                 if model_endpoint is None:
                     raise KeyboardInterrupt
@@ -380,7 +382,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
         other_option_str = "[enter model name manually]"
 
         # Check if the model we have set already is even in the list (informs our default)
-        valid_model = config.default_llm_config.model in hardcoded_model_options
+        valid_model = config.default_llm_config and config.default_llm_config.model in hardcoded_model_options
         model = questionary.select(
             "Select default model (recommended: gpt-4):",
             choices=hardcoded_model_options + [see_all_option_str, other_option_str],
@@ -395,7 +397,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
             model = questionary.select(
                 "Select default model (recommended: gpt-4):",
                 choices=fetched_model_options + [other_option_str],
-                default=config.default_llm_config.model if valid_model else fetched_model_options[0],
+                default=config.default_llm_config.model if (valid_model and config.default_llm_config) else fetched_model_options[0],
             ).ask()
             if model is None:
                 raise KeyboardInterrupt
@@ -493,7 +495,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
         if model_endpoint_type == "ollama":
             default_model = (
                 config.default_llm_config.model
-                if config.default_llm_config.model and config.default_llm_config.model_endpoint_type == "ollama"
+                if config.default_llm_config and config.default_llm_config.model_endpoint_type == "ollama"
                 else DEFAULT_OLLAMA_MODEL
             )
             model = questionary.text(
@@ -505,9 +507,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
             model = None if len(model) == 0 else model
 
         default_model = (
-            config.default_llm_config.model
-            if config.default_llm_config.model and config.default_llm_config.model_endpoint_type == "vllm"
-            else ""
+            config.default_llm_config.model if config.default_llm_config and config.default_llm_config.model_endpoint_type == "vllm" else ""
         )
 
         # vllm needs huggingface model tag
@@ -655,7 +655,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
 def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials):
     # configure embedding endpoint
 
-    default_embedding_endpoint_type = config.default_embedding_config.embedding_endpoint_type
+    default_embedding_endpoint_type = config.default_embedding_config.embedding_endpoint_type if config.default_embedding_config else None
 
     embedding_endpoint_type, embedding_endpoint, embedding_dim, embedding_model = None, None, None, None
     embedding_provider = questionary.select(
@@ -721,7 +721,7 @@ def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCreden
 
         # get model type
         default_embedding_model = (
-            config.default_embedding_config.embedding_model if config.default_embedding_config.embedding_model else "BAAI/bge-large-en-v1.5"
+            config.default_embedding_config.embedding_model if config.default_embedding_config else "BAAI/bge-large-en-v1.5"
         )
         embedding_model = questionary.text(
             "Enter HuggingFace model tag (e.g. BAAI/bge-large-en-v1.5):",
@@ -731,7 +731,7 @@ def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCreden
             raise KeyboardInterrupt
 
         # get model dimentions
-        default_embedding_dim = config.default_embedding_config.embedding_dim if config.default_embedding_config.embedding_dim else "1024"
+        default_embedding_dim = config.default_embedding_config.embedding_dim if config.default_embedding_config else "1024"
         embedding_dim = questionary.text("Enter embedding model dimentions (e.g. 1024):", default=str(default_embedding_dim)).ask()
         if embedding_dim is None:
             raise KeyboardInterrupt

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -227,9 +227,7 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
         provider = "anthropic"
 
     else:  # local models
-        # backend_options_old = ["webui", "webui-legacy", "llamacpp", "koboldcpp", "ollama", "lmstudio", "lmstudio-legacy", "vllm", "openai"]
-        backend_options = builtins.list(DEFAULT_ENDPOINTS.keys())
-        # assert backend_options_old == backend_options, (backend_options_old, backend_options)
+        backend_options = ["webui", "webui-legacy", "llamacpp", "koboldcpp", "ollama", "lmstudio", "lmstudio-legacy", "vllm", "openai"]
         default_model_endpoint_type = None
         if config.default_llm_config.model_endpoint_type in backend_options:
             # set from previous config
@@ -341,12 +339,8 @@ def get_model_options(
 
         else:
             # Attempt to do OpenAI endpoint style model fetching
-            # TODO support local auth with api-key header
-            if credentials.openllm_auth_type == "bearer_token":
-                api_key = credentials.openllm_key
-            else:
-                api_key = None
-            fetched_model_options_response = openai_get_model_list(url=model_endpoint, api_key=api_key, fix_url=True)
+            # TODO support local auth
+            fetched_model_options_response = openai_get_model_list(url=model_endpoint, api_key=None)
             model_options = [obj["id"] for obj in fetched_model_options_response["data"]]
             # NOTE no filtering of local model options
 
@@ -451,44 +445,6 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
             raise KeyboardInterrupt
 
     else:  # local models
-
-        # ask about local auth
-        if model_endpoint_type in ["groq"]:  # TODO all llm engines under 'local' that will require api keys
-            use_local_auth = True
-            local_auth_type = "bearer_token"
-            local_auth_key = questionary.password(
-                "Enter your Groq API key:",
-            ).ask()
-            if local_auth_key is None:
-                raise KeyboardInterrupt
-            credentials.openllm_auth_type = local_auth_type
-            credentials.openllm_key = local_auth_key
-            credentials.save()
-        else:
-            use_local_auth = questionary.confirm(
-                "Is your LLM endpoint authenticated? (default no)",
-                default=False,
-            ).ask()
-            if use_local_auth is None:
-                raise KeyboardInterrupt
-            if use_local_auth:
-                local_auth_type = questionary.select(
-                    "What HTTP authentication method does your endpoint require?",
-                    choices=SUPPORTED_AUTH_TYPES,
-                    default=SUPPORTED_AUTH_TYPES[0],
-                ).ask()
-                if local_auth_type is None:
-                    raise KeyboardInterrupt
-                local_auth_key = questionary.password(
-                    "Enter your authentication key:",
-                ).ask()
-                if local_auth_key is None:
-                    raise KeyboardInterrupt
-                # credentials = MemGPTCredentials.load()
-                credentials.openllm_auth_type = local_auth_type
-                credentials.openllm_key = local_auth_key
-                credentials.save()
-
         # ollama also needs model type
         if model_endpoint_type == "ollama":
             default_model = (
@@ -511,7 +467,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
         )
 
         # vllm needs huggingface model tag
-        if model_endpoint_type in ["vllm", "groq"]:
+        if model_endpoint_type == "vllm":
             try:
                 # Don't filter model list for vLLM since model list is likely much smaller than OpenAI/Azure endpoint
                 # + probably has custom model names
@@ -565,6 +521,31 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
         ).ask()
         if model_wrapper is None:
             raise KeyboardInterrupt
+
+        # ask about local auth
+        use_local_auth = questionary.confirm(
+            "Is your LLM endpoint authenticated? (default no)",
+            default=False,
+        ).ask()
+        if use_local_auth is None:
+            raise KeyboardInterrupt
+        if use_local_auth:
+            local_auth_type = questionary.select(
+                "What HTTP authentication method does your endpoint require?",
+                choices=SUPPORTED_AUTH_TYPES,
+                default=SUPPORTED_AUTH_TYPES[0],
+            ).ask()
+            if local_auth_type is None:
+                raise KeyboardInterrupt
+            local_auth_key = questionary.password(
+                "Enter your authentication key:",
+            ).ask()
+            if local_auth_key is None:
+                raise KeyboardInterrupt
+            # credentials = MemGPTCredentials.load()
+            credentials.openllm_auth_type = local_auth_type
+            credentials.openllm_key = local_auth_key
+            credentials.save()
 
     # set: context_window
     if str(model) not in LLM_MAX_TOKENS:
@@ -744,6 +725,7 @@ def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCreden
         embedding_endpoint = None
         embedding_model = "BAAI/bge-small-en-v1.5"
         embedding_dim = 384
+        embedding_model = "BAAI/bge-small-en-v1.5"
 
     return embedding_endpoint_type, embedding_endpoint, embedding_dim, embedding_model
 
@@ -999,7 +981,7 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
         """List all data sources"""
 
         # create table
-        table.field_names = ["Name", "Description", "Embedding Model", "Embedding Dim", "Created At", "Agents"]
+        table.field_names = ["Name", "Embedding Model", "Embedding Dim", "Created At", "Agents"]
         # TODO: eventually look accross all storage connections
         # TODO: add data source stats
         # TODO: connect to agents
@@ -1012,14 +994,7 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
             agent_names = [agent_state.name for agent_state in agent_states if agent_state is not None]
 
             table.add_row(
-                [
-                    source.name,
-                    source.description,
-                    source.embedding_model,
-                    source.embedding_dim,
-                    utils.format_datetime(source.created_at),
-                    ",".join(agent_names),
-                ]
+                [source.name, source.embedding_model, source.embedding_dim, utils.format_datetime(source.created_at), ",".join(agent_names)]
             )
 
         print(table)

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -227,7 +227,9 @@ def configure_llm_endpoint(config: MemGPTConfig, credentials: MemGPTCredentials)
         provider = "anthropic"
 
     else:  # local models
-        backend_options = ["webui", "webui-legacy", "llamacpp", "koboldcpp", "ollama", "lmstudio", "lmstudio-legacy", "vllm", "openai"]
+        # backend_options_old = ["webui", "webui-legacy", "llamacpp", "koboldcpp", "ollama", "lmstudio", "lmstudio-legacy", "vllm", "openai"]
+        backend_options = builtins.list(DEFAULT_ENDPOINTS.keys())
+        # assert backend_options_old == backend_options, (backend_options_old, backend_options)
         default_model_endpoint_type = None
         if config.default_llm_config.model_endpoint_type in backend_options:
             # set from previous config
@@ -339,8 +341,12 @@ def get_model_options(
 
         else:
             # Attempt to do OpenAI endpoint style model fetching
-            # TODO support local auth
-            fetched_model_options_response = openai_get_model_list(url=model_endpoint, api_key=None)
+            # TODO support local auth with api-key header
+            if credentials.openllm_auth_type == "bearer_token":
+                api_key = credentials.openllm_key
+            else:
+                api_key = None
+            fetched_model_options_response = openai_get_model_list(url=model_endpoint, api_key=api_key, fix_url=True)
             model_options = [obj["id"] for obj in fetched_model_options_response["data"]]
             # NOTE no filtering of local model options
 
@@ -445,6 +451,44 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
             raise KeyboardInterrupt
 
     else:  # local models
+
+        # ask about local auth
+        if model_endpoint_type in ["groq"]:  # TODO all llm engines under 'local' that will require api keys
+            use_local_auth = True
+            local_auth_type = "bearer_token"
+            local_auth_key = questionary.password(
+                "Enter your Groq API key:",
+            ).ask()
+            if local_auth_key is None:
+                raise KeyboardInterrupt
+            credentials.openllm_auth_type = local_auth_type
+            credentials.openllm_key = local_auth_key
+            credentials.save()
+        else:
+            use_local_auth = questionary.confirm(
+                "Is your LLM endpoint authenticated? (default no)",
+                default=False,
+            ).ask()
+            if use_local_auth is None:
+                raise KeyboardInterrupt
+            if use_local_auth:
+                local_auth_type = questionary.select(
+                    "What HTTP authentication method does your endpoint require?",
+                    choices=SUPPORTED_AUTH_TYPES,
+                    default=SUPPORTED_AUTH_TYPES[0],
+                ).ask()
+                if local_auth_type is None:
+                    raise KeyboardInterrupt
+                local_auth_key = questionary.password(
+                    "Enter your authentication key:",
+                ).ask()
+                if local_auth_key is None:
+                    raise KeyboardInterrupt
+                # credentials = MemGPTCredentials.load()
+                credentials.openllm_auth_type = local_auth_type
+                credentials.openllm_key = local_auth_key
+                credentials.save()
+
         # ollama also needs model type
         if model_endpoint_type == "ollama":
             default_model = (
@@ -467,7 +511,7 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
         )
 
         # vllm needs huggingface model tag
-        if model_endpoint_type == "vllm":
+        if model_endpoint_type in ["vllm", "groq"]:
             try:
                 # Don't filter model list for vLLM since model list is likely much smaller than OpenAI/Azure endpoint
                 # + probably has custom model names
@@ -521,31 +565,6 @@ def configure_model(config: MemGPTConfig, credentials: MemGPTCredentials, model_
         ).ask()
         if model_wrapper is None:
             raise KeyboardInterrupt
-
-        # ask about local auth
-        use_local_auth = questionary.confirm(
-            "Is your LLM endpoint authenticated? (default no)",
-            default=False,
-        ).ask()
-        if use_local_auth is None:
-            raise KeyboardInterrupt
-        if use_local_auth:
-            local_auth_type = questionary.select(
-                "What HTTP authentication method does your endpoint require?",
-                choices=SUPPORTED_AUTH_TYPES,
-                default=SUPPORTED_AUTH_TYPES[0],
-            ).ask()
-            if local_auth_type is None:
-                raise KeyboardInterrupt
-            local_auth_key = questionary.password(
-                "Enter your authentication key:",
-            ).ask()
-            if local_auth_key is None:
-                raise KeyboardInterrupt
-            # credentials = MemGPTCredentials.load()
-            credentials.openllm_auth_type = local_auth_type
-            credentials.openllm_key = local_auth_key
-            credentials.save()
 
     # set: context_window
     if str(model) not in LLM_MAX_TOKENS:
@@ -725,7 +744,6 @@ def configure_embedding_endpoint(config: MemGPTConfig, credentials: MemGPTCreden
         embedding_endpoint = None
         embedding_model = "BAAI/bge-small-en-v1.5"
         embedding_dim = 384
-        embedding_model = "BAAI/bge-small-en-v1.5"
 
     return embedding_endpoint_type, embedding_endpoint, embedding_dim, embedding_model
 
@@ -981,7 +999,7 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
         """List all data sources"""
 
         # create table
-        table.field_names = ["Name", "Embedding Model", "Embedding Dim", "Created At", "Agents"]
+        table.field_names = ["Name", "Description", "Embedding Model", "Embedding Dim", "Created At", "Agents"]
         # TODO: eventually look accross all storage connections
         # TODO: add data source stats
         # TODO: connect to agents
@@ -994,7 +1012,14 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
             agent_names = [agent_state.name for agent_state in agent_states if agent_state is not None]
 
             table.add_row(
-                [source.name, source.embedding_model, source.embedding_dim, utils.format_datetime(source.created_at), ",".join(agent_names)]
+                [
+                    source.name,
+                    source.description,
+                    source.embedding_model,
+                    source.embedding_dim,
+                    utils.format_datetime(source.created_at),
+                    ",".join(agent_names),
+                ]
             )
 
         print(table)

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -157,10 +157,6 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
 
         # write the file to a temporary directory (deleted after the context manager exits)
         with tempfile.TemporaryDirectory() as tmpdirname:
-<<<<<<< HEAD
-=======
-            print("TEMPORARY DIRECTORY", tmpdirname)
->>>>>>> 25b1ac3 (fix file upload route)
             file_path = os.path.join(tmpdirname, file.filename)
             with open(file_path, "wb") as buffer:
                 buffer.write(file.file.read())

--- a/memgpt/server/rest_api/sources/index.py
+++ b/memgpt/server/rest_api/sources/index.py
@@ -157,6 +157,10 @@ def setup_sources_index_router(server: SyncServer, interface: QueuingInterface, 
 
         # write the file to a temporary directory (deleted after the context manager exits)
         with tempfile.TemporaryDirectory() as tmpdirname:
+<<<<<<< HEAD
+=======
+            print("TEMPORARY DIRECTORY", tmpdirname)
+>>>>>>> 25b1ac3 (fix file upload route)
             file_path = os.path.join(tmpdirname, file.filename)
             with open(file_path, "wb") as buffer:
                 buffer.write(file.file.read())


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
When there is no `~/.memgpt/config` file, the fields `config.default_embedding_config` and `config.default_llm_config` are set to `None` -- this causes errors when the configure command tries to fill in default values. 

**How to test**
`poetry run memgpt configure`

**Have you tested this PR?**
Yes 

**Related issues or PRs**
None
