### PR TITLE
fix: use params in get_all_users(GET) endpoint

### DIFF
--- a/memgpt/client/admin.py
+++ b/memgpt/client/admin.py
@@ -34,8 +34,12 @@ class Admin:
         self.headers = {"accept": "application/json", "content-type": "application/json", "authorization": f"Bearer {token}"}
 
     def get_users(self, cursor: Optional[uuid.UUID] = None, limit: Optional[int] = 50):
-        payload = {"cursor": str(cursor) if cursor else None, "limit": limit}
-        response = requests.get(f"{self.base_url}/admin/users", headers=self.headers, json=payload)
+        params = {}
+        if cursor:
+            params['cursor'] = str(cursor)
+        if limit:
+            params['limit'] = limit
+        response = requests.get(f"{self.base_url}/admin/users", params=params, headers=self.headers)
         if response.status_code != 200:
             raise HTTPError(response.json())
         return GetAllUsersResponse(**response.json())

--- a/memgpt/client/admin.py
+++ b/memgpt/client/admin.py
@@ -36,9 +36,9 @@ class Admin:
     def get_users(self, cursor: Optional[uuid.UUID] = None, limit: Optional[int] = 50):
         params = {}
         if cursor:
-            params['cursor'] = str(cursor)
+            params["cursor"] = str(cursor)
         if limit:
-            params['limit'] = limit
+            params["limit"] = limit
         response = requests.get(f"{self.base_url}/admin/users", params=params, headers=self.headers)
         if response.status_code != 200:
             raise HTTPError(response.json())

--- a/memgpt/server/rest_api/admin/users.py
+++ b/memgpt/server/rest_api/admin/users.py
@@ -11,11 +11,6 @@ from memgpt.server.server import SyncServer
 router = APIRouter()
 
 
-class GetAllUsersRequest(BaseModel):
-    cursor: Optional[uuid.UUID] = Field(None, description="Cursor to which to start the paginated request.")
-    limit: Optional[int] = Field(50, description="Maximum number of users to retrieve per page.")
-
-
 class GetAllUsersResponse(BaseModel):
     cursor: Optional[uuid.UUID] = Field(None, description="Cursor for the next page in the response.")
     user_list: List[dict] = Field(..., description="A list of users.")
@@ -40,10 +35,6 @@ class CreateAPIKeyResponse(BaseModel):
     api_key: str = Field(..., description="New API key generated.")
 
 
-class GetAPIKeysRequest(BaseModel):
-    user_id: uuid.UUID = Field(..., description="Identifier of the user (UUID).")
-
-
 class GetAPIKeysResponse(BaseModel):
     api_key_list: List[str] = Field(..., description="Identifier of the user (UUID).")
 
@@ -60,12 +51,12 @@ class DeleteUserResponse(BaseModel):
 
 def setup_admin_router(server: SyncServer, interface: QueuingInterface):
     @router.get("/users", tags=["admin"], response_model=GetAllUsersResponse)
-    def get_all_users(request: GetAllUsersRequest = Body(...)):
+    def get_all_users(cursor: Optional[uuid.UUID] = Query(None), limit: Optional[int] = Query(50)):
         """
         Get a list of all users in the database
         """
         try:
-            next_cursor, users = server.ms.get_all_users(request.cursor, request.limit)
+            next_cursor, users = server.ms.get_all_users(cursor, limit)
             processed_users = [{"user_id": user.id} for user in users]
         except HTTPException:
             raise


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Ensure that the GET request does not expect a body and correctly handles the parameters as part of the query string

**How to test**
poetry run pytest -s tests

**Have you tested this PR?**
NA

**Related issues or PRs**
NA

**Is your PR over 500 lines of code?**
No

**Additional context**
NA
