### PR TITLE
fix: creation of invalid tool in tool builder

### DIFF
--- a/memgpt/functions/functions.py
+++ b/memgpt/functions/functions.py
@@ -69,7 +69,7 @@ def write_function(module_name: str, function_name: str, function_code: str):
 
     # Write the function to a file
     file_path = os.path.join(USER_FUNCTIONS_DIR, f"{module_name}.py")
-    with open(file_path, "a") as f:
+    with open(file_path, "w") as f:
         f.write(function_code)
     succ, error = validate_function(module_name, file_path)
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

This PR is a quick fix for a bug discovered in the MemGPT Dev Portal's Tool Builder.

The bug occurs when attempting to add a new tool to through the web interface and the source code happens to be invalid. The `write_function` still creates the python file in the user functions directory despite the result of `validation_function`. When attempting to update the tool it appends the source code in the end of the file, instead of the expected behaviour of overwriting it.