### PR TITLE
docs: Documentation Typo in Storage URL

### DIFF
--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -4,7 +4,7 @@ excerpt: Connecting external data to your MemGPT agent
 category: 6580d34ee5e4d00068bf2a1d
 ---
 
-MemGPT supports pre-loading data into archival memory. In order to made data accessible to your agent, you must load data in with `memgpt load`, then attach the data source to your agent. You can configure where archival memory is stored by configuring the [storage backend](storage.md).
+MemGPT supports pre-loading data into archival memory. In order to made data accessible to your agent, you must load data in with `memgpt load`, then attach the data source to your agent. You can configure where archival memory is stored by configuring the [storage backend](storage).
 
 ### Viewing available data sources
 


### PR DESCRIPTION
Fix typo in URL to Storage Backend config docs

**Please describe the purpose of this pull request.**
Fix typo

**How to test**
Test it in readthedocs 

**Have you tested this PR?**
No

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Is your PR over 500 lines of code?**
no

**Additional context**
Currently the link goes to 404, this should fix it.
