### PR TITLE
fix: don't reverse the sort expression

### DIFF
--- a/memgpt/agent_store/db.py
+++ b/memgpt/agent_store/db.py
@@ -18,7 +18,6 @@ from sqlalchemy import (
     asc,
     create_engine,
     desc,
-    func,
     or_,
     select,
     text,
@@ -314,19 +313,13 @@ class SQLStorageConnector(StorageConnector):
             # cursor logic: filter records based on before/after ID
             if after:
                 after_value = getattr(self.get(id=after), order_by)
-                if reverse:  # if reverse, then we want to get records that are less than the after_value
-                    sort_exp = getattr(self.db_model, order_by) < after_value
-                else:  # otherwise, we want to get records that are greater than the after_value
-                    sort_exp = getattr(self.db_model, order_by) > after_value
+                sort_exp = getattr(self.db_model, order_by) > after_value
                 query = query.filter(
                     or_(sort_exp, and_(getattr(self.db_model, order_by) == after_value, self.db_model.id > after))  # tiebreaker case
                 )
             if before:
                 before_value = getattr(self.get(id=before), order_by)
-                if reverse:
-                    sort_exp = getattr(self.db_model, order_by) > before_value
-                else:
-                    sort_exp = getattr(self.db_model, order_by) < before_value
+                sort_exp = getattr(self.db_model, order_by) < before_value
                 query = query.filter(or_(sort_exp, and_(getattr(self.db_model, order_by) == before_value, self.db_model.id < before)))
 
             # get records


### PR DESCRIPTION
The sort expression should not change even if we reverse the order of the items a date before should still be a date before the initial sort takes care of everything we need already

There's a bug in the cursor api for messages. if reverse is set to true the sort expressions are also reversed, this is actually incorrect. I attached a drawing below that explains why

Here is a diagram that shows why simply removing it works
![explanation](https://github.com/cpacker/MemGPT/assets/35136007/10750dbc-2827-43e8-b169-2818708cf8b4)
The comparison stays the same, regardless of how we order the records

