### PR TITLE
fix: fix dump and dumpraw

### DIFF
--- a/memgpt/schemas/message.py
+++ b/memgpt/schemas/message.py
@@ -357,7 +357,7 @@ class Message(BaseMessage):
     def to_openai_dict(
         self,
         max_tool_id_length: int = TOOL_CALL_ID_MAX_LEN,
-        put_inner_thoughts_in_kwargs: bool = True,
+        put_inner_thoughts_in_kwargs: bool = False,
     ) -> dict:
         """Go from Message class to ChatCompletion message object"""
 


### PR DESCRIPTION
`/dump` and `/dumpraw` weren't showing inner thoughts because we accidentally left the `put_inner_thouguhts_in_kwargs` on by default in the `to_openai_dict` converter.