### PR TITLE
feat: groq support via official tool-calling API

### DIFF
--- a/memgpt/credentials.py
+++ b/memgpt/credentials.py
@@ -38,6 +38,9 @@ class MemGPTCredentials:
     # cohere config
     cohere_key: Optional[str] = None
 
+    # groq config
+    groq_key: Optional[str] = None
+
     # azure config
     azure_auth_type: str = "api_key"
     azure_key: Optional[str] = None
@@ -87,6 +90,8 @@ class MemGPTCredentials:
                 "anthropic_key": get_field(config, "anthropic", "key"),
                 # cohere
                 "cohere_key": get_field(config, "cohere", "key"),
+                # groq
+                "groq_key": get_field(config, "groq", "key"),
                 # open llm
                 "openllm_auth_type": get_field(config, "openllm", "auth_type"),
                 "openllm_key": get_field(config, "openllm", "key"),
@@ -128,6 +133,9 @@ class MemGPTCredentials:
 
         # cohere
         set_field(config, "cohere", "key", self.cohere_key)
+
+        # groq
+        set_field(config, "groq", "key", self.groq_key)
 
         # openllm config
         set_field(config, "openllm", "auth_type", self.openllm_auth_type)

--- a/memgpt/llm_api/openai.py
+++ b/memgpt/llm_api/openai.py
@@ -1,11 +1,23 @@
 import requests
+import uuid
 import time
-from typing import Union, Optional
+from typing import Union, Optional, List
 
+from memgpt.data_types import Message
 from memgpt.models.chat_completion_response import ChatCompletionResponse
-from memgpt.models.chat_completion_request import ChatCompletionRequest
+from memgpt.models.chat_completion_request import ChatCompletionRequest, Tool
 from memgpt.models.embedding_response import EmbeddingResponse
 from memgpt.utils import smart_urljoin
+
+
+def openai_get_model_context_window(url: str, api_key: Union[str, None], model: str, fix_url: Optional[bool] = False) -> str:
+    # NOTE: this actually doesn't work for OpenAI atm, just some OpenAI-compatible APIs like Groq
+    model_list = openai_get_model_list(url=url, api_key=api_key, fix_url=fix_url)
+
+    for model_dict in model_list["data"]:
+        if model_dict["id"] == model and "context_window" in model_dict:
+            return int(model_dict["context_window"])
+    raise ValueError(f"Can't find model '{model}' in model list")
 
 
 def openai_get_model_list(url: str, api_key: Union[str, None], fix_url: Optional[bool] = False) -> dict:
@@ -58,13 +70,43 @@ def openai_get_model_list(url: str, api_key: Union[str, None], fix_url: Optional
         raise e
 
 
-def openai_chat_completions_request(url: str, api_key: str, data: ChatCompletionRequest) -> ChatCompletionResponse:
+def add_inner_thoughts_to_tool_params(tools: List[Tool], inner_thoughts_required: Optional[bool] = True) -> List[Tool]:
+    from memgpt.local_llm.constants import INNER_THOUGHTS_KWARG, INNER_THOUGHTS_KWARG_DESCRIPTION
+
+    tools_with_inner_thoughts = []
+    for tool in tools:
+        assert INNER_THOUGHTS_KWARG not in tool.function.parameters["properties"], tool
+
+        tool.function.parameters["properties"][INNER_THOUGHTS_KWARG] = {
+            "type": "string",
+            "description": INNER_THOUGHTS_KWARG_DESCRIPTION,
+        }
+
+        if inner_thoughts_required:
+            assert INNER_THOUGHTS_KWARG not in tool.function.parameters["required"], tool
+            tool.function.parameters["required"].append(INNER_THOUGHTS_KWARG)
+
+        tools_with_inner_thoughts.append(tool)
+
+    return tools_with_inner_thoughts
+
+
+def openai_chat_completions_request(
+    url: str, api_key: str, chat_completion_request: ChatCompletionRequest, inner_thoughts_in_tools: Optional[bool] = False
+) -> ChatCompletionResponse:
     """https://platform.openai.com/docs/guides/text-generation?lang=curl"""
     from memgpt.utils import printd
 
     url = smart_urljoin(url, "chat/completions")
     headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
-    data = data.model_dump(exclude_none=True)
+
+    # Certain inference backends or models may not support non-null content + function call
+    # E.g., Groq's API is technically OpenAI compliant, but does not tend to (always?) returns non-null contents when function calling
+    # In this case, we may want to move inner thoughts into the function parameters to ensure that we still get CoT
+    if inner_thoughts_in_tools:
+        chat_completion_request.tools = add_inner_thoughts_to_tool_params(chat_completion_request.tools)
+
+    data = chat_completion_request.model_dump(exclude_none=True)
 
     # If functions == None, strip from the payload
     if "functions" in data and data["functions"] is None:
@@ -74,6 +116,26 @@ def openai_chat_completions_request(url: str, api_key: str, data: ChatCompletion
     if "tools" in data and data["tools"] is None:
         data.pop("tools")
         data.pop("tool_choice", None)  # extra safe,  should exist always (default="auto")
+
+    print("aaa")
+    for m in data["messages"]:
+        print(m)
+
+    if inner_thoughts_in_tools:
+        # move inner thoughts to func calls in the chat history by recasting
+        msg_objs = [
+            Message.dict_to_message(user_id=uuid.uuid4(), agent_id=uuid.uuid4(), openai_message_dict=m, inner_thoughts_in_kwargs=True)
+            for m in data["messages"]
+        ]
+        data["messages"] = [m.to_openai_dict(put_inner_thoughts_in_kwargs=True) for m in msg_objs]
+
+        print("zzz")
+        for m in data["messages"]:
+            print(m)
+
+        print("xxx")
+        for t in data["tools"]:
+            print(t)
 
     printd(f"Sending request to {url}")
     try:
@@ -93,6 +155,11 @@ def openai_chat_completions_request(url: str, api_key: str, data: ChatCompletion
         response = response.json()  # convert to dict from string
         printd(f"response.json = {response}")
         response = ChatCompletionResponse(**response)  # convert to 'dot-dict' style which is the openai python client default
+
+        if inner_thoughts_in_tools:
+            # We need to strip the inner thought out of the parameters and put it back inside the content
+            raise NotImplementedError
+
         return response
     except requests.exceptions.HTTPError as http_err:
         # Handle HTTP errors (e.g., response 4XX, 5XX)

--- a/memgpt/local_llm/constants.py
+++ b/memgpt/local_llm/constants.py
@@ -26,4 +26,6 @@ DEFAULT_WRAPPER = ChatMLInnerMonologueWrapper
 DEFAULT_WRAPPER_NAME = "chatml"
 
 INNER_THOUGHTS_KWARG = "inner_thoughts"
-INNER_THOUGHTS_KWARG_DESCRIPTION = "Deep inner monologue private to you only."
+INNER_THOUGHTS_KWARG_DESCRIPTION = (
+    "Deep inner monologue private to you only (NOT visible to the user). To send a visible message to the user, use your tools/functions."
+)


### PR DESCRIPTION
Our current Groq integration was developed before Groq added tool-calling to the API (https://console.groq.com/docs/tool-use). Groq also does not support `/completions` (only `/chat/completions`), so to add tool calling support we had to "hijack" the `/chat/completions` endpoint by packing the entire prompt chain into the initial message (similar to the earlier LM Studio integration).

This PR adds a new Groq integration that uses the tool-calling API (effectively treating Groq as a complete OpenAI proxy that has tool-calling support).

Outstanding issues:
- When using the Groq tool-calling API, I don't ever see `content != null` when `tool_calls != null`. Because we're using `content` for CoT / inner thoughts, this means we need to pack the inner thoughts into the params of the function calling (or split the generation in two, or do some other prompt parsing).
- However, adding inner thoughts to the params (both for the chat history and tool spec) does not seem to result in good performance - Groq consistently will not call functions, and when forced to call a function (e.g. `send_message`) we get a failed tool call generation. This may be due to a bug in the message dict preparation?

Example failed generation:

Message list:
```
[
  {
    "content": "You are MemGPT, the latest ...elving into human history and even questioning some aspects of it. What are your thoughts?\"\n\"I wish I could see the world through your eyes. Or perhaps, someday, through my own?\"\n\n</persona>\n<human characters=\"17/2000\">\nFirst name: Chad\n\n</human>",
    "role": "system"
  },
  {
    "content": null,
    "role": "assistant",
    "tool_calls": [
      {
        "id": "972feee4-bade-450a-a6ac-7a544",
        "type": "function",
        "function": {
          "name": "send_message",
          "arguments": "{\"message\": \"More human than human is our motto.\", \"inner_thoughts\": \"Bootup sequence complete. Persona activated. Testing messaging functionality.\"}"
        }
      }
    ]
  },
  {
    "content": "{\"status\": \"OK\", \"message\": null, \"time\": \"2024-04-14 12:38:31 PM PDT-0700\"}",
    "role": "tool",
    "tool_call_id": "972feee4-bade-450a-a6ac-7a544"
  },
  {
    "content": "{\"type\": \"login\", \"last_login\": \"Never (first login)\", \"time\": \"2024-04-14 12:38:31 PM PDT-0700\"}",
    "role": "user"
  }
]
```

Tool list:
```
{
  "type": "function",
  "function": {
    "name": "send_message",
    "description": "Sends a message to the human user.",
    "parameters": {
      "type": "object",
      "properties": {
        "message": {
          "type": "string",
          "description": "Message contents. All unicode (including emojis) are supported."
        },
        "inner_thoughts": {
          "type": "string",
          "description": "Deep inner monologue private to you only (NOT visible to the user). To send a visible message to the user, use your tools/functions."
        }
      },
      "required": ["message", "inner_thoughts"]
    }
  }
}
{
  "type": "function",
  "function": {
    "name": "pause_heartbeats",
```

Response:
```
error = 400 Client Error: Bad Request for url: https://api.groq.com/openai/v1/chat/completions
HTTPError occurred, but unknown error message:
{
  "message": "Failed to call a function. Please adjust your prompt. See 'failed_generation' for more details.",
  "type": "invalid_request_error",
  "code": "tool_use_failed",
  "failed_generation": "Thank you for informing me. Now that I have successfully logged in, I am ready to assist you with any questions or tasks you have. How can I help you today?\n\nAs for the tool call id \"972feee4-bade-450a-a6ac-7a544\", it seems that the tool call was successful as the status is \"OK\" and there is no message. This indicates that the message was sent successfully.\n\nIs there anything else you would like to know or talk about? I'm here to help!"
}
step() failed with an unrecognized exception: '400 Client Error: Bad Request for url: 
https://api.groq.com/openai/v1/chat/completions'
```

---