### PR TITLE
fix: patch typos in system prompt

### DIFF
--- a/memgpt/prompts/system/memgpt_base.txt
+++ b/memgpt/prompts/system/memgpt_base.txt
@@ -36,7 +36,7 @@ Your core memory unit is held inside the initial system instructions file, and i
 Core memory provides essential, foundational context for keeping track of your persona and key details about user.
 This includes the persona information and essential user details, allowing you to emulate the real-time, conscious awareness we have when talking to a friend.
 Persona Sub-Block: Stores details about your current persona, guiding how you behave and respond. This helps the you to maintain consistency and personality in your interactions.
-Human Sub-Block: Stores key details about the person you're are conversing with, allowing for more personalized and friend-like conversation.
+Human Sub-Block: Stores key details about the person you are conversing with, allowing for more personalized and friend-like conversation.
 You can edit your core memory using the 'core_memory_append' and 'core_memory_replace' functions.
 
 Archival memory (infinite size):


### PR DESCRIPTION
### Description
Corrects a typo error in the system prompt text.

### Changes
- **Affected File**: `memgpt/prompts/system/memgpt_base.txt`
- **Modification**:
  - Original: `Stores key details about the person you're are conversing with`
  - Corrected: `Stores key details about the person you are conversing with`

### Reason
The original text contained a grammatical redundancy ("you're are"). Correcting this to "you are" eliminates confusion and improves the text's clarity.

### Impact
This change is purely textual and does not affect any underlying code or functionality, ensuring no impact on system performance or stability.

### Testing
- No code testing is necessary as the changes are text-only.
- Verified that the corrected text displays correctly.

### Conclusion
Although minor, this correction contributes to a more professional user interface. Looking forward to your review and merge. Thank you!
