### PR TITLE
fix: simple_summary_wrapper function_call KeyError

### DIFF
--- a/memgpt/local_llm/llm_chat_completion_wrappers/simple_summary_wrapper.py
+++ b/memgpt/local_llm/llm_chat_completion_wrappers/simple_summary_wrapper.py
@@ -107,7 +107,7 @@ class SimpleSummaryWrapper(LLMChatCompletionWrapper):
             elif message["role"] == "assistant":
                 prompt += f"\nASSISTANT: {message['content']}"
                 # need to add the function call if there was one
-                if message["function_call"]:
+                if "function_call" in message and message["function_call"]:
                     prompt += f"\n{create_function_call(message['function_call'])}"
             elif message["role"] in ["function", "tool"]:
                 # TODO find a good way to add this


### PR DESCRIPTION
Fixes https://github.com/cpacker/MemGPT/issues/1261

**How to test**
Use ollama and the default dolphin model and spam the chat until it hits the context window limit and an automatic `/summarize` is triggered. Alternatively, just use `/summarize`.

**Have you tested this PR?**
Yes

**Is your PR over 500 lines of code?**
No
