### PR TITLE
refactor: move prompt string generation in `Memory` to a non-overloaded function

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -107,7 +107,7 @@ def compile_system_message(
             archival_memory=archival_memory,
             recall_memory=recall_memory,
         )
-        full_memory_string = memory_metadata_string + "\n" + in_context_memory.string()
+        full_memory_string = memory_metadata_string + "\n" + in_context_memory.compile()
 
         # Add to the variables list to inject
         variables[IN_CONTEXT_MEMORY_KEYWORD] = full_memory_string
@@ -216,7 +216,7 @@ class Agent(object):
         # Initialize the memory object
         self.memory = self.agent_state.memory
         assert isinstance(self.memory, Memory), f"Memory object is not of type Memory: {type(self.memory)}"
-        printd("Initialized memory object", self.memory.string())
+        printd("Initialized memory object", self.memory.compile())
 
         # Interface must implement:
         # - internal_monologue
@@ -992,7 +992,7 @@ class Agent(object):
         curr_system_message = self.messages[0]  # this is the system + memory bank, not just the system prompt
 
         # NOTE: This is a hacky way to check if the memory has changed
-        memory_repr = self.memory.string()
+        memory_repr = self.memory.compile()
         if not force and memory_repr == curr_system_message["content"][-(len(memory_repr)) :]:
             printd(f"Memory has not changed, not rebuilding system")
             return

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -992,7 +992,7 @@ class Agent(object):
         curr_system_message = self.messages[0]  # this is the system + memory bank, not just the system prompt
 
         # NOTE: This is a hacky way to check if the memory has changed
-        memory_repr = str(self.memory)
+        memory_repr = self.memory.string()
         if not force and memory_repr == curr_system_message["content"][-(len(memory_repr)) :]:
             printd(f"Memory has not changed, not rebuilding system")
             return

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -216,7 +216,7 @@ class Agent(object):
         # Initialize the memory object
         self.memory = self.agent_state.memory
         assert isinstance(self.memory, Memory), f"Memory object is not of type Memory: {type(self.memory)}"
-        printd("Initialized memory object", self.memory)
+        printd("Initialized memory object", self.memory.string())
 
         # Interface must implement:
         # - internal_monologue

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -1,6 +1,5 @@
 import datetime
 import inspect
-import json
 import traceback
 from typing import List, Literal, Optional, Tuple, Union
 
@@ -108,7 +107,7 @@ def compile_system_message(
             archival_memory=archival_memory,
             recall_memory=recall_memory,
         )
-        full_memory_string = memory_metadata_string + "\n" + str(in_context_memory)
+        full_memory_string = memory_metadata_string + "\n" + in_context_memory.string()
 
         # Add to the variables list to inject
         variables[IN_CONTEXT_MEMORY_KEYWORD] = full_memory_string

--- a/memgpt/schemas/memory.py
+++ b/memgpt/schemas/memory.py
@@ -19,9 +19,6 @@ class Memory(BaseModel, validate_assignment=True):
             obj.memory[key] = Block(**value)
         return obj
 
-    def __str__(self) -> str:
-        raise NotImplementedError("Use the .compile() method instead")
-
     def compile(self) -> str:
         """Generate a string representation of the memory in-context"""
         section_strs = []

--- a/memgpt/schemas/memory.py
+++ b/memgpt/schemas/memory.py
@@ -20,6 +20,9 @@ class Memory(BaseModel, validate_assignment=True):
         return obj
 
     def __str__(self) -> str:
+        raise NotImplementedError("Use the .string() method instead")
+
+    def string(self) -> str:
         """Representation of the memory in-context"""
         section_strs = []
         for section, module in self.memory.items():

--- a/memgpt/schemas/memory.py
+++ b/memgpt/schemas/memory.py
@@ -20,10 +20,10 @@ class Memory(BaseModel, validate_assignment=True):
         return obj
 
     def __str__(self) -> str:
-        raise NotImplementedError("Use the .string() method instead")
+        raise NotImplementedError("Use the .compile() method instead")
 
-    def string(self) -> str:
-        """Representation of the memory in-context"""
+    def compile(self) -> str:
+        """Generate a string representation of the memory in-context"""
         section_strs = []
         for section, module in self.memory.items():
             section_strs.append(f'<{section} characters="{len(module)}/{module.limit}">\n{module.value}\n</{section}>')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,7 +104,7 @@ def test_memory(client, agent):
     # _reset_config()
 
     memory_response = client.get_in_context_memory(agent_id=agent.id)
-    print("MEMORY", memory_response)
+    print("MEMORY", memory_response.string())
 
     updated_memory = {"human": "Updated human memory", "persona": "Updated persona memory"}
     client.update_in_context_memory(agent_id=agent.id, section="human", value=updated_memory["human"])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,7 +104,7 @@ def test_memory(client, agent):
     # _reset_config()
 
     memory_response = client.get_in_context_memory(agent_id=agent.id)
-    print("MEMORY", memory_response.string())
+    print("MEMORY", memory_response.compile())
 
     updated_memory = {"human": "Updated human memory", "persona": "Updated persona memory"}
     client.update_in_context_memory(agent_id=agent.id, section="human", value=updated_memory["human"])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -173,7 +173,7 @@ def test_create_agent_tool(client):
 
     # initial memory
     initial_memory = client.get_in_context_memory(agent.id)
-    print("initial memory", initial_memory)
+    print("initial memory", initial_memory.string())
     human = initial_memory.get_block("human")
     persona = initial_memory.get_block("persona")
     print("Initial memory:", human, persona)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -173,7 +173,7 @@ def test_create_agent_tool(client):
 
     # initial memory
     initial_memory = client.get_in_context_memory(agent.id)
-    print("initial memory", initial_memory.string())
+    print("initial memory", initial_memory.compile())
     human = initial_memory.get_block("human")
     persona = initial_memory.get_block("persona")
     print("Initial memory:", human, persona)


### PR DESCRIPTION
tl;dr `Memory.__str__()` is now `Memory.compile()`

Move the prompt string generation to a dedicated non-overloaded function, since it's confusing to have potential complex logic handled behind an overloaded `__str__`. [PLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

Follow-up PR will modify prompt string generation logic to be via a templating engine (eg jinja2) if possible to enable easier visualization and modification of the prompt generation in the frontend (vs passing python code back and forth).