### PR TITLE
feat/1260/secure auth and jwt

### DIFF
--- a/configs/server_config.yaml
+++ b/configs/server_config.yaml
@@ -20,17 +20,21 @@ embedding_chunk_size = 300
 [archival_storage]
 type = postgres
 path = /root/.memgpt/chroma
-uri = postgresql+pg8000://memgpt:memgpt@pgvector_db:5432/memgpt
+uri = postgresql+pg8000://swis_memgpt:swis_memgpt@pgvector_db:5432/swis_memgpt
 
 [recall_storage]
 type = postgres
 path = /root/.memgpt
-uri = postgresql+pg8000://memgpt:memgpt@pgvector_db:5432/memgpt
+uri = postgresql+pg8000://swis_memgpt:swis_memgpt@pgvector_db:5432/swis_memgpt
 
 [metadata_storage]
 type = postgres
 path = /root/.memgpt
-uri = postgresql+pg8000://memgpt:memgpt@pgvector_db:5432/memgpt
+uri = postgresql+pg8000://swis_memgpt:swis_memgpt@pgvector_db:5432/swis_memgpt
+
+[version]
+memgpt_version = 0.3.14
 
 [client]
 anon_clientid = 00000000-0000-0000-0000-000000000000
+

--- a/configs/server_config.yaml
+++ b/configs/server_config.yaml
@@ -20,21 +20,17 @@ embedding_chunk_size = 300
 [archival_storage]
 type = postgres
 path = /root/.memgpt/chroma
-uri = postgresql+pg8000://swis_memgpt:swis_memgpt@pgvector_db:5432/swis_memgpt
+uri = postgresql+pg8000://memgpt:memgpt@pgvector_db:5432/memgpt
 
 [recall_storage]
 type = postgres
 path = /root/.memgpt
-uri = postgresql+pg8000://swis_memgpt:swis_memgpt@pgvector_db:5432/swis_memgpt
+uri = postgresql+pg8000://memgpt:memgpt@pgvector_db:5432/memgpt
 
 [metadata_storage]
 type = postgres
 path = /root/.memgpt
-uri = postgresql+pg8000://swis_memgpt:swis_memgpt@pgvector_db:5432/swis_memgpt
-
-[version]
-memgpt_version = 0.3.14
+uri = postgresql+pg8000://memgpt:memgpt@pgvector_db:5432/memgpt
 
 [client]
 anon_clientid = 00000000-0000-0000-0000-000000000000
-

--- a/memgpt/server/rest_api/auth/index.py
+++ b/memgpt/server/rest_api/auth/index.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from memgpt.server.rest_api.interface import QueuingInterface
 from memgpt.server.server import SyncServer
 
-router = APIRouter()
+router = APIRouter(prefix="/auth")
 
 
 class AuthResponse(BaseModel):
@@ -18,7 +18,8 @@ class AuthRequest(BaseModel):
 
 
 def setup_auth_router(server: SyncServer, interface: QueuingInterface, password: str) -> APIRouter:
-    @router.post("/auth", tags=["auth"], response_model=AuthResponse)
+
+    @router.post("/", tags=["auth"], response_model=AuthResponse)
     def authenticate_user(request: AuthRequest) -> AuthResponse:
         """
         Authenticates the user and sends response with User related data.
@@ -35,5 +36,30 @@ def setup_auth_router(server: SyncServer, interface: QueuingInterface, password:
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"{e}")
         return AuthResponse(uuid=response)
+
+    @router.post("/jwt-auth", tags=["auth"])
+    def login_for_access_token():
+        """
+        converts the given API key to a jwt refresh token
+        """
+        # decode and validate api token
+        # get user
+        # create refresh token for user
+        # return refresh token
+
+    @router.post("/jwt-refresh", tags=["auth"])
+    def refresh_access_token(
+        # scopes? how do we want to scope this?
+        # I think for now this is hard-keyed, something like:
+        # {"admin": bool, "agentId": str } - because a jwt should be scoped to an agent right?
+        # maybe also this is when we introduce an idea of "team" or "organization" - this is missing right now.
+
+    ):
+        """
+        creates a new jwt access token using the given refresh token
+        """
+        # decode and validate refresh token
+        # create access token for user
+        # return access token
 
     return router

--- a/memgpt/server/rest_api/auth/security.py
+++ b/memgpt/server/rest_api/auth/security.py
@@ -53,7 +53,9 @@ class Security:
         Returns:
             bool: True if the secret matches the encrypted secret, False otherwise
         """
-        return self.secret_context.verify(candidate_key.raw_secret, target_key.encrypted_secret)
+        return all(
+            ((candidate_key.key_id == target_key.key_id),
+            self.secret_context.verify(candidate_key.raw_secret, target_key.encrypted_secret),))
 
 
     def create_jwt_auth_token(self, data: dict) -> str:

--- a/memgpt/server/rest_api/auth/security.py
+++ b/memgpt/server/rest_api/auth/security.py
@@ -1,0 +1,91 @@
+from typing import Tuple
+from base64 import b64encode, b64decode
+import uuid
+from pydantic import BaseModel
+from passlib.context import CryptContext
+
+from memgpt.settings import settings
+
+
+class EncryptedSecureKey(BaseModel):
+    key_id: int
+    encrypted_secret: str
+
+class RawSecureKey(BaseModel):
+    key_id: int
+    raw_secret: str
+
+class Security:
+    secret_context: CryptContext
+    algorithm: str = "HS256"
+
+    def __init__(self):
+        self.secret_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+        self.settings = settings
+
+    def get_hashed_pair(self) -> Tuple[str, str]:
+        """creates a one-way hashed pair: a secret, and the hash of that secret
+
+        Returns:
+            Tuple[str, str]: a secret and its hash
+        """
+        secret = uuid.uuid4().hex
+        return secret, self.secret_context.hash(secret)
+
+    def decode_raw_api_key(self, api_key: str) -> "RawSecureKey":
+        """parses the encoded api key and returns the key ID and encrypted secret"""
+        try:
+            encoded = api_key.split("sks-")[1]
+        except IndexError:
+            raise ValueError("Not a secure api key")
+        # add back in the vanity-removed padding
+        id, secret = b64decode(encoded.encode("utf-8") + b"==").decode().split(":")
+        return RawSecureKey(key_id=int(id), raw_secret=secret)
+
+    def encode_raw_secure_key(self, secure_key: "RawSecureKey") -> str:
+        """encodes the key ID and encrypted secret into an API key designated secure"""
+        plaintext = f"{secure_key.key_id}:{secure_key.raw_secret}"
+        encoded = b64encode(plaintext.encode()).decode().strip("=")
+        return f"sks-{encoded}"
+
+    def verify_secure_key(self, candidate_key: RawSecureKey, target_key:EncryptedSecureKey) -> bool:
+        """verifies the candidate secret against the encrypted secret in the secure key
+        Returns:
+            bool: True if the secret matches the encrypted secret, False otherwise
+        """
+        return self.secret_context.verify(candidate_key.raw_secret, target_key.encrypted_secret)
+
+
+    def create_jwt_auth_token(self, data: dict) -> str:
+        """creates an authentication token
+        Args:
+            data (dict): data to be stored in the token
+        Returns:
+            str: authentication token
+        """
+        raise NotImplementedError
+
+    def create_jwt_refresh_token(self, data: dict) -> str:
+        """creates a refresh token
+        Args:
+            data (dict): data to be stored in the token
+
+        Returns:
+            str: refresh token
+        """
+        raise NotImplementedError
+
+    def _create_jwt_access_token(self, data: dict, expires: Tuple[str, int]) -> str:
+        """creates a JWT access token
+        Args:
+            data (dict): data to be stored in the token
+            expires (Tuple[str, int]): expiration time for the token in format (time unit, time value) e.g. ("hours", 1)
+
+        Returns:
+            str: JWT access token
+        """
+        raise NotImplementedError
+
+    def read_jwt_access_token(self, token: str) -> dict:
+        """reads the data stored in the access token"""
+        raise NotImplementedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ pytest = { version = "^7.4.4", optional = true }
 pydantic-settings = "^2.2.1"
 httpx-sse = "^0.4.0"
 isort = { version = "^5.13.2", optional = true }
+passlib = "^1.7.4"
 
 [tool.poetry.extras]
 local = ["llama-index-embeddings-huggingface"]

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1,7 +1,8 @@
 from pytest import fixture
 import uuid
-from httpx import AsyncClient
+from httpx import Client
 
+from memgpt.server import app
 from memgpt.metadata import MetadataStore, User, SecureTokenModel
 from memgpt.server.rest_api.auth.security import Security, EncryptedSecureKey, RawSecureKey
 
@@ -51,7 +52,7 @@ class TestAuthUnit:
         control_key = EncryptedSecureKey(key_id=secure_token.id, encrypted_secret=secure_token.token)
         # bad token
         assert not security.verify_secure_key(raw_key, control_key)
-
+        breakpoint()
         # bad id (sanity check)
         new_bad_key = security.decode_raw_api_key(api_key=api_key)
         new_bad_key.key_id = secure_token.id + 1
@@ -61,6 +62,9 @@ class TestAuthUnit:
 
 class TestAuth:
 
-    def test_login(self, client: AsyncClient):
+    def test_login(self):
+
+        client = Client(app=app, base_url="/v1")
+
         response = client.post("/login", json={"username": "test", "password": "test"})
         assert response.status_code == 200

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1,4 +1,55 @@
+from pytest import fixture
+import uuid
 from httpx import AsyncClient
+
+from memgpt.metadata import MetadataStore, User, SecureTokenModel
+from memgpt.server.rest_api.auth.security import Security, EncryptedSecureKey, RawSecureKey
+
+class TestAuthUnit:
+    """localized unit tests for the security enhancements"""
+
+    @fixture
+    def user_storage(self, tmpdir) -> "MetadataStore":
+
+        class ConfigStub:
+            metadata_storage_type = "sqlite"
+            metadata_storage_path = str(tmpdir)
+        metadata_store = MetadataStore(ConfigStub())
+        user_id = uuid.uuid4()
+        metadata_store.create_user(User(id=user_id))
+        return user_id, metadata_store
+
+    def _generate_new_secure_key(self, user_id:"uuid.UUID", db:"MetadataStore"):
+        """Isolating this since seeding it would be a bear right now."""
+        with db.session_maker() as session:
+            api_key, secure_token = SecureTokenModel.create(user_id=user_id, session=session)
+        return api_key, secure_token
+
+    @fixture
+    def key_pair(self, user_storage):
+        user_id, db = user_storage
+        return self._generate_new_secure_key(user_id, db)
+
+    def test_generate_new_secure_key(self, key_pair):
+        api_key, secure_token = key_pair
+        assert api_key
+        assert api_key.startswith("sks-")
+        assert not secure_token.token == api_key
+
+    def test_valid_api_key_validates(self, key_pair):
+        api_key, secure_token = key_pair
+        security = Security()
+        raw_key = security.decode_raw_api_key(api_key)
+        control_key = EncryptedSecureKey(key_id=secure_token.id, encrypted_secret=secure_token.token)
+        assert security.verify_secure_key(raw_key, control_key)
+
+    def test_invalid_api_key_fails_validation(self, key_pair):
+        api_key, secure_token = key_pair
+        security = Security()
+        bad_key = security.encode_raw_secure_key(RawSecureKey(key_id=secure_token.id, raw_secret="this is a bad key"))
+        raw_key = security.decode_raw_api_key(bad_key)
+        control_key = EncryptedSecureKey(key_id=secure_token.id, encrypted_secret=secure_token.token)
+        assert not security.verify_secure_key(raw_key, control_key)
 
 
 class TestAuth:

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -52,19 +52,7 @@ class TestAuthUnit:
         control_key = EncryptedSecureKey(key_id=secure_token.id, encrypted_secret=secure_token.token)
         # bad token
         assert not security.verify_secure_key(raw_key, control_key)
-        breakpoint()
         # bad id (sanity check)
         new_bad_key = security.decode_raw_api_key(api_key=api_key)
         new_bad_key.key_id = secure_token.id + 1
         assert not security.verify_secure_key(new_bad_key, control_key)
-
-
-
-class TestAuth:
-
-    def test_login(self):
-
-        client = Client(app=app, base_url="/v1")
-
-        response = client.post("/login", json={"username": "test", "password": "test"})
-        assert response.status_code == 200

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1,0 +1,8 @@
+from httpx import AsyncClient
+
+
+class TestAuth:
+
+    def test_login(self, client: AsyncClient):
+        response = client.post("/login", json={"username": "test", "password": "test"})
+        assert response.status_code == 200

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -49,7 +49,14 @@ class TestAuthUnit:
         bad_key = security.encode_raw_secure_key(RawSecureKey(key_id=secure_token.id, raw_secret="this is a bad key"))
         raw_key = security.decode_raw_api_key(bad_key)
         control_key = EncryptedSecureKey(key_id=secure_token.id, encrypted_secret=secure_token.token)
+        # bad token
         assert not security.verify_secure_key(raw_key, control_key)
+
+        # bad id (sanity check)
+        new_bad_key = security.decode_raw_api_key(api_key=api_key)
+        new_bad_key.key_id = secure_token.id + 1
+        assert not security.verify_secure_key(new_bad_key, control_key)
+
 
 
 class TestAuth:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR is the first feature adding a secure token auth option to the Memgpt Server. 
Secure tokens (denoted with `sks-` prefix for "secret key secure") are HS256 encrypted so they are not compromised in the event of a data breach. 

For example, here's a secure API key: 
 `sks-MTpjNDYwMjA5N2I2NDU0MWU3YWQ5NGVhMmQ3OGI5ZGMyNw`

Here is how the key decodes: 
`key_id=1, raw_secret='c4602097b64541e7ad94ea2d78b9dc27'`

And this is what's stored in the database for row # 1: 
`id=1, token='$2b$12$ZL85RPO49B4JVHqsFgsgKexfysUAnNQQr7ZoN8KzPli6pq5nMs6s6'`

If someone gets their hands on database creds, they can steal all the tokens and the API keys are still theoretically secure.


**How to test**
Run the test suite and include the `TestAuthUnit` test class (included by default).

**Have you tested this PR?**
New tests are added in the PR. 


**Related issues or PRs**
#898 #1260 

**Additional context**
More to come this is still WIP. Need to: 
- [ ] integrate this secure API auth flow with the rest api
- [ ] add jwt support across all endpoints
- [ ] add a API key / jwt handoff
- [ ] add jwt refresh endpoints
- [ ] integration testing via httpx client