### PR TITLE
fix: add `ensure_ascii` to missing `json.dumps` calls

### DIFF
--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -12,6 +12,7 @@ from memgpt.constants import (
     DEFAULT_HUMAN,
     DEFAULT_PERSONA,
     DEFAULT_PRESET,
+    JSON_ENSURE_ASCII,
     LLM_MAX_TOKENS,
     MAX_EMBEDDING_DIM,
     TOOL_CALL_ID_MAX_LEN,
@@ -551,7 +552,7 @@ class Message(Record):
                 cohere_message = []
                 for tc in self.tool_calls:
                     # TODO better way to pack?
-                    function_call_text = json.dumps(tc.to_dict())
+                    function_call_text = json.dumps(tc.to_dict(), ensure_ascii=JSON_ENSURE_ASCII)
                     cohere_message.append(
                         {
                             "role": function_call_role,

--- a/memgpt/llm_api/anthropic.py
+++ b/memgpt/llm_api/anthropic.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 
 import requests
 
+from memgpt.constants import JSON_ENSURE_ASCII
 from memgpt.data_types import Message
 from memgpt.models.chat_completion_request import ChatCompletionRequest, Tool
 from memgpt.models.chat_completion_response import (
@@ -256,7 +257,7 @@ def convert_anthropic_response_to_chatcompletion(
                 type="function",
                 function=FunctionCall(
                     name=response_json["content"][1]["name"],
-                    arguments=json.dumps(response_json["content"][1]["input"]),
+                    arguments=json.dumps(response_json["content"][1]["input"], ensure_ascii=JSON_ENSURE_ASCII),
                 ),
             )
         ]

--- a/memgpt/llm_api/google_ai.py
+++ b/memgpt/llm_api/google_ai.py
@@ -310,7 +310,7 @@ def convert_google_ai_response_to_chatcompletion(
                             type="function",
                             function=FunctionCall(
                                 name=function_name,
-                                arguments=clean_json_string_extra_backslash(json.dumps(function_args)),
+                                arguments=clean_json_string_extra_backslash(json.dumps(function_args, ensure_ascii=JSON_ENSURE_ASCII)),
                             ),
                         )
                     ],

--- a/memgpt/local_llm/grammars/gbnf_grammar_generator.py
+++ b/memgpt/local_llm/grammars/gbnf_grammar_generator.py
@@ -21,6 +21,8 @@ from typing import (
 from docstring_parser import parse
 from pydantic import BaseModel, create_model
 
+from memgpt.constants import JSON_ENSURE_ASCII
+
 
 class PydanticDataType(Enum):
     """
@@ -729,7 +731,7 @@ def generate_markdown_documentation(
 
         if hasattr(model, "Config") and hasattr(model.Config, "json_schema_extra") and "example" in model.Config.json_schema_extra:
             documentation += f"  Expected Example Output for {format_model_and_field_name(model.__name__)}:\n"
-            json_example = json.dumps(model.Config.json_schema_extra["example"])
+            json_example = json.dumps(model.Config.json_schema_extra["example"], ensure_ascii=JSON_ENSURE_ASCII)
             documentation += format_multiline_description(json_example, 2) + "\n"
 
     return documentation


### PR DESCRIPTION
Partially closes (see particular comment) https://github.com/cpacker/MemGPT/issues/799#issuecomment-2183956679