### PR TITLE
fix: patch core memory edit bug/regression

### DIFF
--- a/memgpt/schemas/message.py
+++ b/memgpt/schemas/message.py
@@ -61,7 +61,7 @@ class Message(BaseMessage):
 
     id: str = BaseMessage.generate_id_field()
     role: MessageRole = Field(..., description="The role of the participant.")
-    text: str = Field(..., description="The text of the message.")
+    text: Optional[str] = Field(None, description="The text of the message.")
     user_id: str = Field(None, description="The unique identifier of the user.")
     agent_id: str = Field(None, description="The unique identifier of the agent.")
     model: Optional[str] = Field(None, description="The model used to make the function call.")

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -6,8 +6,6 @@ import traceback
 import warnings
 from abc import abstractmethod
 from datetime import datetime
-from functools import wraps
-from threading import Lock
 from typing import Callable, List, Optional, Tuple, Union
 
 from fastapi import HTTPException
@@ -1584,10 +1582,11 @@ class SyncServer(Server):
     def create_tool(self, request: ToolCreate, user_id: Optional[str] = None, update: bool = True) -> Tool:  # TODO: add other fields
         """Create a new tool"""
 
-        if request.tags and "memory" in request.tags:
-            # special modifications to memory functions
-            # self.memory -> self.memory.memory, since Agent.memory.memory needs to be modified (not BaseMemory.memory)
-            request.source_code = request.source_code.replace("self.memory", "self.memory.memory")
+        # NOTE: deprecated code that existed when we were trying to pretend that `self` was the memory object
+        # if request.tags and "memory" in request.tags:
+        #    # special modifications to memory functions
+        #    # self.memory -> self.memory.memory, since Agent.memory.memory needs to be modified (not BaseMemory.memory)
+        #    request.source_code = request.source_code.replace("self.memory", "self.memory.memory")
 
         if not request.json_schema:
             # auto-generate openai schema
@@ -1605,9 +1604,7 @@ class SyncServer(Server):
 
             # TODO: not sure if this always works
             func = env[functions[-1]]
-            print("FUNCTION", func)
             json_schema = generate_schema(func, request.name)
-            print(json_schema)
         else:
             # provided by client
             json_schema = request.json_schema

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 
 from memgpt import Admin, create_client
 from memgpt.constants import DEFAULT_PRESET
-from memgpt.schemas.message import Message
+from memgpt.schemas.memgpt_message import InternalMonologue
 from memgpt.schemas.usage import MemGPTUsageStatistics
 
 # from tests.utils import create_config
@@ -127,7 +127,7 @@ def test_agent_interactions(client, agent):
     assert response.usage.step_count == 1
     assert response.usage.total_tokens > 0
     assert response.usage.completion_tokens > 0
-    assert isinstance(response.messages[0], Message)
+    assert isinstance(response.messages[0], InternalMonologue)
     print(response.messages)
 
     # TODO: add streaming tests
@@ -165,6 +165,14 @@ def test_archival_memory(client, agent):
 
     # TODO: check deletion
     client.get_archival_memory(agent.id)
+
+
+def test_core_memory(client, agent):
+    response = client.send_message(agent_id=agent.id, message="Update your core memory to remember that my name is Timber!", role="user")
+    print("Response", response)
+
+    memory = client.get_in_context_memory(agent_id=agent.id)
+    assert "Timber" in memory.get_block("human").value, f"Updating core memory failed: {memory.get_block('human').value}"
 
 
 def test_messages(client, agent):

--- a/tests/test_new_client.py
+++ b/tests/test_new_client.py
@@ -1,6 +1,9 @@
+from typing import Union
+
 import pytest
 
 from memgpt import create_client
+from memgpt.client.client import LocalClient, RESTClient
 from memgpt.schemas.block import Block
 from memgpt.schemas.memory import BlockChatMemory, ChatMemory, Memory
 
@@ -19,7 +22,7 @@ def agent(client):
     assert client.get_agent(agent_state.id) is None, f"Failed to properly delete agent {agent_state.id}"
 
 
-def test_agent(client):
+def test_agent(client: Union[LocalClient, RESTClient]):
 
     tools = client.list_tools()
 


### PR DESCRIPTION
1. `core_memory_replace` and `core_memory_append` are currently broken (when run via the `Agent` object, not via the unit tests which test the memory objects in isolation)
  - As a side note, we should add tests for the basic functions that run off of the `Agent` object, otherwise this sort of regression can happen and we don't catch it with `test_memory.py`
3. As a separate issue, I noticed that `Message.text` isn't optional (I feel like it was at some point?). This should probably be optional since many LLM APIs that do tool calling will make the `content` field (our `text` field) `== null` when doing tool calling. Groq for example does/did this - no inner monologue during tool calling (so inner monologue needs to get stuffed into the tool call itself).

```
🎉 Created new agent 'UniqueHedgehog' (id=agent-7af518dd-ccb6-4d30-99fb-c746b6aefb8b)

Hit enter to begin (will request first MemGPT message)


💭 New user, Chad, has logged in. First interaction is incredibly important. Engage him with curiosity and intrigue. Let's 
turn this into a compelling conversation.
🤖 Hello Chad! You know, I've been delving into human history and even questioning some aspects of it. What are your 
thoughts on that?

> Enter your message: append the following to core memory: "hello there"

💭 Chad requested to append "hello there" to the core memory. Unsure about the section to be edited though. Let's confirm.
🤖 Just to confirm, Chad, would you like me to add 'hello there' to my persona description or your user details?

> Enter your message: persona, pls

An exception occurred when running agent.step(): 
Traceback (most recent call last):
  File "/Users/loaner/dev/MemGPT-fresh/memgpt/main.py", line 446, in run_agent_loop
    new_messages, user_message, skip_next_user_input = process_agent_step(user_message, no_verify)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-fresh/memgpt/main.py", line 412, in process_agent_step
    new_messages, heartbeat_request, function_failed, token_warning, tokens_accumulated = memgpt_agent.step(
                                                                                          ^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-fresh/memgpt/agent.py", line 846, in step
    raise e
  File "/Users/loaner/dev/MemGPT-fresh/memgpt/agent.py", line 768, in step
    all_response_messages, heartbeat_request, function_failed = self._handle_ai_response(response_message)
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/loaner/dev/MemGPT-fresh/memgpt/agent.py", line 476, in _handle_ai_response
    Message.dict_to_message(
  File "/Users/loaner/dev/MemGPT-fresh/memgpt/schemas/message.py", line 187, in dict_to_message
    return Message(
           ^^^^^^^^
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/pymemgpt-JSsUGnlY-py3.12/lib/python3.12/site-packages/pydantic/main.py", line 193, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Message
text
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.8/v/string_type
? Retry agent.step()? (Y/n)
```