### PR TITLE
fix: Fixed NameError: name 'attach' is not defined

### DIFF
--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -74,9 +74,7 @@ class MemGPTConversableAgent(ConversableAgent):
     def attach(self, data_source: str):
         # attach new data
         config = MemGPTConfig.load()
-        source_connector = StorageConnector.get_storage_connector(
-                        TableType.PASSAGES, config, user_id=self.agent.agent_state.user_id
-                    )
+        source_connector = StorageConnector.get_storage_connector(TableType.PASSAGES, config, user_id=self.agent.agent_state.user_id)
         self.agent.attach_source(data_source, source_connector, ms=self.ms)
 
     def load_and_attach(self, name: str, type: str, force=False, **kwargs):

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -73,7 +73,11 @@ class MemGPTConversableAgent(ConversableAgent):
 
     def attach(self, data_source: str):
         # attach new data
-        attach(agent_name=self.agent.agent_state.name, data_source=data_source)
+        config = MemGPTConfig.load()
+        source_connector = StorageConnector.get_storage_connector(
+                        TableType.PASSAGES, config, user_id=self.agent.agent_state.user_id
+                    )
+        self.agent.attach_source(data_source, source_connector, ms=self.ms)
 
     def load_and_attach(self, name: str, type: str, force=False, **kwargs):
         # check if data source already exists


### PR DESCRIPTION
Fixes attaching memory in scripts
https://github.com/cpacker/MemGPT/issues/1254

```python
# then pass the config to the constructor
software_engineering_expert = create_memgpt_autogen_agent_from_config(
    "Chad - Software Engineering Lead",
    llm_config=llm_config_memgpt,
    system_message=f"Chad, you are a seasoned software engineering lead with extensive experience in managing complex projects. Your role is to oversee the quality of software development, ensuring that all implementations meet high standards. Challenge incomplete information and push for optimal solutions. Engage with other agents to enhance the software features based on engineering best practices. If unsure, admit it freely, but always aim to provide valuable feedback and direction.",
    interface_kwargs=interface_kwargs,
    skip_verify=False,  # NOTE: you should set this to True if you expect your MemGPT AutoGen agent to call a function other than send_message on the first turn
    auto_save=True, 
    is_termination_msg=lambda x: x.get("content", "") and x.get("content", "").rstrip().endswith("TERMINATE"),
    default_auto_reply="Reply 'TERMINATE' in the end when everything is done. "
)

software_engineering_expert.attach("software_engineering")
```