### PR TITLE
feat: create an admin return all agents route

### DIFF
--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -614,6 +614,13 @@ class MetadataStore:
             return [r.to_record() for r in results]
 
     @enforce_types
+    def list_all_agents(self) -> List[AgentState]:
+        with self.session_maker() as session:
+            results = session.query(AgentModel).all()
+
+            return [r.to_record() for r in results]
+
+    @enforce_types
     def list_sources(self, user_id: uuid.UUID) -> List[Source]:
         with self.session_maker() as session:
             results = session.query(SourceModel).filter(SourceModel.user_id == user_id).all()

--- a/memgpt/server/rest_api/admin/agents.py
+++ b/memgpt/server/rest_api/admin/agents.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Body, HTTPException, Query
+from memgpt.server.rest_api.interface import QueuingInterface
+
+from memgpt.server.rest_api.agents.index import ListAgentsResponse
+from memgpt.server.server import SyncServer
+
+router = APIRouter()
+
+
+def setup_agents_admin_router(server: SyncServer, interface: QueuingInterface):
+    @router.get("/agents", tags=["agents"], response_model=ListAgentsResponse)
+    def get_all_agents():
+        """
+        Get a list of all agents in the database
+        """
+        interface.clear()
+        agents_data = server.list_agents_legacy()
+
+        return ListAgentsResponse(**agents_data)
+
+
+    return router

--- a/memgpt/server/rest_api/auth/index.py
+++ b/memgpt/server/rest_api/auth/index.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
+from typing import Optional
 
 from memgpt.log import get_logger
 from memgpt.server.rest_api.interface import QueuingInterface
@@ -13,6 +14,7 @@ router = APIRouter()
 
 class AuthResponse(BaseModel):
     uuid: UUID = Field(..., description="UUID of the user")
+    is_admin: Optional[bool] = Field(None, description="Whether the user is an admin")
 
 
 class AuthRequest(BaseModel):
@@ -29,10 +31,13 @@ def setup_auth_router(server: SyncServer, interface: QueuingInterface, password:
         Currently, this is a placeholder that simply returns a UUID placeholder
         """
         interface.clear()
+
+        is_admin = False
         if request.password != password:
             response = server.api_key_to_user(api_key=request.password)
         else:
+            is_admin = True
             response = server.authenticate_user()
-        return AuthResponse(uuid=response)
+        return AuthResponse(uuid=response, is_admin=is_admin)
 
     return router

--- a/memgpt/server/rest_api/server.py
+++ b/memgpt/server/rest_api/server.py
@@ -19,6 +19,7 @@ from memgpt.server.rest_api.agents.config import setup_agents_config_router
 from memgpt.server.rest_api.agents.index import setup_agents_index_router
 from memgpt.server.rest_api.agents.memory import setup_agents_memory_router
 from memgpt.server.rest_api.agents.message import setup_agents_message_router
+from memgpt.server.rest_api.admin.agents import setup_agents_admin_router
 from memgpt.server.rest_api.auth.index import setup_auth_router
 from memgpt.server.rest_api.config.index import setup_config_index_router
 from memgpt.server.rest_api.humans.index import setup_humans_index_router
@@ -69,6 +70,7 @@ def verify_password(credentials: HTTPAuthorizationCredentials = Depends(security
 
 
 ADMIN_PREFIX = "/admin"
+ADMIN_API_PREFIX = "/api/admin"
 API_PREFIX = "/api"
 OPENAI_API_PREFIX = "/v1"
 
@@ -88,6 +90,9 @@ app.include_router(setup_auth_router(server, interface, password), prefix=API_PR
 # /admin/users endpoints
 app.include_router(setup_admin_router(server, interface), prefix=ADMIN_PREFIX, dependencies=[Depends(verify_password)])
 app.include_router(setup_tools_index_router(server, interface), prefix=ADMIN_PREFIX, dependencies=[Depends(verify_password)])
+
+# /api/admin/agents endpoints
+app.include_router(setup_agents_admin_router(server, interface), prefix=ADMIN_API_PREFIX, dependencies=[Depends(verify_password)])
 
 # /api/agents endpoints
 app.include_router(setup_agents_command_router(server, interface, password), prefix=API_PREFIX)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from functools import wraps
 from threading import Lock
 from typing import Callable, List, Optional, Tuple, Union
-
 from fastapi import HTTPException
 
 import memgpt.constants as constants
@@ -883,13 +882,19 @@ class SyncServer(LockingServer):
     # TODO make return type pydantic
     def list_agents_legacy(
         self,
-        user_id: uuid.UUID,
+        user_id: Optional[uuid.UUID] = None,
     ) -> dict:
         """List all available agents to a user"""
-        if self.ms.get_user(user_id=user_id) is None:
-            raise ValueError(f"User user_id={user_id} does not exist")
 
-        agents_states = self.ms.list_agents(user_id=user_id)
+
+        if user_id is None:
+            agents_states = self.ms.list_all_agents()
+        else:
+            if self.ms.get_user(user_id=user_id) is None:
+                raise ValueError(f"User user_id={user_id} does not exist")
+
+            agents_states = self.ms.list_agents(user_id=user_id)
+
         agents_states_dicts = [self._agent_state_to_config(state) for state in agents_states]
 
         # TODO add a get_message_obj_from_message_id(...) function
@@ -900,7 +905,7 @@ class SyncServer(LockingServer):
         for agent_state, return_dict in zip(agents_states, agents_states_dicts):
 
             # Get the agent object (loaded in memory)
-            memgpt_agent = self._get_or_load_agent(user_id=user_id, agent_id=agent_state.id)
+            memgpt_agent = self._get_or_load_agent(user_id=agent_state.user_id, agent_id=agent_state.id)
 
             # TODO remove this eventually when return type get pydanticfied
             # this is to add persona_name and human_name so that the columns in UI can populate
@@ -918,7 +923,7 @@ class SyncServer(LockingServer):
             # get tool info from agent state
             tools = []
             for tool_name in agent_state.tools:
-                tool = self.ms.get_tool(tool_name, user_id)
+                tool = self.ms.get_tool(tool_name, agent_state.user_id)
                 tools.append(tool)
             return_dict["tools"] = tools
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Attempts to address [this issue](https://github.com/cpacker/MemGPT/issues/1522) by adding a new endpoint that will return all agents, regardless of user behind an `/api/admin` endpoint.
 
**How to test**
You can pull down the code and run this command to test:

```
curl http://localhost:4200/api/admin/agents  -H "Authorization: Bearer $ADMIN_PASSWORD"
```

**Have you tested this PR?**
Yes

**Related issues or PRs**
[Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).
](https://github.com/cpacker/MemGPT/issues/1522)

**Is your PR over 500 lines of code?**
No

**Additional context**
Add any other context or screenshots about the PR here.
