### PR TITLE
fix: syntax warning on startup

### DIFF
--- a/memgpt/local_llm/json_parser.py
+++ b/memgpt/local_llm/json_parser.py
@@ -18,7 +18,7 @@ def clean_json_string_extra_backslash(s):
 
 
 def replace_escaped_underscores(string: str):
-    """Handles the case of escaped underscores, e.g.:
+    r"""Handles the case of escaped underscores, e.g.:
 
     {
       "function":"send\_message",
@@ -26,7 +26,7 @@ def replace_escaped_underscores(string: str):
         "inner\_thoughts": "User is asking for information about themselves. Retrieving data from core memory.",
         "message": "I know that you are Chad. Is there something specific you would like to know or talk about regarding yourself?"
     """
-    return string.replace("\_", "_")
+    return string.replace(r"\_", "_")
 
 
 def extract_first_json(string: str):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Fixes a couple of small syntax warnings that appear on startup of the memgpt server (in dev). 

```
memgpt_server-1  | Starting MEMGPT server...
memgpt_server-1  | /memgpt/local_llm/json_parser.py:21: SyntaxWarning: invalid escape sequence '\_'
memgpt_server-1  |   """Handles the case of escaped underscores, e.g.:
memgpt_server-1  | /memgpt/local_llm/json_parser.py:29: SyntaxWarning: invalid escape sequence '\_'
memgpt_server-1  |   return string.replace("\_", "_")
```

**How to test**
You can run the service locally and see that the syntax warnings are no longer in the logs. `docker compose -f dev-compose.yaml up --build`

**Have you tested this PR?**
Yes! Output is just the "starting" line without the syntax warnings. 

```
memgpt_server-1  | Starting MEMGPT server...
```

**Related issues or PRs**
n/a

**Is your PR over 500 lines of code?**
n/a

**Additional context**
n/a 