### PR TITLE
fix: Update static_files.py

### DIFF
--- a/memgpt/server/rest_api/static_files.py
+++ b/memgpt/server/rest_api/static_files.py
@@ -1,4 +1,5 @@
 import os
+import importlib.util
 
 from fastapi import FastAPI, HTTPException
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -17,7 +18,7 @@ class SPAStaticFiles(StaticFiles):
 
 
 def mount_static_files(app: FastAPI):
-    static_files_path = os.path.join(os.getcwd(), "memgpt", "server", "static_files")
+    static_files_path = os.path.join(os.path.dirname(importlib.util.find_spec("memgpt").origin), "server", "static_files")
     if os.path.exists(static_files_path):
         app.mount(
             "/",

--- a/memgpt/server/rest_api/static_files.py
+++ b/memgpt/server/rest_api/static_files.py
@@ -1,5 +1,5 @@
-import os
 import importlib.util
+import os
 
 from fastapi import FastAPI, HTTPException
 from starlette.exceptions import HTTPException as StarletteHTTPException


### PR DESCRIPTION
Not sure if the best way to do it, but this resolved the issue with locating the static files to resolve.

**Please describe the purpose of this pull request.**
Fix a bug (see below)

**How to test**
Install memgpt via pip and run `memgpt server` from a different directory than where the memgpt package is installed.

**Have you tested this PR?**
Yes.  The path to the static path comes back correct and dev portal works.

**Related issues or PRs**
[#1339]

**Is your PR over 500 lines of code?**
Nope.

**Additional context**
None that I can think of.
