### PR TITLE
refactor: remove the concept of 'section' from the jinja2 prompt formatter

### DIFF
--- a/memgpt/schemas/memory.py
+++ b/memgpt/schemas/memory.py
@@ -25,10 +25,10 @@ class Memory(BaseModel, validate_assignment=True):
 
     # Memory.template is a Jinja2 template for compiling memory module into a prompt string.
     prompt_template: str = Field(
-        default="{% for section, block in memory.items() %}"
-        '<{{ section }} characters="{{ block.value|length }}/{{ block.limit }}">\n'
+        default="{% for block in memory.values() %}"
+        '<{{ block.name }} characters="{{ block.value|length }}/{{ block.limit }}">\n'
         "{{ block.value }}\n"
-        "</{{ section }}>"
+        "</{{ block.name }}>"
         "{% if not loop.last %}\n{% endif %}"
         "{% endfor %}",
         description="Jinja2 template for compiling memory blocks into a prompt string",


### PR DESCRIPTION
This is probably a cleaner way to view the prompt template.

Alternatively we can even remove the `memory` dict and instead make it a `List[Block]` (since we now have `get_block`)