### PR TITLE
docs: Update git clone link in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ MemGPT provides a developer portal that enables you to easily create, edit, moni
 
 **Option 1 (Recommended)**: Run with docker compose  
 1. [Install docker on your system](https://docs.docker.com/get-docker/)
-2. Clone the repo: `git clone git@github.com:cpacker/MemGPT.git`
+2. Clone the repo: `git clone https://github.com/cpacker/MemGPT.git`
 3. Run `docker compose up`
 4. Go to `memgpt.localhost` in the browser to view the developer portal 
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR is for updating the github link to clone that repo that is listed in the readme.md file.
I have updated it to `https://github.com/cpacker/MemGPT.git` which is what should be used for users who don't own the repo.

**How to test**
Just try the new clone commad listed in the readme.md file.

**Have you tested this PR?**
Yes, I have tested and clone link works fine now.

**Related issues or PRs**
None

**Is your PR over 500 lines of code?**
Nope

**Additional context**
None
