### PR TITLE
fix: patches to the API for non-streaming OAI proxy backends

### DIFF
--- a/memgpt/llm_api/llm_api_tools.py
+++ b/memgpt/llm_api/llm_api_tools.py
@@ -272,7 +272,9 @@ def create(
         else:
             inner_thoughts_in_kwargs = True if inner_thoughts_in_kwargs == OptionState.YES else False
 
-        assert isinstance(inner_thoughts_in_kwargs, bool), type(inner_thoughts_in_kwargs)
+        if not isinstance(inner_thoughts_in_kwargs, bool):
+            warnings.warn(f"Bad type detected: {type(inner_thoughts_in_kwargs)}")
+            inner_thoughts_in_kwargs = bool(inner_thoughts_in_kwargs)
         if inner_thoughts_in_kwargs:
             functions = add_inner_thoughts_to_functions(
                 functions=functions,

--- a/memgpt/local_llm/utils.py
+++ b/memgpt/local_llm/utils.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import List
 
 import requests
@@ -191,9 +192,13 @@ def num_tokens_from_messages(messages: List[dict], model: str = "gpt-4") -> int:
         # print("Warning: gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
         return num_tokens_from_messages(messages, model="gpt-4-0613")
     else:
-        raise NotImplementedError(
+        warnings.warn(
             f"""num_tokens_from_messages() is not implemented for model {model}. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens."""
         )
+        return num_tokens_from_messages(messages, model="gpt-4-0613")
+        # raise NotImplementedError(
+        # f"""num_tokens_from_messages() is not implemented for model {model}. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens."""
+        # )
     num_tokens = 0
     for message in messages:
         num_tokens += tokens_per_message

--- a/memgpt/server/rest_api/agents/message.py
+++ b/memgpt/server/rest_api/agents/message.py
@@ -95,8 +95,6 @@ async def send_message_to_agent(
 ) -> Union[StreamingResponse, UserMessageResponse]:
     """Split off into a separate function so that it can be imported in the /chat/completion proxy."""
 
-    print(f"stream_legacy:{stream_legacy}, stream_steps:{stream_steps}, stream_tokens:{stream_tokens}")
-
     # TODO this is a total hack but is required until we move streaming into the model config
     if server.server_llm_config.model_endpoint != "https://api.openai.com/v1":
         stream_tokens = False

--- a/memgpt/server/rest_api/agents/message.py
+++ b/memgpt/server/rest_api/agents/message.py
@@ -95,7 +95,12 @@ async def send_message_to_agent(
 ) -> Union[StreamingResponse, UserMessageResponse]:
     """Split off into a separate function so that it can be imported in the /chat/completion proxy."""
 
-    include_final_message = True
+    print(f"stream_legacy:{stream_legacy}, stream_steps:{stream_steps}, stream_tokens:{stream_tokens}")
+
+    # TODO this is a total hack but is required until we move streaming into the model config
+    if server.server_llm_config.model_endpoint != "https://api.openai.com/v1":
+        stream_tokens = False
+
     # handle the legacy mode streaming
     if stream_legacy:
         # NOTE: override

--- a/memgpt/server/rest_api/interface.py
+++ b/memgpt/server/rest_api/interface.py
@@ -500,7 +500,7 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
 
                     processed_chunk = {
                         "function_call": {
-                            # "id": function_call.id,
+                            "id": function_call.id,
                             "name": function_call.function["name"],
                             "arguments": function_call.function["arguments"],
                         },


### PR DESCRIPTION
Currently, the dev portal is written to always ask for a stream reply, and if the backend doesn't support streaming, we send back a very similar looking data streaming, but instead of having N chunks for N tokens, we just send back 1 chunk per message ("fake streaming").

This is as intended, however the backend is currently incorrectly coded - it sees the request for `stream_tokens`, and sets up a streaming tokens compatible interface to get ready to send the response. However, in the case of the free MemGPT inference server, this is set up as an OAI proxy (`llm_config.endpoint_type == 'openai'`), so the related LLM API code thinks that we can actually support streaming, and turns on the streaming listeners. However, the proxy backend does not actually support streaming.

We need to figure out how to properly handle this situation (perhaps by moving `streaming` into the `llm_config`). In the meantime, I'm adding this sad monkeypatch that turns off token streaming on API calls unless the API provider is OAI (the only one that we really support atm anyways).