### PR TITLE
feat: add character limits for persona/human to /config response

### DIFF
--- a/memgpt/config.py
+++ b/memgpt/config.py
@@ -7,7 +7,14 @@ from dataclasses import dataclass
 
 import memgpt
 import memgpt.utils as utils
-from memgpt.constants import DEFAULT_HUMAN, DEFAULT_PERSONA, DEFAULT_PRESET, MEMGPT_DIR
+from memgpt.constants import (
+    CORE_MEMORY_HUMAN_CHAR_LIMIT,
+    CORE_MEMORY_PERSONA_CHAR_LIMIT,
+    DEFAULT_HUMAN,
+    DEFAULT_PERSONA,
+    DEFAULT_PRESET,
+    MEMGPT_DIR,
+)
 from memgpt.data_types import AgentState, EmbeddingConfig, LLMConfig
 from memgpt.log import get_logger
 
@@ -75,6 +82,10 @@ class MemGPTConfig:
 
     # user info
     policies_accepted: bool = False
+
+    # Default memory limits
+    core_memory_persona_char_limit: int = CORE_MEMORY_PERSONA_CHAR_LIMIT
+    core_memory_human_char_limit: int = CORE_MEMORY_HUMAN_CHAR_LIMIT
 
     def __post_init__(self):
         # ensure types

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1215,15 +1215,19 @@ class SyncServer(LockingServer):
         # TODO: do we need a seperate server config?
         base_config = vars(self.config)
         clean_base_config = clean_keys(base_config)
-        clean_base_config["default_llm_config"] = vars(clean_base_config["default_llm_config"])
-        clean_base_config["default_embedding_config"] = vars(clean_base_config["default_embedding_config"])
+
+        clean_base_config_default_llm_config_dict = vars(clean_base_config["default_llm_config"])
+        clean_base_config_default_embedding_config_dict = vars(clean_base_config["default_embedding_config"])
+
+        clean_base_config["default_llm_config"] = clean_base_config_default_llm_config_dict
+        clean_base_config["default_embedding_config"] = clean_base_config_default_embedding_config_dict
         response = {"config": clean_base_config}
 
         if include_defaults:
             default_config = vars(MemGPTConfig())
             clean_default_config = clean_keys(default_config)
-            clean_default_config["default_llm_config"] = vars(clean_default_config["default_llm_config"])
-            clean_default_config["default_embedding_config"] = vars(clean_default_config["default_embedding_config"])
+            clean_default_config["default_llm_config"] = clean_base_config_default_llm_config_dict
+            clean_default_config["default_embedding_config"] = clean_base_config_default_embedding_config_dict
             response["defaults"] = clean_default_config
 
         return response


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

Adding CORE_MEMORY_HUMAN_CHAR_LIMIT and CORE_MEMORY_PERSONA_CHAR_LIMIT to the /config response
so they can be used to dynamically adjust the frontend text area limits

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
