### PR TITLE
feat: make `list_agents` paginated

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -36,6 +36,7 @@ from memgpt.system import (
 from memgpt.utils import (
     count_tokens,
     create_uuid_from_string,
+    datetime_to_unix_int,
     get_local_time,
     get_tool_call_id,
     get_utc_time,
@@ -938,8 +939,7 @@ class Agent(object):
             self.agent_state._metadata = {}
         # When was the last run step?
         last_msg_obj = self._messages[-1]
-        from memgpt.utils import datetime_to_unix_int
-
+        # NOTE: this has to be stored as a JSON-serializeable format, so we have to cast out of datetime
         self.agent_state._metadata["last_run"] = datetime_to_unix_int(last_msg_obj.created_at)
         # Basic memory statistics
         recall_memory = self.persistence_manager.recall_memory

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -934,6 +934,8 @@ class Agent(object):
         }
 
         ## Additional metadata we want to track (that's useful for the client to know)
+        if self.agent_state._metadata is None:
+            self.agent_state._metadata = {}
         # When was the last run step?
         last_msg_obj = self._messages[-1]
         self.agent_state._metadata["last_run"] = last_msg_obj.created_at

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -938,7 +938,9 @@ class Agent(object):
             self.agent_state._metadata = {}
         # When was the last run step?
         last_msg_obj = self._messages[-1]
-        self.agent_state._metadata["last_run"] = last_msg_obj.created_at
+        from memgpt.utils import datetime_to_unix_int
+
+        self.agent_state._metadata["last_run"] = datetime_to_unix_int(last_msg_obj.created_at)
         # Basic memory statistics
         recall_memory = self.persistence_manager.recall_memory
         archival_memory = self.persistence_manager.archival_memory

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -24,7 +24,7 @@ from memgpt.models.pydantic_models import (
 )
 from memgpt.server.rest_api.agents.command import CommandResponse
 from memgpt.server.rest_api.agents.config import GetAgentResponse
-from memgpt.server.rest_api.agents.index import CreateAgentResponse, ListAgentsResponse
+from memgpt.server.rest_api.agents.index import CreateAgentResponse
 from memgpt.server.rest_api.agents.memory import (
     ArchivalMemoryObject,
     GetAgentArchivalMemoryResponse,
@@ -232,9 +232,9 @@ class RESTClient(AbstractClient):
         self.base_url = base_url
         self.headers = {"accept": "application/json", "authorization": f"Bearer {token}"}
 
-    def list_agents(self):
+    def list_agents(self) -> List[AgentState]:
         response = requests.get(f"{self.base_url}/api/agents", headers=self.headers)
-        return ListAgentsResponse(**response.json())
+        return [AgentState(a) for a in response.json()]
 
     def agent_exists(self, agent_id: Optional[str] = None, agent_name: Optional[str] = None) -> bool:
         response = requests.get(f"{self.base_url}/api/agents/{str(agent_id)}/config", headers=self.headers)

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -711,9 +711,9 @@ class LocalClient(AbstractClient):
             raise ValueError(f"Only one of agent_id or agent_name can be provided")
         existing = self.list_agents()
         if agent_id:
-            return agent_id in [agent["id"] for agent in existing["agents"]]
+            return str(agent_id) in [str(agent.id) for agent in existing]
         else:
-            return agent_name in [agent["name"] for agent in existing["agents"]]
+            return agent_name in [agent.name for agent in existing]
 
     def create_agent(
         self,

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -617,7 +617,14 @@ class MetadataStore:
             results = session.query(AgentModel).filter(AgentModel.user_id == user_id).all()
             return [r.to_record() for r in results]
 
+    @enforce_types
+    def count_agents(self, user_id: uuid.UUID) -> int:
+        with self.session_maker() as session:
+            count = session.query(func.count(AgentModel.id)).filter(AgentModel.user_id == user_id).scalar()
+        return count
+
     # @enforce_types
+    # NOTE: disabled because - TypeError: Subscripted generics cannot be used with class and instance checks
     def list_agents(
         self,
         user_id: uuid.UUID,

--- a/memgpt/models/utils.py
+++ b/memgpt/models/utils.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+
+from memgpt.data_types import AgentState, EmbeddingConfig, LLMConfig
+from memgpt.models.pydantic_models import (
+    AgentStateModel,
+    EmbeddingConfigModel,
+    LLMConfigModel,
+)
+
+
+def datetime_to_unix_int(dt: datetime) -> int:
+    unix_timestamp = int(dt.replace(tzinfo=timezone.utc).timestamp())
+    return unix_timestamp
+
+
+def embeddingconfig_to_embeddingconfigmodel(embedding_config: EmbeddingConfig):
+    return EmbeddingConfigModel(
+        embedding_endpoint_type=embedding_config.embedding_endpoint_type,
+        embedding_endpoint=embedding_config.embedding_endpoint,
+        embedding_model=embedding_config.embedding_model,
+        embedding_dim=embedding_config.embedding_dim,
+        embedding_chunk_size=embedding_config.embedding_chunk_size,
+    )
+
+
+def llmconfig_to_llmconfigmodel(llm_config: LLMConfig):
+    return LLMConfigModel(
+        model=llm_config.model,
+        model_endpoint_type=llm_config.model_endpoint_type,
+        model_endpoint=llm_config.model_endpoint,
+        model_wrapper=llm_config.model_wrapper,
+        context_window=llm_config.context_window,
+    )
+
+
+def agentstate_to_agentstatemodel(agent_state: AgentState):
+    return AgentStateModel(
+        id=agent_state.id,
+        name=agent_state.name,
+        description=None,
+        user_id=agent_state.user_id,
+        created_at=datetime_to_unix_int(agent_state.created_at),
+        tools=agent_state.tools,
+        system=agent_state.system,
+        llm_config=llmconfig_to_llmconfigmodel(agent_state.llm_config),
+        embedding_config=embeddingconfig_to_embeddingconfigmodel(agent_state.embedding_config),
+        state=agent_state.state,
+        metadata=agent_state._metadata,
+    )

--- a/memgpt/models/utils.py
+++ b/memgpt/models/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from memgpt.data_types import AgentState, EmbeddingConfig, LLMConfig
 from memgpt.models.pydantic_models import (
@@ -6,11 +6,7 @@ from memgpt.models.pydantic_models import (
     EmbeddingConfigModel,
     LLMConfigModel,
 )
-
-
-def datetime_to_unix_int(dt: datetime) -> int:
-    unix_timestamp = int(dt.replace(tzinfo=timezone.utc).timestamp())
-    return unix_timestamp
+from memgpt.utils import datetime_to_unix_int
 
 
 def embeddingconfig_to_embeddingconfigmodel(embedding_config: EmbeddingConfig):
@@ -34,7 +30,7 @@ def llmconfig_to_llmconfigmodel(llm_config: LLMConfig):
 
 
 def agentstate_to_agentstatemodel(agent_state: AgentState):
-    return AgentStateModel(
+    model = AgentStateModel(
         id=agent_state.id,
         name=agent_state.name,
         description=None,
@@ -47,3 +43,9 @@ def agentstate_to_agentstatemodel(agent_state: AgentState):
         state=agent_state.state,
         metadata=agent_state._metadata,
     )
+
+    # TODO this really needs to be done via a pydantic model auto-conversion
+    if "last_run" in model.metadata and isinstance(model.metadata["last_run"], datetime):
+        model.metadata["last_run"] = datetime_to_unix_int(model.metadata["last_run"])
+
+    return model

--- a/memgpt/server/rest_api/agents/index.py
+++ b/memgpt/server/rest_api/agents/index.py
@@ -65,8 +65,7 @@ def setup_agents_index_router(server: SyncServer, interface: QueuingInterface, p
             limit=request.limit,
             order=request.order,
         )
-        # TODO make this the real count
-        num_agents = len(agents_data)
+        num_agents = server.ms.count_agents(user_id=user_id)
         return ListAgentsResponse(num_agents=num_agents, agents=agents_data)
 
     @router.post("/agents", tags=["agents"], response_model=CreateAgentResponse)

--- a/memgpt/server/rest_api/agents/index.py
+++ b/memgpt/server/rest_api/agents/index.py
@@ -24,7 +24,8 @@ router = APIRouter()
 class ListAgentsRequest(BaseModel):
     after: Optional[uuid.UUID] = Field(None, description="Unique agent ID to start the query range at.")
     before: Optional[uuid.UUID] = Field(None, description="Unique agent ID to end the query range at.")
-    limit: Optional[int] = Field(None, description="How many results to include in the response.")
+    # TODO should these be 'optional'?
+    limit: int = Field(20, description="How many results to include in the response.")
     order: Literal["asc", "desc"] = Field("desc", description="Sort order, asc for ascending order and desc for descending order.")
 
 
@@ -48,7 +49,7 @@ def setup_agents_index_router(server: SyncServer, interface: QueuingInterface, p
 
     @router.get("/agents", tags=["agents"], response_model=ListAgentsResponse)
     def list_agents(
-        request: ListAgentsRequest = Body(...),
+        request: ListAgentsRequest = Depends(),  # NOTE: using depends here, since all the pieces have defaults
         user_id: uuid.UUID = Depends(get_current_user_with_server),
     ):
         """

--- a/memgpt/server/rest_api/agents/sources.py
+++ b/memgpt/server/rest_api/agents/sources.py
@@ -1,0 +1,29 @@
+import uuid
+from functools import partial
+from typing import List
+
+from fastapi import APIRouter, Depends
+
+from memgpt.models.pydantic_models import SourceModel
+from memgpt.server.rest_api.auth_token import get_current_user
+from memgpt.server.rest_api.interface import QueuingInterface
+from memgpt.server.server import SyncServer
+
+router = APIRouter()
+
+
+def setup_agents_sources_router(server: SyncServer, interface: QueuingInterface, password: str):
+    get_current_user_with_server = partial(partial(get_current_user, server), password)
+
+    @router.get("/agents/{agent_id}/sources", tags=["agents"], response_model=List[SourceModel])
+    def get_agent_sources(
+        agent_id: uuid.UUID,
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Retrieve all the tools associated with an agent.
+        """
+        agent_state = server.ms.get_agent(agent_id=agent_id, user_id=user_id)
+        sources_ids = server.ms.list_attached_sources(agent_id=agent_state.id)
+        sources = [server.ms.get_source(source_id=s_id) for s_id in sources_ids]
+        return sources

--- a/memgpt/server/rest_api/agents/tools.py
+++ b/memgpt/server/rest_api/agents/tools.py
@@ -1,0 +1,28 @@
+import uuid
+from functools import partial
+from typing import List
+
+from fastapi import APIRouter, Depends
+
+from memgpt.models.pydantic_models import ToolModel
+from memgpt.server.rest_api.auth_token import get_current_user
+from memgpt.server.rest_api.interface import QueuingInterface
+from memgpt.server.server import SyncServer
+
+router = APIRouter()
+
+
+def setup_agents_tools_router(server: SyncServer, interface: QueuingInterface, password: str):
+    get_current_user_with_server = partial(partial(get_current_user, server), password)
+
+    @router.get("/agents/{agent_id}/tools", tags=["agents"], response_model=List[ToolModel])
+    def get_agent_tools(
+        agent_id: uuid.UUID,
+        user_id: uuid.UUID = Depends(get_current_user_with_server),
+    ):
+        """
+        Retrieve all the tools associated with an agent.
+        """
+        agent_state = server.ms.get_agent(agent_id=agent_id, user_id=user_id)
+        all_available_tools = server.ms.list_tools()
+        return [tool for tool in all_available_tools if tool.name in agent_state.tools]

--- a/memgpt/server/rest_api/server.py
+++ b/memgpt/server/rest_api/server.py
@@ -19,6 +19,8 @@ from memgpt.server.rest_api.agents.config import setup_agents_config_router
 from memgpt.server.rest_api.agents.index import setup_agents_index_router
 from memgpt.server.rest_api.agents.memory import setup_agents_memory_router
 from memgpt.server.rest_api.agents.message import setup_agents_message_router
+from memgpt.server.rest_api.agents.sources import setup_agents_sources_router
+from memgpt.server.rest_api.agents.tools import setup_agents_tools_router
 from memgpt.server.rest_api.auth.index import setup_auth_router
 from memgpt.server.rest_api.config.index import setup_config_index_router
 from memgpt.server.rest_api.humans.index import setup_humans_index_router
@@ -95,6 +97,8 @@ app.include_router(setup_agents_config_router(server, interface, password), pref
 app.include_router(setup_agents_index_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_agents_memory_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_agents_message_router(server, interface, password), prefix=API_PREFIX)
+app.include_router(setup_agents_tools_router(server, interface, password), prefix=API_PREFIX)
+app.include_router(setup_agents_sources_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_humans_index_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_personas_index_router(server, interface, password), prefix=API_PREFIX)
 app.include_router(setup_models_index_router(server, interface, password), prefix=API_PREFIX)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -866,24 +866,6 @@ class SyncServer(LockingServer):
 
         agents_states = self.ms.list_agents(user_id=user_id, after=after, before=before, limit=limit, order=order)
         agents_states = [agentstate_to_agentstatemodel(a_s) for a_s in agents_states]
-
-        # For the UI listing panel, we need to add the following metadata:
-        # - tool breakdown (num base/core tools, num other)
-        # - last run data
-        # - memory stats (recall, archival)
-        # - number of sources
-        for agent_state in agents_states:
-
-            # Add information about attached sources
-            sources_ids = self.ms.list_attached_sources(agent_id=agent_state.id)
-            sources = [self.ms.get_source(source_id=s_id) for s_id in sources_ids]
-            agent_state.metadata["sources"] = [vars(s) for s in sources]
-
-            # Put full tool information inside the metadata
-            all_available_tools = self.ms.list_tools()
-            # agent_state.metadata["tools"] = [tool for tool in all_available_tools if tool.json_schema in memgpt_agent.functions]
-            agent_state.metadata["tools"] = [tool for tool in all_available_tools if tool.name in agent_state.tools]
-
         return agents_states
 
     def list_personas(self, user_id: uuid.UUID):

--- a/memgpt/utils.py
+++ b/memgpt/utils.py
@@ -468,6 +468,11 @@ NOUN_BANK = [
 ]
 
 
+def datetime_to_unix_int(dt: datetime) -> int:
+    unix_timestamp = int(dt.replace(tzinfo=timezone.utc).timestamp())
+    return unix_timestamp
+
+
 def smart_urljoin(base_url: str, relative_url: str) -> str:
     """urljoin is stupid and wants a trailing / at the end of the endpoint address, or it will chop the suffix off"""
     if not base_url.endswith("/"):


### PR DESCRIPTION
Closes #1498 

## Change in API endpoint

GET request is now paginated, in the style of: https://platform.openai.com/docs/api-reference/assistants/listAssistants

## Change in data locations

For @goetzrobin: there's some differences in the data coming back from the GET request (apart from it now accepting additional pagination args): https://github.com/cpacker/MemGPT/blob/82ae5a22b641a66fda674a8278ce08d8413f561f/memgpt/server/server.py#L864

### "persona" / "human"

```python
            return_dict["persona"] = agent_state._metadata.get("persona", None)
            return_dict["human"] = agent_state._metadata.get("human", None)
``` 

This should still be accessible in the `List[AgentStateModel]` being returned

### "tools"

```python
            return_dict["tools"] = [tool for tool in all_available_tools if tool.json_schema in memgpt_agent.functions]

```

~~This is now in `AgentStateModel.metadata["tools"]`~~

NOTE: this has been moved to a separate `GET` request: see new route `def get_agent_tools` (`router.get("/agents/{agent_id}/tools`)

### "memory stats"

```python
            # Add information about memory (raw core, size of recall, size of archival)
            core_memory = memgpt_agent.memory
            recall_memory = memgpt_agent.persistence_manager.recall_memory
            archival_memory = memgpt_agent.persistence_manager.archival_memory
            memory_obj = {
                "core_memory": {section: module.value for (section, module) in core_memory.memory.items()},
                "recall_memory": len(recall_memory) if recall_memory is not None else None,
                "archival_memory": len(archival_memory) if archival_memory is not None else None,
            }
            return_dict["memory"] = memory_obj
```

This is now in `AgentStateModel.metadata["memory_stats"]`, see new `Agent.update_state` function

### "last run"

```python
            # Add information about last run
            # NOTE: 'last_run' is just the timestamp on the latest message in the buffer
            # Retrieve the Message object via the recall storage or by directly access _messages
            last_msg_obj = memgpt_agent._messages[-1]
            return_dict["last_run"] = last_msg_obj.created_at
```

This is now in `AgentStateModel.metadata["last_run"]`

### "attached sources"

```python
            # Add information about attached sources
            sources_ids = self.ms.list_attached_sources(agent_id=agent_state.id)
            sources = [self.ms.get_source(source_id=s_id) for s_id in sources_ids]
            return_dict["sources"] = [vars(s) for s in sources]
```

~~This is now in `AgentStateModel.metadata["sources"]`~~

NOTE: this has been moved to a separate `GET` request: `def get_agent_sources` (`/agents/{agent_id}/sources`)

^extra note @goetzrobin these metadata fields may be `null` for old agents, since they are stored inside of `metadata` they will get refreshed on `.step()`, so only agents that have been run post-PR will have the metadata fields. The frontend should have sane defaults / not crash on null accordingly.