### PR TITLE
fix: read embedding_model and embedding_dim from embedding_config

### DIFF
--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -1147,8 +1147,8 @@ def list(arg: Annotated[ListChoice, typer.Argument]):
                 [
                     source.name,
                     source.description,
-                    source.embedding_model,
-                    source.embedding_dim,
+                    source.embedding_config.embedding_model,
+                    source.embedding_config.embedding_dim,
                     utils.format_datetime(source.created_at),
                 ]
             )


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fix a bug with the `memgpt list sources` CLI command. 

**How to test**
In a fresh project, you can load a simple data source and run `memgpt list sources` which should break with `AttributeError: 'SourceModel' object has no attribute 'embedding_dim'. Did you mean: 'embedding_config'?`

**Have you tested this PR?**
Yes. Tested this change using
```
memgpt load directory --name test --input-dir ~/testing/memgpt_data_sources
memgpt list sources
```

**Related issues or PRs**
https://github.com/cpacker/MemGPT/issues/1587

