### PR TITLE
fix: Docker Via Reverse Proxy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,3 +138,10 @@ Please be sure to follow the project's Code of Conduct.
 Need help or just want to say hi? We're here for you. Reach out through filing an issue on this GitHub repository or message us on our [Discord server](https://discord.gg/9GEQrxmVyE).
 
 Thanks for making MemGPT even more fantastic!
+
+## WIP - 🐋 Docker Development
+If you prefer to keep your resources isolated by developing purely in containers, you can start MemGPT in development with:
+```shell
+docker compose -f compose.yaml -f development.compose.yml up
+```
+This will volume mount your local codebase and reload the server on file changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ EXPOSE 8083
 
 CMD ./memgpt/server/startup.sh
 
-FROM builder as tests
+# allow for in-container development and testing
+FROM builder as development
 ARG MEMGPT_ENVIRONMENT=PRODUCTION
 ENV MEMGPT_ENVIRONMENT=${MEMGPT_ENVIRONMENT}
 ENV VIRTUAL_ENV=/app/.venv \
@@ -48,4 +49,4 @@ COPY ./memgpt /memgpt
 COPY ./configs/server_config.yaml /root/.memgpt/config
 EXPOSE 8083
 
-CMD  pytest /tests
+CMD ./memgpt/server/startup.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,11 @@
 services:
   memgpt_db:
     image: ankane/pgvector:v0.5.1
-    hostname: memgpt-db
+    networks:
+      default:
+        aliases:
+          - pgvector_db
+          - memgpt-db
     environment:
       - POSTGRES_USER=${MEMGPT_PG_USER}
       - POSTGRES_PASSWORD=${MEMGPT_PG_PASSWORD}
@@ -12,13 +16,8 @@ services:
     ports:
       - "5432:5432"
   memgpt_server:
-    image: memgpt_server
+    image: memgpt/memgpt-server:0.3.7
     hostname: memgpt-server
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        - MEMGPT_ENVIRONMENT=DEVELOPMENT
     depends_on:
       - memgpt_db
     ports:
@@ -26,35 +25,16 @@ services:
       - "8283:8283"
     env_file:
       - .env
-    volumes:
-      - ./memgpt:/memgpt
-      - ~/.memgpt/credentials:/root/.memgpt/credentials
-      #- ./configs/server_config.yaml:/root/.memgpt/config
-  memgpt_tests:
-    image: memgpt_tests
-    profiles:
-      - tests
-    hostname: memgpt-tests
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: tests
-      args:
-        - MEMGPT_ENVIRONMENT=DEVELOPMENT
-    depends_on:
-      - memgpt_db
-    env_file:
-      - .env
     environment:
-      - MEMGPT_SERVER_PASS=test_server_token
+      - MEMGPT_PGURI=postgresql://${MEMGPT_PG_USER}:${MEMGPT_PG_PASSWORD}@pgvector_db:5432/${MEMGPT_PG_DB}
+      - MEMGPT_SERVER_PASS=${MEMGPT_SERVER_PASS} # memgpt server password
+      - MEMGPT_PG_DB=${MEMGPT_PG_DB}
+      - MEMGPT_PG_USER=${MEMGPT_PG_USER}
+      - MEMGPT_PG_PASSWORD=${MEMGPT_PG_PASSWORD}
+      - MEMGPT_PG_URL=pgvector_db
     volumes:
-      - ./CONTRIBUTING.md:/CONTRIBUTING.md
-      - ./tests/pytest_cache:/memgpt/.pytest_cache
-      - ./tests/pytest.ini:/memgpt/pytest.ini
-      - ./pyproject.toml:/pyproject.toml
-      - ./memgpt:/memgpt
-      - ./tests:/tests
-      - ~/.memgpt/credentials:/root/.memgpt/credentials
+      - ./configs/server_config.yaml:/root/.memgpt/config # config file
+      - ~/.memgpt/credentials:/root/.memgpt/credentials # credentials file
   memgpt_nginx:
     hostname: memgpt-nginx
     image: nginx:stable-alpine3.17-slim

--- a/configs/server_config.yaml
+++ b/configs/server_config.yaml
@@ -12,27 +12,26 @@ context_window = 8192
 [embedding]
 embedding_endpoint_type = openai
 embedding_endpoint = https://api.openai.com/v1
-embedding_model = text-embedding-ada-002
 embedding_dim = 1536
 embedding_chunk_size = 300
 
 [archival_storage]
 type = postgres
 path = /root/.memgpt/chroma
-uri = postgresql://memgpt:memgpt@pgvector_db:5432/memgpt
+uri = postgresql+pg8000://swis_memgpt:swis_memgpt@memgpt-db/swis_memgpt
 
 [recall_storage]
 type = postgres
 path = /root/.memgpt
-uri = postgresql://memgpt:memgpt@pgvector_db:5432/memgpt
+uri = postgresql+pg8000://swis_memgpt:swis_memgpt@memgpt-db/swis_memgpt
 
 [metadata_storage]
 type = postgres
 path = /root/.memgpt
-uri = postgresql://memgpt:memgpt@pgvector_db:5432/memgpt
+uri = postgresql+pg8000://swis_memgpt:swis_memgpt@memgpt-db/swis_memgpt
 
 [version]
-memgpt_version = 0.3.7
+memgpt_version = 0.3.10
 
 [client]
 anon_clientid = 00000000-0000-0000-0000-000000000000

--- a/development.compose.yml
+++ b/development.compose.yml
@@ -1,0 +1,28 @@
+services:
+  memgpt_server:
+    image: memgpt_server
+    hostname: memgpt-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+      args:
+        - MEMGPT_ENVIRONMENT=DEVELOPMENT
+    depends_on:
+      - memgpt_db
+    env_file:
+      - .env
+    environment:
+      - MEMGPT_SERVER_PASS=test_server_token
+    volumes:
+      - ./memgpt:/memgpt
+      - ~/.memgpt/credentials:/root/.memgpt/credentials
+      - ./configs/server_config.yaml:/root/.memgpt/config
+      - ./CONTRIBUTING.md:/CONTRIBUTING.md
+      - ./tests/pytest_cache:/memgpt/.pytest_cache
+      - ./tests/pytest.ini:/memgpt/pytest.ini
+      - ./pyproject.toml:/pyproject.toml
+      - ./tests:/tests
+    ports:
+      - "8083:8083"
+      - "8283:8283"


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Migrated from #1235 / #1233

This breaks out running server via compose from development in compose. The running server is exposed at [memgpt.localhost](http://memgpt.localhost)

- `docker compose up` to run 
- `docker compose -f compose.yaml -f development.compose.yml up` to run as development

there are still some decisions to be made for in-container development to be 100% usable - testing/linting is clunky and we probably want some helper tooling in a separate PR.