### PR TITLE
Memory validation fix + core_memory_replace runaway content repeating fix

### DIFF
--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -28,10 +28,12 @@ class MemoryModule(BaseModel):
 
     def __setattr__(self, name, value):
         """Run validation if self.value is updated"""
-        super().__setattr__(name, value)
         if name == "value":
-            # run validation
-            self.__class__.validate(self.dict(exclude_unset=True))
+            # Temporarily set the attribute to run validation
+            temp = self.copy(update={name: value})
+            self.__class__.validate(temp.dict(exclude_unset=True))
+
+        super().__setattr__(name, value)
 
     @validator("value", always=True)
     def check_value_length(cls, v, values):

--- a/memgpt/memory.py
+++ b/memgpt/memory.py
@@ -126,7 +126,10 @@ class ChatMemory(BaseMemory):
         Returns:
             Optional[str]: None is always returned as this function does not produce a response.
         """
-        self.memory[name].value = self.memory[name].value.replace(old_content, new_content)
+        if old_content == "":
+            self.memory[name].value = new_content
+        else:
+            self.memory[name].value = self.memory[name].value.replace(old_content, new_content)
         return None
 
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

Fixes bug (Also see note at bottom)

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

Make agent core memory (human or persona be 1999 characters with a 2000 limit) Ask agent to save something more to the memory. If it does actually do it, the validation and function call would fail but the data was still applied to the agent. On next agent load it will throw an error because the memory is over the limit.

For next item, just have the AI update a memory block with core_memory_replace and have it send "" for old content. It will replace the text with a huge blob (size based on # characters on the existing content in that bank)

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

I am now able to trigger a save, function fail, and then the length remained at (1999).
I was also able to have AI repair its own persona by replacing it entirely with old_content = "" and new_content = "lorem ipsum etc".

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.

Idk if the validation system being used normally recommends set_attr to be overridden like it is but I'm not an expert on the lib being used. I needed to move super call to be after the validation, and to run validation on a copy so the old value is reserved if it fails (exits before super called).

[Action item #1] - Also, there was a bug with core_memory_replace. If the AI sends a "" for old content, it will replace every existing character with the new_content value. This leads to trying to save repeating text in the hundreds of thousands of characters long (depending on the existing length of old_content on agent already. I updated the function in code to replace all if no old content was specified. I don't know if that's ideal per design or not.. if not then please update this PR with a validation rule so the AI can at least be aware of an issue.

[Action item #2] - My sqlite database toolmodel table for core_memory_append and replace referenced the memory as self.memory.memory[name] = ...    but the code I edited in this PR would only apply to new agents (I believe) So there may need to be a migration script added to this PR to repair existing agents if you guys deem the code update necessary. Also, the code I edited for the append referenced memory as self.memory[name].value instead of self.memory.memory[name].value. I'm not sure of the reasons why there is a difference but memory.memory (in the db) is what works for me.

I added the two action items above for some minor help/adjustments to this PR if needed. I fixed this to get past some blockers I had using local llms and updated the tool in my own DB but the migration stuff I want to leave to you guys. I assume it's sqlite, postgres, etc or something. Overall I think this contains most of a critical fix. Someone else in the chats were having agents break from some of the things happening here. (huge text sizes and it saving huge text sizes in the first place)