### PR TITLE
feat: create an abstract agent type + cleanup typing errors in `memory.py`

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -1,6 +1,7 @@
 import datetime
 import inspect
 import traceback
+from abc import ABC, abstractmethod
 from typing import List, Literal, Optional, Tuple, Union
 
 from tqdm import tqdm
@@ -68,8 +69,8 @@ def compile_memory_metadata_block(
     memory_metadata_block = "\n".join(
         [
             f"### Memory [last modified: {timestamp_str}]",
-            f"{len(recall_memory) if recall_memory else 0} previous messages between you and the user are stored in recall memory (use functions to access them)",
-            f"{len(archival_memory) if archival_memory else 0} total memories you created are stored in archival memory (use functions to access them)",
+            f"{recall_memory.count() if recall_memory else 0} previous messages between you and the user are stored in recall memory (use functions to access them)",
+            f"{archival_memory.count() if archival_memory else 0} total memories you created are stored in archival memory (use functions to access them)",
             "\nCore memory shown below (limited in size, additional information stored in archival / recall memory):",
         ]
     )
@@ -186,6 +187,18 @@ def initialize_message_sequence(
         ]
 
     return messages
+
+
+class BaseAgent(ABC):
+    """Base class for all agents. Only two interfaces are required: step and update_state."""
+
+    @abstractmethod
+    def step(self, message: Message) -> List[Message]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_state(self) -> AgentState:
+        raise NotImplementedError
 
 
 class Agent(object):

--- a/memgpt/autogen/memgpt_agent.py
+++ b/memgpt/autogen/memgpt_agent.py
@@ -13,7 +13,7 @@ from autogen.agentchat import (
 import memgpt.constants as constants
 import memgpt.system as system
 import memgpt.utils as utils
-from memgpt.agent import Agent as MemGPTAgent
+from memgpt.agent import Agent as Agent
 from memgpt.agent import save_agent
 from memgpt.agent_store.storage import StorageConnector, TableType
 from memgpt.autogen.interface import AutoGenInterface
@@ -29,7 +29,7 @@ class MemGPTConversableAgent(ConversableAgent):
     def __init__(
         self,
         name: str,
-        agent: MemGPTAgent,
+        agent: Agent,
         skip_verify: bool = False,
         auto_save: bool = False,
         concat_other_agent_messages: bool = False,
@@ -271,7 +271,7 @@ def load_autogen_memgpt_agent(
 
     # Create the agent object directly from the loaded state (not via preset creation)
     try:
-        memgpt_agent = MemGPTAgent(agent_state=agent_state, interface=interface)
+        memgpt_agent = Agent(agent_state=agent_state, interface=interface)
     except Exception:
         print(f"Failed to create an agent object from agent state =\n{agent_state}")
         raise
@@ -359,7 +359,7 @@ def create_autogen_memgpt_agent(
         preset_obj.human = agent_config["human"] if "human" in agent_config else get_human_text(config.human)
         preset_obj.persona = agent_config["persona"] if "persona" in agent_config else get_persona_text(config.persona)
 
-        memgpt_agent = MemGPTAgent(
+        memgpt_agent = Agent(
             interface=interface,
             name=agent_config["name"] if "name" in agent_config else None,
             created_by=user.id,


### PR DESCRIPTION
This is in anticipation of adding future agent types, e.g. see: https://github.com/cpacker/MemGPT/pull/1700

I was going to rename symbol `Agent` to `MemGPTAgent`, but decided we may want to punt that until the integration branch is merged to avoid a huge file diff on this PR.
