### PR TITLE
feat: persist agent blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1012,6 +1012,7 @@ FodyWeavers.xsd
 ## cached db data
 pgdata/
 !pgdata/.gitkeep
+.persist/
 
 ## pytest mirrors
 memgpt/.pytest_cache/

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -1143,8 +1143,6 @@ class Agent(object):
         )
 
 
-# FIXME: I believe this is called on every agent interaction, but if not we'll need to call save_agent_memory in
-# a few other places.
 def save_agent(agent: Agent, ms: MetadataStore):
     """Save agent to metadata store"""
 
@@ -1166,7 +1164,6 @@ def save_agent(agent: Agent, ms: MetadataStore):
     assert isinstance(agent.agent_state.memory, Memory), f"Memory is not a Memory object: {type(agent_state.memory)}"
 
 
-# FIXME: decide whether we want this to live in update_state or not (would require plumbing metadata_store)
 def save_agent_memory(agent: Agent, ms: MetadataStore):
     """
     Save agent memory to metadata store. Memory is a collection of blocks and each block is persisted to the block table.
@@ -1175,6 +1172,9 @@ def save_agent_memory(agent: Agent, ms: MetadataStore):
     """
 
     for block_dict in agent.memory.to_dict().values():
+        # TODO: block creation should happen in one place to enforce these sort of constraints consistently.
+        if block_dict.get("user_id", None) is None:
+            block_dict["user_id"] = agent.agent_state.user_id
         block = Block(**block_dict)
         # FIXME: should we expect for block values to be None? If not, we need to figure out why that is
         # the case in some tests, if so we should relax the DB constraint.

--- a/memgpt/cli/cli_config.py
+++ b/memgpt/cli/cli_config.py
@@ -1,9 +1,9 @@
-import builtins
 import ast
+import builtins
 import os
 import uuid
 from enum import Enum
-from typing import Annotated, Optional, List
+from typing import Annotated, List, Optional
 
 import questionary
 import typer

--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -67,6 +67,7 @@ class AbstractClient(object):
         human: Optional[str] = None,
         embedding_config: Optional[EmbeddingConfig] = None,
         llm_config: Optional[LLMConfig] = None,
+        memory: Optional[Memory] = None,
     ) -> AgentState:
         """Create a new agent with the specified configuration."""
         raise NotImplementedError

--- a/memgpt/functions/schema_generator.py
+++ b/memgpt/functions/schema_generator.py
@@ -1,7 +1,6 @@
 import inspect
 import typing
-from typing import Optional, get_args, get_origin, Type, Dict, Any
-
+from typing import Any, Dict, Optional, Type, get_args, get_origin
 
 from docstring_parser import parse
 from pydantic import BaseModel
@@ -11,7 +10,6 @@ from memgpt.constants import (
     FUNCTION_PARAM_NAME_REQ_HEARTBEAT,
     FUNCTION_PARAM_TYPE_REQ_HEARTBEAT,
 )
-
 
 NO_HEARTBEAT_FUNCTIONS = ["send_message", "pause_heartbeats"]
 

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -422,8 +422,10 @@ def run_agent_loop(
                 skip_verify=no_verify,
                 stream=stream,
                 inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
+                ms=ms,
             )
 
+            agent.save_agent(memgpt_agent, ms)
             skip_next_user_input = False
             if token_warning:
                 user_message = system.get_token_limit_warning()

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -16,7 +16,7 @@ from memgpt.agent_store.storage import StorageConnector, TableType
 # import benchmark
 from memgpt.benchmark.benchmark import bench
 from memgpt.cli.cli import delete_agent, open_folder, quickstart, run, server, version
-from memgpt.cli.cli_config import add, add_tool, list_tools, configure, delete, list
+from memgpt.cli.cli_config import add, add_tool, configure, delete, list, list_tools
 from memgpt.cli.cli_load import app as load_app
 from memgpt.config import MemGPTConfig
 from memgpt.constants import (

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -715,6 +715,15 @@ class MetadataStore:
             return results[0].to_record()
 
     @enforce_types
+    def get_block(self, block_id: str) -> Optional[Block]:
+        with self.session_maker() as session:
+            results = session.query(BlockModel).filter(BlockModel.id == block_id).all()
+            if len(results) == 0:
+                return None
+            assert len(results) == 1, f"Expected 1 result, got {len(results)}"
+            return results[0].to_record()
+
+    @enforce_types
     def get_blocks(
         self,
         user_id: Optional[str],

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -500,7 +500,16 @@ class MetadataStore:
     def create_block(self, block: Block):
         with self.session_maker() as session:
             # TODO: fix?
-            if session.query(BlockModel).filter(BlockModel.name == block.name).filter(BlockModel.user_id == block.user_id).count() > 0:
+            # we are only validating that more than one template block
+            # with a given name doesn't exist.
+            if (
+                session.query(BlockModel)
+                .filter(BlockModel.name == block.name)
+                .filter(BlockModel.user_id == block.user_id)
+                .filter(BlockModel.template == True)
+                .count()
+                > 0
+            ):
                 raise ValueError(f"Block with name {block.name} already exists")
             session.add(BlockModel(**vars(block)))
             session.commit()

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -553,6 +553,16 @@ class MetadataStore:
             session.commit()
 
     @enforce_types
+    def update_or_create_block(self, block: Block):
+        with self.session_maker() as session:
+            existing_block = session.query(BlockModel).filter(BlockModel.id == block.id).first()
+            if existing_block:
+                session.query(BlockModel).filter(BlockModel.id == block.id).update(vars(block))
+            else:
+                session.add(BlockModel(**vars(block)))
+            session.commit()
+
+    @enforce_types
     def update_tool(self, tool: Tool):
         with self.session_maker() as session:
             session.query(ToolModel).filter(ToolModel.id == tool.id).update(vars(tool))

--- a/memgpt/schemas/memory.py
+++ b/memgpt/schemas/memory.py
@@ -70,8 +70,8 @@ class ChatMemory(Memory):
 
     def __init__(self, persona: str, human: str, limit: int = 2000):
         super().__init__()
-        self.link_block(name="persona", block=Block(name="persona", value=persona, limit=limit))
-        self.link_block(name="human", block=Block(name="human", value=human, limit=limit))
+        self.link_block(name="persona", block=Block(name="persona", value=persona, limit=limit, label="persona"))
+        self.link_block(name="human", block=Block(name="human", value=human, limit=limit, label="human"))
 
     def core_memory_append(self, name: str, content: str) -> Optional[str]:
         """

--- a/memgpt/schemas/tool.py
+++ b/memgpt/schemas/tool.py
@@ -1,11 +1,14 @@
 from typing import Dict, List, Optional
 
-from pydantic import Field
 from crewai_tools import BaseTool as CrewAiBaseTool
+from pydantic import Field
 
+from memgpt.functions.schema_generator import (
+    generate_schema_from_args_schema,
+    generate_tool_wrapper,
+)
 from memgpt.schemas.memgpt_base import MemGPTBase
 from memgpt.schemas.openai.chat_completions import ToolCall
-from memgpt.functions.schema_generator import generate_schema_from_args_schema, generate_tool_wrapper
 
 
 class BaseTool(MemGPTBase):

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -885,6 +885,8 @@ class SyncServer(LockingServer):
         # TODO: delete related tables (recall/archival memory)
 
         # TODO: Make sure the user owns the agent
+        # TODO: consider clean up any blocks associated with this agent
+        # and no other agents (e.g. not templates, but not used as shared blocks either)
         agent = self.ms.get_agent(agent_id=agent_id, user_id=user_id)
         if agent is not None:
             self.ms.delete_agent(agent_id=agent_id)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -410,6 +410,7 @@ class SyncServer(LockingServer):
                 return_dicts=False,
                 stream=token_streaming,
                 timestamp=timestamp,
+                ms=self.ms,
             )
             step_count += 1
             total_usage += usage
@@ -784,6 +785,11 @@ class SyncServer(LockingServer):
                 # gpt-3.5-turbo tends to omit inner monologue, relax this requirement for now
                 first_message_verify_mono=True if (llm_config.model is not None and "gpt-4" in llm_config.model) else False,
             )
+            # rebuilding agent memory on agent create in case shared memory blocks
+            # were specified in the new agent's memory config. we're doing this for two reasons:
+            # 1. if only the ID of the shared memory block was specified, we can fetch its most recent value
+            # 2. if the shared block state changed since this agent initialization started, we can be sure to have the latest value
+            agent.rebuild_memory(force=True, ms=self.ms)
             # FIXME: this is a hacky way to get the system prompts injected into agent into the DB
             # self.ms.update_agent(agent.agent_state)
         except Exception as e:

--- a/tests/test_new_client.py
+++ b/tests/test_new_client.py
@@ -1,5 +1,4 @@
 import pytest
-
 from crewai_tools import ScrapeWebsiteTool
 
 from memgpt import create_client

--- a/tests/test_new_client.py
+++ b/tests/test_new_client.py
@@ -41,6 +41,7 @@ def test_agent(client):
     print("TOOLS", [t.name for t in tools])
     agent_state = client.get_agent(agent_state_test.id)
     assert agent_state.name == "test_agent2"
+    # TODO: we should test that the blocks were persisted correctly here
 
     assert isinstance(agent_state.memory, Memory)
     # update agent: name

--- a/tests/test_new_client.py
+++ b/tests/test_new_client.py
@@ -41,7 +41,10 @@ def test_agent(client):
     print("TOOLS", [t.name for t in tools])
     agent_state = client.get_agent(agent_state_test.id)
     assert agent_state.name == "test_agent2"
-    # TODO: we should test that the blocks were persisted correctly here
+    for block in agent_state.memory.to_dict().values():
+        db_block = client.server.ms.get_block(block.get("id"))
+        assert db_block is not None, "memory block not persisted on agent create"
+        assert db_block.value == block.get("value"), "persisted block data does not match in-memory data"
 
     assert isinstance(agent_state.memory, Memory)
     # update agent: name


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This is the first step in adding shared blocks functionality. To share blocks between agents we need to make sure block data is persisted in a normalized fashion outside of the agent memory.

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

Tested with `poetry run pytest -s tests/test_new_client.py` and validated manually that blocks are being added on every agent create. 

I have a few followups before this is ready to merge, like where the best place to add tests is.

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

yes! see above

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).
n/a

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.
n/a
**Additional context**
Add any other context or screenshots about the PR here.
n/a