### PR TITLE
feat: Fix CLI agent delete functionality & allow importation of file for system prompt - attempt #2

### DIFF
--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -396,6 +396,7 @@ def run(
     agent: Annotated[Optional[str], typer.Option(help="Specify agent name")] = None,
     human: Annotated[Optional[str], typer.Option(help="Specify human")] = None,
     system: Annotated[Optional[str], typer.Option(help="Specify system prompt (raw text)")] = None,
+    system_file: Annotated[Optional[str], typer.Option(help="Specify raw text file containing system prompt")] = None,
     # model flags
     model: Annotated[Optional[str], typer.Option(help="Specify the LLM model")] = None,
     model_wrapper: Annotated[Optional[str], typer.Option(help="Specify the LLM model wrapper")] = None,
@@ -651,6 +652,13 @@ def run(
             persona_obj = ms.get_persona(persona, user.id)
             # TODO pull system prompts from the metadata store
             # NOTE: will be overriden later to a default
+            if system_file:
+                try:
+                    with open(system_file, "r", encoding="utf-8") as file:
+                        system = file.read().strip()
+                        printd("Loaded system file successfully.")
+                except FileNotFoundError:
+                    typer.secho(f"System file not found at {system_file}", fg=typer.colors.RED)
             system_prompt = system if system else None
             if human_obj is None:
                 typer.secho("Couldn't find human {human} in database, please run `memgpt add human`", fg=typer.colors.RED)

--- a/memgpt/cli/cli.py
+++ b/memgpt/cli/cli.py
@@ -396,7 +396,6 @@ def run(
     agent: Annotated[Optional[str], typer.Option(help="Specify agent name")] = None,
     human: Annotated[Optional[str], typer.Option(help="Specify human")] = None,
     system: Annotated[Optional[str], typer.Option(help="Specify system prompt (raw text)")] = None,
-    system_file: Annotated[Optional[str], typer.Option(help="Specify raw text file containing system prompt")] = None,
     # model flags
     model: Annotated[Optional[str], typer.Option(help="Specify the LLM model")] = None,
     model_wrapper: Annotated[Optional[str], typer.Option(help="Specify the LLM model wrapper")] = None,
@@ -652,13 +651,6 @@ def run(
             persona_obj = ms.get_persona(persona, user.id)
             # TODO pull system prompts from the metadata store
             # NOTE: will be overriden later to a default
-            if system_file:
-                try:
-                    with open(system_file, "r", encoding="utf-8") as file:
-                        system = file.read().strip()
-                        printd("Loaded system file successfully.")
-                except FileNotFoundError:
-                    typer.secho(f"System file not found at {system_file}", fg=typer.colors.RED)
             system_prompt = system if system else None
             if human_obj is None:
                 typer.secho("Couldn't find human {human} in database, please run `memgpt add human`", fg=typer.colors.RED)

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -1212,7 +1212,7 @@ def delete(option: str, name: str):
             client.delete_source(source_id=source.id)
         elif option == "agent":
             agent = client.get_agent(agent_name=name)
-            assert agent is not None, f"Agent {name} does not exist"        
+            assert agent is not None, f"Agent {name} does not exist"
             client.delete_agent(agent_id=agent.id)
         elif option == "human":
             human = client.get_human(name=name)

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -1211,7 +1211,9 @@ def delete(option: str, name: str):
             assert source is not None, f"Source {name} does not exist"
             client.delete_source(source_id=source.id)
         elif option == "agent":
-            client.delete_agent(name=name)
+            agent = client.get_agent(agent_name=name)
+            assert agent is not None, f"Agent {name} does not exist"        
+            client.delete_agent(agent_id=agent.id)
         elif option == "human":
             human = client.get_human(name=name)
             assert human is not None, f"Human {name} does not exist"

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -98,14 +98,13 @@ class ChatMemory(BaseMemory):
             "human": MemoryModule(name="human", value=human, limit=limit),
         }
 
-    def core_memory_append(self, name: str, content: str, subsection: Optional[str] = "None") -> Optional[str]:
+    def core_memory_append(self, name: str, content: str) -> Optional[str]:
         """
         Append to the contents of core memory.
 
         Args:
             name (str): Section of the memory to be edited (persona or human).
             content (str): Content to write to the memory. All unicode (including emojis) are supported.
-            subsection (Optional[str]): Name of sub-section to store memory.  Must be "public", "private", or "relationship". Defaults to "private".
 
         Returns:
             Optional[str]: None is always returned as this function does not produce a response.

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -98,13 +98,14 @@ class ChatMemory(BaseMemory):
             "human": MemoryModule(name="human", value=human, limit=limit),
         }
 
-    def core_memory_append(self, name: str, content: str) -> Optional[str]:
+    def core_memory_append(self, name: str, content: str, subsection: Optional[str] = "None") -> Optional[str]:
         """
         Append to the contents of core memory.
 
         Args:
             name (str): Section of the memory to be edited (persona or human).
             content (str): Content to write to the memory. All unicode (including emojis) are supported.
+            subsection (Optional[str]): Name of sub-section to store memory.  Must be "public", "private", or "relationship". Defaults to "private".
 
         Returns:
             Optional[str]: None is always returned as this function does not produce a response.


### PR DESCRIPTION
Please describe the purpose of this pull request.
I should learn how to use git better..

Changes the cli_config.py broke the delete agent functionality. LocalClient.delete_agent() expects an agent id to be provided but code provides the agent name.
Adds code to allow a text file to be used to import the system prompt from memgpt run for use in new agent creation.
How to test

Try to delete an agent without change. LocalClient will respond back with:
LocalClient.delete_agent() got an unexpected keyword argument 'agent_name'
Apply fix and try again.

memgpt run --system-file <name of text file>
Will load the text file during new agent creation.

Have you tested this PR?
Yes, it works.

Related issues or PRs
Please link any related GitHub issues or PRs.

Is your PR over 500 lines of code?
Nope

Additional context
Not really.