### PR TITLE
fix: Fixes error when calling function without providing timestamp (even t…

### DIFF
--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -653,7 +653,7 @@ class SyncServer(LockingServer):
             message.created_at = timestamp
 
         # Run the agent state forward
-        return self._step(user_id=user_id, agent_id=agent_id, input_message=packaged_system_message)
+        return self._step(user_id=user_id, agent_id=agent_id, input_message=packaged_system_message, timestamp=None)
 
     # @LockingServer.agent_lock_decorator
     def run_command(self, user_id: uuid.UUID, agent_id: uuid.UUID, command: str) -> Union[MemGPTUsageStatistics, None]:


### PR DESCRIPTION
…hough it's marked as optional)

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

Fixes a bug

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

Send a message to agent via API. But instead of user message, use system. It errors with missing timestamp argument. This small code changed unblocked me. I've done system calls in the past so this must have slipped through recently.

{
    "message": "This is a user triggered system alert",
    "role": "system",
    "stream": true,
    "timestamp": "2024-07-20 09:05:18.346725"
}

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

I was blocked, did this code change, got a success back.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
