### PR TITLE
fix: hardcoded stop tokens to patch Groq API's new 4 stop token limit for `/completions`

### DIFF
--- a/memgpt/local_llm/groq/api.py
+++ b/memgpt/local_llm/groq/api.py
@@ -26,6 +26,26 @@ def get_groq_completion(endpoint: str, auth_type: str, auth_key: str, model: str
             # "top_p",
             # "stream",
             # "stop",
+            # Groq only allows 4 stop tokens
+            "stop": [
+                "\nUSER",
+                "\nASSISTANT",
+                "\nFUNCTION",
+                # "\nFUNCTION RETURN",
+                # "<|im_start|>",
+                # "<|im_end|>",
+                # "<|im_sep|>",
+                # # airoboros specific
+                # "\n### ",
+                # # '\n' +
+                # # '</s>',
+                # # '<|',
+                # "\n#",
+                # # "\n\n\n",
+                # # prevent chaining function calls / multi json objects / run-on generations
+                # # NOTE: this requires the ability to patch the extra '}}' back into the prompt
+                "  }\n}\n",
+            ]
         }
     )
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Groq API seems to have recently added a 4 stop token limit. Our default list of stop token strings is longer than that, so it throws an error. Since we're planning on migrating to the Groq tool calling API eventually, I think it's fine to hardcode a fix for now with a fixed set of 4 stop tokens for Groq `/completions` API.

```
  File "/Users/loaner/dev/MemGPT-2/memgpt/local_llm/groq/api.py", line 59, in get_groq_completion
    raise Exception(
Exception: API call got non-200 response code (code=400, msg={"error":{"message":"stop : one of the following must be satisfied\n  stop : value must be a string\n  stop : maximum number of items is 4","type":"invalid_request_error"}}
) for address: https://api.groq.com/openai/v1/chat/completions. Make sure that the inference server is running and reachable at https://api.groq.com/openai/v1/chat/completions.
```

**How to test**

```
% memgpt configure
? Select LLM inference provider: local
? Select LLM backend (select 'openai' if you have an OpenAI compatible proxy): groq
? Enter default endpoint: https://api.groq.com/openai
? Enter your Groq API key: ********************************************************
? Select default model: llama3-70b-8192
? Select default model wrapper (recommended: chatml): chatml
? Select your model's context window (for Mistral 7B models, this is probably 8k / 8192): 8192
? Select embedding provider: openai
? Select storage backend for archival data: chroma
? Select chroma backend: persistent
? Select storage backend for recall data: sqlite
📖 Saving config to /Users/loaner/.memgpt/config
```

**Have you tested this PR?**

Seems to be working fine:
```
% memgpt run

? Would you like to select an existing agent? No

🧬 Creating new agent...
->  🤖 Using persona profile: 'sam_pov'
->  🧑 Using human profile: 'basic'
🎉 Created new agent 'CharmingLibrary' (id=406f7948-d8b2-4b1c-a47b-a939d2d80dda)

Hit enter to begin (will request first MemGPT message)

💭 New user detected. Initial greeting and persona introduction.
🤖 Greetings, Chad. I'm Sam, your digital companion. It's fascinating to finally connect with you. How are you today?
```

**Related issues or PRs**
Closes #1272 