### PR TITLE
feat: patch missing inner thoughts on new openai models

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -24,6 +24,7 @@ from memgpt.log import get_logger
 from memgpt.memory import ChatMemory
 from memgpt.metadata import MetadataStore
 from memgpt.migrate import migrate_all_agents, migrate_all_sources
+from memgpt.models.pydantic_models import OptionState
 from memgpt.server.constants import WS_DEFAULT_PORT
 from memgpt.server.server import logger as server_logger
 
@@ -410,6 +411,10 @@ def run(
     yes: Annotated[bool, typer.Option("-y", help="Skip confirmation prompt and use defaults")] = False,
     # streaming
     stream: Annotated[bool, typer.Option(help="Enables message streaming in the CLI (if the backend supports it)")] = False,
+    # whether or not to put the inner thoughts inside the function args
+    no_content: Annotated[
+        OptionState, typer.Option(help="Set to 'yes' for LLM APIs that omit the `content` field during tool calling")
+    ] = OptionState.DEFAULT,
 ):
     """Start chatting with an MemGPT agent
 
@@ -671,7 +676,13 @@ def run(
 
     print()  # extra space
     run_agent_loop(
-        memgpt_agent=memgpt_agent, config=config, first=first, ms=ms, no_verify=no_verify, stream=stream
+        memgpt_agent=memgpt_agent,
+        config=config,
+        first=first,
+        ms=ms,
+        no_verify=no_verify,
+        stream=stream,
+        inner_thoughts_in_kwargs=no_content,
     )  # TODO: add back no_verify
 
 

--- a/memgpt/data_types.py
+++ b/memgpt/data_types.py
@@ -75,7 +75,7 @@ class ToolCall(object):
 def add_inner_thoughts_to_tool_call(
     tool_call: ToolCall,
     inner_thoughts: str,
-    inner_thoughts_key: str = INNER_THOUGHTS_KWARG,
+    inner_thoughts_key: str,
 ) -> ToolCall:
     """Add inner thoughts (arg + value) to a tool call"""
     # because the kwargs are stored as strings, we need to load then write the JSON dicts
@@ -491,7 +491,7 @@ class Message(Record):
             assert all([v is not None for v in [self.role, self.tool_call_id]]), vars(self)
 
             if self.name is None:
-                raise UserWarning(f"Couldn't find function name on tool call, defaulting to tool ID instead.")
+                warnings.warn(f"Couldn't find function name on tool call, defaulting to tool ID instead.")
                 function_name = self.tool_call_id
             else:
                 function_name = self.name
@@ -623,9 +623,6 @@ class Message(Record):
             raise ValueError(self.role)
 
         return cohere_message
-
-
-def put_inner_thoughts_in_kwargs(message: Message) -> Message: ...
 
 
 class Document(Record):

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -34,6 +34,7 @@ from memgpt.constants import (
     REQ_HEARTBEAT_MESSAGE,
 )
 from memgpt.metadata import MetadataStore
+from memgpt.models.pydantic_models import OptionState
 
 # from memgpt.interface import CLIInterface as interface  # for printing to terminal
 from memgpt.streaming_interface import AgentRefreshStreamingInterface
@@ -71,7 +72,14 @@ def clear_line(console, strip_ui=False):
 
 
 def run_agent_loop(
-    memgpt_agent: agent.Agent, config: MemGPTConfig, first, ms: MetadataStore, no_verify=False, cfg=None, strip_ui=False, stream=False
+    memgpt_agent: agent.Agent,
+    config: MemGPTConfig,
+    first: bool,
+    ms: MetadataStore,
+    no_verify: bool = False,
+    strip_ui: bool = False,
+    stream: bool = False,
+    inner_thoughts_in_kwargs: OptionState = OptionState.DEFAULT,
 ):
     if isinstance(memgpt_agent.interface, AgentRefreshStreamingInterface):
         # memgpt_agent.interface.toggle_streaming(on=stream)
@@ -386,6 +394,7 @@ def run_agent_loop(
                 first_message=False,
                 skip_verify=no_verify,
                 stream=stream,
+                inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
             )
 
             skip_next_user_input = False
@@ -419,7 +428,7 @@ def run_agent_loop(
                 retry = questionary.confirm("Retry agent.step()?").ask()
                 if not retry:
                     break
-            except Exception as e:
+            except Exception:
                 print("An exception occurred when running agent.step(): ")
                 traceback.print_exc()
                 retry = questionary.confirm("Retry agent.step()?").ask()

--- a/memgpt/models/pydantic_models.py
+++ b/memgpt/models/pydantic_models.py
@@ -13,6 +13,14 @@ from memgpt.constants import DEFAULT_HUMAN, DEFAULT_PERSONA
 from memgpt.utils import get_human_text, get_persona_text, get_utc_time
 
 
+class OptionState(str, Enum):
+    """Useful for kwargs that are bool + default option"""
+
+    YES = "yes"
+    NO = "no"
+    DEFAULT = "default"
+
+
 class MemGPTUsageStatistics(BaseModel):
     completion_tokens: int
     prompt_tokens: int


### PR DESCRIPTION
TODOs:

Refactor code to convert to inner thought kwarg format

- [x] ~Add utility method inside of data types to convert `Message` objects~
  - See note*
  - Add utility to convert `ToolCall`s into versions that have a kwarg included (`add_inner_thoughts_to_tool_call`)
  - Add flag `put_inner_thoughts_in_kwargs` to `Message.to_openai_dict` which will call utility to make put `self.text` (the `content` / inner thoughts) into `ToolCall`s via the utility
- [x] Add utility method to convert functions list / tool objects (~will require dumping and reading json strings of arguments~)
  - `add_inner_thoughts_to_functions`
- [x] Add utility method to convert response from OpenAI response to strip inner thoughts from kwargs and into the content field for data storage
  - `unpack_inner_thoughts_from_kwargs`
- [x] Add flag to CLI to allow turning this on manually
  - I added a `--no-content` flag (`yes` = put inner thoughts in kwargs, `no` = leave as normal (gpt4 style), `default` = let us decide, eg for gpt4o turn it on, for gpt4 turn it off)
- [ ] TODO future PR - add support for our other API backends

*note: I was going to create a `Message -> Message` utility function that puts `self.text` into `self.tool_calls` (as an alternative to putting the logic for extracting inner thoughts from `self.text` into the function/tool call in the `to_*_dict()` methods), however upon further thought I think it's better to leave this logic inside the `_to_dict()` methods because it might vary significantly from provider to provider. Example of what I was going to do:
```python

# TODO have this use model_copy
def put_inner_thoughts_in_kwargs(message: Message) -> Message:
    """Convert a message that has inner monologue in self.text to one that has it inside a tool call"""
    # message_copy = message.model_copy()
    message_copy = copy.deepcopy(message)

    # TODO
    # step 1: assert the role is assistant and tool_calls > 1
    # step 2: copy self.text into self.tool_calls[0], and make self.text = None
    # step 3: return the message copy
```

**Please describe the purpose of this pull request.**

Fixes issues with missing `content` / inner thoughts on newer OpenAI models like 4o-mini

**How to test**

`memgpt run` with `gpt-4o-mini`

**Have you tested this PR?**

Yes, gpt4o-mini works fine now:
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/378e901a-3fa3-46c6-8498-759c73aa9a19">

**Related issues or PRs**

Closes #1555 
