### PR TITLE
feat: move tool functions to user 

### DIFF
--- a/memgpt/client/admin.py
+++ b/memgpt/client/admin.py
@@ -1,12 +1,9 @@
 import uuid
-from typing import List, Optional
+from typing import Optional
 
 import requests
 from requests import HTTPError
 
-from memgpt.functions.functions import parse_source_code
-from memgpt.functions.schema_generator import generate_schema
-from memgpt.models.pydantic_models import ToolModel
 from memgpt.server.rest_api.admin.users import (
     CreateAPIKeyResponse,
     CreateUserResponse,
@@ -15,7 +12,6 @@ from memgpt.server.rest_api.admin.users import (
     GetAllUsersResponse,
     GetAPIKeysResponse,
 )
-from memgpt.server.rest_api.tools.index import CreateToolRequest, ListToolsResponse
 
 
 class Admin:
@@ -85,57 +81,3 @@ class Admin:
             for key in keys:
                 self.delete_key(key)
             self.delete_user(user["user_id"])
-
-    def create_tool(
-        self,
-        func,
-        name: Optional[str] = None,
-        update: Optional[bool] = True,  # TODO: actually use this
-        tags: Optional[List[str]] = None,
-    ):
-        """Create a tool
-
-        Args:
-            func (callable): The function to create a tool for.
-            tags (Optional[List[str]], optional): Tags for the tool. Defaults to None.
-            update (bool, optional): Update the tool if it already exists. Defaults to True.
-
-        Returns:
-            Tool object
-        """
-
-        # TODO: check if tool already exists
-        # TODO: how to load modules?
-        # parse source code/schema
-        source_code = parse_source_code(func)
-        json_schema = generate_schema(func, name)
-        source_type = "python"
-        tool_name = json_schema["name"]
-
-        # create data
-        data = {"name": tool_name, "source_code": source_code, "source_type": source_type, "tags": tags, "json_schema": json_schema}
-        CreateToolRequest(**data)  # validate data:w
-
-        # make REST request
-        response = requests.post(f"{self.base_url}/admin/tools", json=data, headers=self.headers)
-        if response.status_code != 200:
-            raise ValueError(f"Failed to create tool: {response.text}")
-        return ToolModel(**response.json())
-
-    def list_tools(self) -> ListToolsResponse:
-        response = requests.get(f"{self.base_url}/admin/tools", headers=self.headers)
-        return ListToolsResponse(**response.json()).tools
-
-    def delete_tool(self, name: str):
-        response = requests.delete(f"{self.base_url}/admin/tools/{name}", headers=self.headers)
-        if response.status_code != 200:
-            raise ValueError(f"Failed to delete tool: {response.text}")
-        return response.json()
-
-    def get_tool(self, name: str):
-        response = requests.get(f"{self.base_url}/admin/tools/{name}", headers=self.headers)
-        if response.status_code == 404:
-            return None
-        elif response.status_code != 200:
-            raise ValueError(f"Failed to get tool: {response.text}")
-        return ToolModel(**response.json())

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -236,8 +236,6 @@ class RESTClient(AbstractClient):
         self.base_url = base_url
         self.headers = {"accept": "application/json", "authorization": f"Bearer {token}"}
 
-    # agents
-
     def list_agents(self):
         response = requests.get(f"{self.base_url}/api/agents", headers=self.headers)
         return ListAgentsResponse(**response.json())
@@ -637,11 +635,14 @@ class RESTClient(AbstractClient):
         source_code = parse_source_code(func)
         json_schema = generate_schema(func, name)
         source_type = "python"
-        tool_name = json_schema["name"]
+        json_schema["name"]
 
         # create data
-        data = {"name": tool_name, "source_code": source_code, "source_type": source_type, "tags": tags, "json_schema": json_schema}
-        CreateToolRequest(**data)  # validate data
+        data = {"source_code": source_code, "source_type": source_type, "tags": tags, "json_schema": json_schema}
+        try:
+            CreateToolRequest(**data)  # validate data
+        except Exception as e:
+            raise ValueError(f"Failed to create tool: {e}, invalid input {data}")
 
         # make REST request
         response = requests.post(f"{self.base_url}/api/tools", json=data, headers=self.headers)

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -604,9 +604,13 @@ class MetadataStore:
 
     @enforce_types
     # def list_tools(self, user_id: uuid.UUID) -> List[ToolModel]: # TODO: add when users can creat tools
-    def list_tools(self) -> List[ToolModel]:
+    def list_tools(self, user_id: Optional[uuid.UUID] = None) -> List[ToolModel]:
         with self.session_maker() as session:
-            results = session.query(ToolModel).all()
+            if user_id:
+                results = session.query(ToolModel).filter(ToolModel.user_id == user_id).all()
+            else:
+                # return all created tools
+                results = session.query(ToolModel).all()
             return results
 
     @enforce_types
@@ -677,10 +681,10 @@ class MetadataStore:
             return results[0].to_record()
 
     @enforce_types
-    def get_tool(self, tool_name: str) -> Optional[ToolModel]:
+    def get_tool(self, tool_name: str, user_id: uuid.UUID) -> Optional[ToolModel]:
         # TODO: add user_id when tools can eventually be added by users
         with self.session_maker() as session:
-            results = session.query(ToolModel).filter(ToolModel.name == tool_name).all()
+            results = session.query(ToolModel).filter(ToolModel.name == tool_name).filter(ToolModel.user_id == user_id).all()
             if len(results) == 0:
                 return None
             assert len(results) == 1, f"Expected 1 result, got {len(results)}"
@@ -752,6 +756,8 @@ class MetadataStore:
     @enforce_types
     def add_tool(self, tool: ToolModel):
         with self.session_maker() as session:
+            if session.query(ToolModel).filter(ToolModel.name == tool.name).filter(ToolModel.user_id == tool.user_id).count() > 0:
+                raise ValueError(f"Tool with name {tool.name} already exists for user_id {tool.user_id}")
             session.add(tool)
             session.commit()
 
@@ -811,9 +817,9 @@ class MetadataStore:
             session.commit()
 
     @enforce_types
-    def delete_tool(self, name: str):
+    def delete_tool(self, name: str, user_id: uuid.UUID):
         with self.session_maker() as session:
-            session.query(ToolModel).filter(ToolModel.name == name).delete()
+            session.query(ToolModel).filter(ToolModel.name == name).filter(ToolModel.user_id == user_id).delete()
             session.commit()
 
     # job related functions

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -65,6 +65,9 @@ class ToolModel(SQLModel, table=True):
 
     json_schema: Dict = Field(default_factory=dict, sa_column=Column(JSON), description="The JSON schema of the function.")
 
+    # optional: user_id (user-specific tools)
+    user_id: Optional[uuid.UUID] = Field(None, description="The unique identifier of the user associated with the function.")
+
     # Needed for Column(JSON)
     class Config:
         arbitrary_types_allowed = True

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -57,7 +57,7 @@ class PresetModel(BaseModel):
 class ToolModel(SQLModel, table=True):
     # TODO move into database
     name: str = Field(..., description="The name of the function.")
-    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the function.", primary_key=True)
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the function.", primary_key=Te)
     tags: List[str] = Field(sa_column=Column(JSON), description="Metadata tags.")
     source_type: Optional[str] = Field(None, description="The type of the source code.")
     source_code: Optional[str] = Field(..., description="The source code of the function.")

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -57,7 +57,7 @@ class PresetModel(BaseModel):
 class ToolModel(SQLModel, table=True):
     # TODO move into database
     name: str = Field(..., description="The name of the function.")
-    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the function.", primary_key=Te)
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the function.", primary_key=True)
     tags: List[str] = Field(sa_column=Column(JSON), description="Metadata tags.")
     source_type: Optional[str] = Field(None, description="The type of the source code.")
     source_code: Optional[str] = Field(..., description="The source code of the function.")

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -56,8 +56,8 @@ class PresetModel(BaseModel):
 
 class ToolModel(SQLModel, table=True):
     # TODO move into database
-    name: str = Field(..., description="The name of the function.", primary_key=True)
-    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the function.")
+    name: str = Field(..., description="The name of the function.")
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, description="The unique identifier of the function.", primary_key=True)
     tags: List[str] = Field(sa_column=Column(JSON), description="Metadata tags.")
     source_type: Optional[str] = Field(None, description="The type of the source code.")
     source_code: Optional[str] = Field(..., description="The source code of the function.")

--- a/memgpt/server/rest_api/admin/tools.py
+++ b/memgpt/server/rest_api/admin/tools.py
@@ -39,7 +39,7 @@ def setup_tools_index_router(server: SyncServer, interface: QueuingInterface):
         # Clear the interface
         interface.clear()
         # tool = server.ms.delete_tool(user_id=user_id, tool_name=tool_name) TODO: add back when user-specific
-        server.ms.delete_tool(name=tool_name)
+        server.ms.delete_tool(name=tool_name, user_id=None)
 
     @router.get("/tools/{tool_name}", tags=["tools"], response_model=ToolModel)
     async def get_tool(tool_name: str):
@@ -49,29 +49,26 @@ def setup_tools_index_router(server: SyncServer, interface: QueuingInterface):
         # Clear the interface
         interface.clear()
         # tool = server.ms.get_tool(user_id=user_id, tool_name=tool_name) TODO: add back when user-specific
-        tool = server.ms.get_tool(tool_name=tool_name)
+        tool = server.ms.get_tool(tool_name=tool_name, user_id=None)
         if tool is None:
             # return 404 error
             raise HTTPException(status_code=404, detail=f"Tool with name {tool_name} not found.")
         return tool
 
     @router.get("/tools", tags=["tools"], response_model=ListToolsResponse)
-    async def list_all_tools(
-        # user_id: uuid.UUID = Depends(get_current_user_with_server), # TODO: add back when user-specific
-    ):
+    async def list_all_tools():
         """
         Get a list of all tools available to agents created by a user
         """
         # Clear the interface
         interface.clear()
         # tools = server.ms.list_tools(user_id=user_id) TODO: add back when user-specific
-        tools = server.ms.list_tools()
+        tools = server.ms.list_tools(user_id=None)
         return ListToolsResponse(tools=tools)
 
     @router.post("/tools", tags=["tools"], response_model=ToolModel)
     async def create_tool(
         request: CreateToolRequest = Body(...),
-        # user_id: uuid.UUID = Depends(get_current_user_with_server), # TODO: add back when user-specific
     ):
         """
         Create a new tool

--- a/memgpt/server/rest_api/tools/index.py
+++ b/memgpt/server/rest_api/tools/index.py
@@ -18,7 +18,7 @@ class ListToolsResponse(BaseModel):
 
 
 class CreateToolRequest(BaseModel):
-    name: str = Field(..., description="The name of the function.")
+    json_schema: dict = Field(..., description="JSON schema of the tool.")
     source_code: str = Field(..., description="The source code of the function.")
     source_type: Optional[Literal["python"]] = Field(None, description="The type of the source code.")
     tags: Optional[List[str]] = Field(None, description="Metadata tags.")
@@ -31,40 +31,10 @@ class CreateToolResponse(BaseModel):
 def setup_user_tools_index_router(server: SyncServer, interface: QueuingInterface, password: str):
     get_current_user_with_server = partial(partial(get_current_user, server), password)
 
-    @router.get("/tools/{tool_name}", tags=["tools"], response_model=ToolModel)
-    async def get_tool(
-        tool_name: str,
-        user_id: uuid.UUID = Depends(get_current_user_with_server),  # TODO: add back when user-specific
-    ):
-        """
-        Get a tool by name
-        """
-        # Clear the interface
-        interface.clear()
-        # tool = server.ms.get_tool(user_id=user_id, tool_name=tool_name) TODO: add back when user-specific
-        tool = server.ms.get_tool(tool_name=tool_name)
-        if tool is None:
-            # return 404 error
-            raise HTTPException(status_code=404, detail=f"Tool with name {tool_name} not found.")
-        return tool
-
-    @router.get("/tools", tags=["tools"], response_model=ListToolsResponse)
-    async def list_all_tools(
-        user_id: uuid.UUID = Depends(get_current_user_with_server),  # TODO: add back when user-specific
-    ):
-        """
-        Get a list of all tools available to agents created by a user
-        """
-        # Clear the interface
-        interface.clear()
-        # tools = server.ms.list_tools(user_id=user_id) TODO: add back when user-specific
-        tools = server.ms.list_tools(user_id=user_id)
-        return ListToolsResponse(tools=tools)
-
     @router.delete("/tools/{tool_name}", tags=["tools"])
     async def delete_tool(
         tool_name: str,
-        user_id: uuid.UUID = Depends(get_current_user_with_server),  # TODO: add back when user-specific
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
         """
         Delete a tool by name
@@ -74,9 +44,38 @@ def setup_user_tools_index_router(server: SyncServer, interface: QueuingInterfac
         # tool = server.ms.delete_tool(user_id=user_id, tool_name=tool_name) TODO: add back when user-specific
         server.ms.delete_tool(name=tool_name, user_id=user_id)
 
+    @router.get("/tools/{tool_name}", tags=["tools"], response_model=ToolModel)
+    async def get_tool(
+        tool_name: str,
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Get a tool by name
+        """
+        # Clear the interface
+        interface.clear()
+        tool = server.ms.get_tool(tool_name=tool_name, user_id=user_id)
+        if tool is None:
+            # return 404 error
+            raise HTTPException(status_code=404, detail=f"Tool with name {tool_name} not found.")
+        return tool
+
+    @router.get("/tools", tags=["tools"], response_model=ListToolsResponse)
+    async def list_all_tools(
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Get a list of all tools available to agents created by a user
+        """
+        # Clear the interface
+        interface.clear()
+        tools = server.ms.list_tools(user_id=user_id)
+        return ListToolsResponse(tools=tools)
+
+    @router.post("/tools", tags=["tools"], response_model=ToolModel)
     async def create_tool(
         request: CreateToolRequest = Body(...),
-        user_id: uuid.UUID = Depends(get_current_user_with_server),  # TODO: add back when user-specific
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
         """
         Create a new tool

--- a/memgpt/server/rest_api/tools/index.py
+++ b/memgpt/server/rest_api/tools/index.py
@@ -58,7 +58,7 @@ def setup_user_tools_index_router(server: SyncServer, interface: QueuingInterfac
         # Clear the interface
         interface.clear()
         # tools = server.ms.list_tools(user_id=user_id) TODO: add back when user-specific
-        tools = server.ms.list_tools()
+        tools = server.ms.list_tools(user_id=user_id)
         return ListToolsResponse(tools=tools)
 
     @router.delete("/tools/{tool_name}", tags=["tools"])
@@ -72,7 +72,7 @@ def setup_user_tools_index_router(server: SyncServer, interface: QueuingInterfac
         # Clear the interface
         interface.clear()
         # tool = server.ms.delete_tool(user_id=user_id, tool_name=tool_name) TODO: add back when user-specific
-        server.ms.delete_tool(name=tool_name)
+        server.ms.delete_tool(name=tool_name, user_id=user_id)
 
     async def create_tool(
         request: CreateToolRequest = Body(...),
@@ -83,7 +83,11 @@ def setup_user_tools_index_router(server: SyncServer, interface: QueuingInterfac
         """
         try:
             return server.create_tool(
-                json_schema=request.json_schema, source_code=request.source_code, source_type=request.source_type, tags=request.tags
+                json_schema=request.json_schema,
+                source_code=request.source_code,
+                source_type=request.source_type,
+                tags=request.tags,
+                user_id=user_id,
             )
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to create tool: {e}")

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1487,7 +1487,13 @@ class SyncServer(LockingServer):
         return sources_with_metadata
 
     def create_tool(
-        self, json_schema: dict, source_code: str, source_type: str, tags: Optional[List[str]] = None, exists_ok: Optional[bool] = True
+        self,
+        json_schema: dict,
+        source_code: str,
+        source_type: str,
+        tags: Optional[List[str]] = None,
+        exists_ok: Optional[bool] = True,
+        user_id: Optional[uuid.UUID] = None,
     ) -> ToolModel:  # TODO: add other fields
         """Create a new tool
 
@@ -1511,7 +1517,9 @@ class SyncServer(LockingServer):
                 raise ValueError(f"Tool with name {name} already exists.")
         else:
             # create new tool
-            tool = ToolModel(name=name, json_schema=json_schema, tags=tags, source_code=source_code, source_type=source_type)
+            tool = ToolModel(
+                name=name, json_schema=json_schema, tags=tags, source_code=source_code, source_type=source_type, user_id=user_id
+            )
             self.ms.add_tool(tool)
 
         return self.ms.get_tool(name)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1522,7 +1522,7 @@ class SyncServer(LockingServer):
             )
             self.ms.add_tool(tool)
 
-        return self.ms.get_tool(name)
+        return self.ms.get_tool(name, user_id=user_id)
 
     def delete_tool(self, name: str):
         """Delete a tool"""

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -336,7 +336,7 @@ class SyncServer(LockingServer):
 
             # Instantiate an agent object using the state retrieved
             logger.info(f"Creating an agent object")
-            tool_objs = [self.ms.get_tool(name) for name in agent_state.tools]  # get tool objects
+            tool_objs = [self.ms.get_tool(name, user_id) for name in agent_state.tools]  # get tool objects
             memgpt_agent = Agent(agent_state=agent_state, interface=interface, tools=tool_objs)
 
             # Add the agent to the in-memory store and return its reference
@@ -763,7 +763,7 @@ class SyncServer(LockingServer):
             # get tools
             tool_objs = []
             for tool_name in tools:
-                tool_obj = self.ms.get_tool(tool_name)
+                tool_obj = self.ms.get_tool(tool_name, user_id=user_id)
                 assert tool_obj is not None, f"Tool {tool_name} does not exist"
                 tool_objs.append(tool_obj)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -69,7 +69,7 @@ def run_server():
 # Fixture to create clients with different configurations
 @pytest.fixture(
     # params=[{"server": True}, {"server": False}],  # whether to use REST API server  # TODO: add when implemented
-    params=[{"server": True}],  # whether to use REST API server  # TODO: add when implemented
+    params=[{"server": False}],  # whether to use REST API server  # TODO: add when implemented
     scope="module",
 )
 def admin_client(request):
@@ -138,34 +138,34 @@ def test_create_tool(client):
     assert tool.user_id == client.user_id, f"Expected {tool.user_id} to be {client.user_id}"
 
 
-def test_create_agent_tool_admin(admin_client):
-    if admin_client is None:
-        return
-
-    def print_tool(message: str):
-        """
-        Args:
-            message (str): The message to print.
-
-        Returns:
-            str: The message that was printed.
-
-        """
-        print(message)
-        return message
-
-    tools = admin_client.list_tools()
-    print(f"Original tools {[t.name for t in tools]}")
-
-    tool = admin_client.create_tool(print_tool, tags=["extras"])
-
-    tools = admin_client.list_tools()
-    assert tool in tools, f"Expected {tool.name} in {[t.name for t in tools]}"
-    print(f"Updated tools {[t.name for t in tools]}")
-
-    # check tool id
-    tool = client.get_tool(tool.name)
-    assert tool.user_id is None, f"Expected {tool.user_id} to be None"
+# def test_create_agent_tool_admin(admin_client):
+#    if admin_client is None:
+#        return
+#
+#    def print_tool(message: str):
+#        """
+#        Args:
+#            message (str): The message to print.
+#
+#        Returns:
+#            str: The message that was printed.
+#
+#        """
+#        print(message)
+#        return message
+#
+#    tools = admin_client.list_tools()
+#    print(f"Original tools {[t.name for t in tools]}")
+#
+#    tool = admin_client.create_tool(print_tool, tags=["extras"])
+#
+#    tools = admin_client.list_tools()
+#    assert tool in tools, f"Expected {tool.name} in {[t.name for t in tools]}"
+#    print(f"Updated tools {[t.name for t in tools]}")
+#
+#    # check tool id
+#    tool = client.get_tool(tool.name)
+#    assert tool.user_id is None, f"Expected {tool.user_id} to be None"
 
 
 def test_create_agent_tool(client):
@@ -187,7 +187,8 @@ def test_create_agent_tool(client):
         return None
 
     # TODO: test attaching and using function on agent
-    tool = client.create_tool(core_memory_clear, tags=["extras"])
+    tool = client.create_tool(core_memory_clear, tags=["extras"], update=True)
+    print(f"Created tool", tool.name)
 
     # create agent with tool
     agent = client.create_agent(name=test_agent_name, tools=[tool.name], persona="You must clear your memory if the human instructs you")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -137,34 +137,34 @@ def test_create_tool(client):
     tool = client.get_tool(tool.name)
 
 
-# def test_create_agent_tool_admin(admin_client):
-#    if admin_client is None:
-#        return
-#
-#    def print_tool(message: str):
-#        """
-#        Args:
-#            message (str): The message to print.
-#
-#        Returns:
-#            str: The message that was printed.
-#
-#        """
-#        print(message)
-#        return message
-#
-#    tools = admin_client.list_tools()
-#    print(f"Original tools {[t.name for t in tools]}")
-#
-#    tool = admin_client.create_tool(print_tool, tags=["extras"])
-#
-#    tools = admin_client.list_tools()
-#    assert tool in tools, f"Expected {tool.name} in {[t.name for t in tools]}"
-#    print(f"Updated tools {[t.name for t in tools]}")
-#
-#    # check tool id
-#    tool = client.get_tool(tool.name)
-#    assert tool.user_id is None, f"Expected {tool.user_id} to be None"
+def test_create_agent_tool_admin(admin_client):
+    if admin_client is None:
+        return
+
+    def print_tool(message: str):
+        """
+        Args:
+            message (str): The message to print.
+
+        Returns:
+            str: The message that was printed.
+
+        """
+        print(message)
+        return message
+
+    tools = admin_client.list_tools()
+    print(f"Original tools {[t.name for t in tools]}")
+
+    tool = admin_client.create_tool(print_tool, tags=["extras"])
+
+    tools = admin_client.list_tools()
+    assert tool in tools, f"Expected {tool.name} in {[t.name for t in tools]}"
+    print(f"Updated tools {[t.name for t in tools]}")
+
+    # check tool id
+    tool = admin_client.get_tool(tool.name)
+    assert tool.user_id is None, f"Expected {tool.user_id} to be None"
 
 
 def test_create_agent_tool(client):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -68,8 +68,8 @@ def run_server():
 
 # Fixture to create clients with different configurations
 @pytest.fixture(
-    # params=[{"server": True}, {"server": False}],  # whether to use REST API server  # TODO: add when implemented
-    params=[{"server": False}],  # whether to use REST API server  # TODO: add when implemented
+    params=[{"server": True}, {"server": False}],  # whether to use REST API server  # TODO: add when implemented
+    # params=[{"server": True}],  # whether to use REST API server  # TODO: add when implemented
     scope="module",
 )
 def admin_client(request):
@@ -135,7 +135,6 @@ def test_create_tool(client):
 
     # check tool id
     tool = client.get_tool(tool.name)
-    assert tool.user_id == client.user_id, f"Expected {tool.user_id} to be {client.user_id}"
 
 
 # def test_create_agent_tool_admin(admin_client):
@@ -192,6 +191,7 @@ def test_create_agent_tool(client):
 
     # create agent with tool
     agent = client.create_agent(name=test_agent_name, tools=[tool.name], persona="You must clear your memory if the human instructs you")
+    assert str(tool.user_id) == str(agent.user_id), f"Expected {tool.user_id} to be {agent.user_id}"
 
     # initial memory
     initial_memory = client.get_agent_memory(agent.id)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -72,7 +72,8 @@ def run_server():
     params=[{"server": True}],  # whether to use REST API server  # TODO: add when implemented
     scope="module",
 )
-def client(request):
+def admin_client(request):
+
     if request.param["server"]:
         # get URL from enviornment
         server_url = os.getenv("MEMGPT_SERVER_URL")
@@ -92,11 +93,19 @@ def client(request):
 
         admin._reset_server()
     else:
-        print("Testing local client")
-        # use local client (no server)
-        token = None
-        server_url = None
-        client = create_client(base_url=server_url, token=token)  # This yields control back to the test function
+        yield None
+
+
+@pytest.fixture(scope="module")
+def client(admin_client):
+    if admin_client:
+        # create user via admin client
+        response = admin_client.create_user()
+        print("Created user", response.user_id, response.api_key)
+        client = create_client(base_url=admin_client.base_url, token=response.api_key)
+        yield client
+    else:
+        client = create_client()
         yield client
 
 
@@ -124,6 +133,40 @@ def test_create_tool(client):
     assert tool in tools, f"Expected {tool.name} in {[t.name for t in tools]}"
     print(f"Updated tools {[t.name for t in tools]}")
 
+    # check tool id
+    tool = client.get_tool(tool.name)
+    assert tool.user_id == client.user_id, f"Expected {tool.user_id} to be {client.user_id}"
+
+
+def test_create_agent_tool_admin(admin_client):
+    if admin_client is None:
+        return
+
+    def print_tool(message: str):
+        """
+        Args:
+            message (str): The message to print.
+
+        Returns:
+            str: The message that was printed.
+
+        """
+        print(message)
+        return message
+
+    tools = admin_client.list_tools()
+    print(f"Original tools {[t.name for t in tools]}")
+
+    tool = admin_client.create_tool(print_tool, tags=["extras"])
+
+    tools = admin_client.list_tools()
+    assert tool in tools, f"Expected {tool.name} in {[t.name for t in tools]}"
+    print(f"Updated tools {[t.name for t in tools]}")
+
+    # check tool id
+    tool = client.get_tool(tool.name)
+    assert tool.user_id is None, f"Expected {tool.user_id} to be None"
+
 
 def test_create_agent_tool(client):
     """Test creation of a agent tool"""
@@ -146,20 +189,11 @@ def test_create_agent_tool(client):
     # TODO: test attaching and using function on agent
     tool = client.create_tool(core_memory_clear, tags=["extras"])
 
-    if isinstance(client, Admin):
-        # conver to user client type
-        response = client.create_user()
-        print("Created user", response.user_id, response.api_key)
-        user_client = create_client(base_url=client.base_url, token=response.api_key)
-    else:
-        user_client = client
-
-    agent = user_client.create_agent(
-        name=test_agent_name, tools=[tool.name], persona="You must clear your memory if the human instructs you"
-    )
+    # create agent with tool
+    agent = client.create_agent(name=test_agent_name, tools=[tool.name], persona="You must clear your memory if the human instructs you")
 
     # initial memory
-    initial_memory = user_client.get_agent_memory(agent.id)
+    initial_memory = client.get_agent_memory(agent.id)
     print("initial memory", initial_memory)
     human = initial_memory.core_memory.human
     persona = initial_memory.core_memory.persona
@@ -168,11 +202,11 @@ def test_create_agent_tool(client):
     assert len(persona) > 0, "Expected persona memory to be non-empty"
 
     # test agent tool
-    response = user_client.send_message(role="user", agent_id=agent.id, message="clear your memory with the core_memory_clear tool")
+    response = client.send_message(role="user", agent_id=agent.id, message="clear your memory with the core_memory_clear tool")
     print(response)
 
     # updated memory
-    updated_memory = user_client.get_agent_memory(agent.id)
+    updated_memory = client.get_agent_memory(agent.id)
     human = updated_memory.core_memory.human
     persona = updated_memory.core_memory.persona
     print("Updated memory:", human, persona)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Instead of requring tools to be global and created by the administrator, this PR makes it possible to create user-specific tools from the user client. The administrator can also create global tools, where `user_id=None`. 

**How to test**
`poetry run pytest -s tests/test_tools.py` 

