### PR TITLE
fix: cleanup stray prints

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -174,13 +174,13 @@ def quickstart(
         else:
             # Load the file from the relative path
             script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
-            print("SCRIPT", script_dir)
+            # print("SCRIPT", script_dir)
             backup_config_path = os.path.join(script_dir, "..", "..", "configs", "memgpt_hosted.json")
-            print("FILE PATH", backup_config_path)
+            # print("FILE PATH", backup_config_path)
             try:
                 with open(backup_config_path, "r", encoding="utf-8") as file:
                     backup_config = json.load(file)
-                    print(backup_config)
+                    # print(backup_config)
                 printd("Loaded config file successfully.")
                 new_config, config_was_modified = set_config_with_dict(backup_config)
             except FileNotFoundError:


### PR DESCRIPTION
```
SCRIPT /Users/loaner/dev/MemGPT-2/memgpt/cli
FILE PATH /Users/loaner/dev/MemGPT-2/memgpt/cli/../../configs/memgpt_hosted.json
{'context_window': 16384, 'model_endpoint_type': 'openai', 'model_endpoint': 'https://inference.memgpt.ai', 'model': 'memgpt-openai', 'embedding_endpoint_type': 'hugging-face', 'embedding_endpoint': 'https://embeddings.memgpt.ai', 'embedding_model': 'BAAI/bge-large-en-v1.5', 'embedding_dim': 1024, 'embedding_chunk_size': 300}
📖 MemGPT configuration file updated!
🧠 model        -> memgpt-openai
🖥️  endpoint     -> https://inference.memgpt.ai
⚡ Run "memgpt run" to create an agent with the new config.
```