### PR TITLE
fix: get_keys_response is a list not a dict

### DIFF
--- a/examples/memgpt_client.py
+++ b/examples/memgpt_client.py
@@ -25,7 +25,7 @@ def main():
 
     # List available keys
     get_keys_response = admin.get_keys(user_id=user_id)
-    print(f"User {user_id} has keys: {get_keys_response.api_key_list}")
+    print(f"User {user_id} has keys: {get_keys_response}")
 
     # Connect to the server as a user
     client = create_client(base_url="http://localhost:8283", token=token)


### PR DESCRIPTION
    print(f"User {user_id} has keys: {get_keys_response.api_key_list}")
AttributeError: 'list' object has no attribute 'api_key_list'

with the git clone of the latest main get_keys_response is a list not a dict