### PR TITLE
fix: static files mounting bug

### DIFF
--- a/memgpt/server/rest_api/app.py
+++ b/memgpt/server/rest_api/app.py
@@ -72,8 +72,6 @@ def create_application() -> "FastAPI":
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    # Usage in your create_application function:
-    app.add_middleware(SmartStaticFilesMiddleware)
 
     for route in v1_routes:
         app.include_router(route, prefix=API_PREFIX)

--- a/memgpt/server/rest_api/app.py
+++ b/memgpt/server/rest_api/app.py
@@ -77,7 +77,7 @@ def create_application() -> "FastAPI":
         app.include_router(route, prefix=API_PREFIX)
         # this gives undocumented routes for "latest" and bare api calls.
         # we should always tie this to the newest version of the api.
-        app.include_router(route, prefix="", include_in_schema=False)
+        # app.include_router(route, prefix="", include_in_schema=False)
         app.include_router(route, prefix="/latest", include_in_schema=False)
 
     # NOTE: ethan these are the extra routes

--- a/memgpt/server/rest_api/static_files.py
+++ b/memgpt/server/rest_api/static_files.py
@@ -29,17 +29,3 @@ def mount_static_files(app: FastAPI):
             ),
             name="spa-static-files",
         )
-
-
-# def mount_static_files(app: FastAPI):
-#     static_files_path = os.path.join(os.path.dirname(importlib.util.find_spec("memgpt").origin), "server", "static_files")
-#     if os.path.exists(static_files_path):
-
-#         @app.get("/{full_path:path}")
-#         async def serve_spa(full_path: str):
-#             if full_path.startswith("v1"):
-#                 raise HTTPException(status_code=404, detail="Not found")
-#             file_path = os.path.join(static_files_path, full_path)
-#             if os.path.isfile(file_path):
-#                 return FileResponse(file_path)
-#             return FileResponse(os.path.join(static_files_path, "index.html"))

--- a/memgpt/server/rest_api/static_files.py
+++ b/memgpt/server/rest_api/static_files.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.staticfiles import StaticFiles
 
@@ -20,12 +21,54 @@ class SPAStaticFiles(StaticFiles):
 def mount_static_files(app: FastAPI):
     static_files_path = os.path.join(os.path.dirname(importlib.util.find_spec("memgpt").origin), "server", "static_files")
     if os.path.exists(static_files_path):
-        app.mount(
-            "/",
-            # "/app",
-            SPAStaticFiles(
-                directory=static_files_path,
-                html=True,
-            ),
-            name="spa-static-files",
-        )
+        app.mount("/assets", StaticFiles(directory=os.path.join(static_files_path, "assets")), name="assets")
+
+        @app.get("/memgpt_logo_transparent.png", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "memgpt_logo_transparent.png"))
+
+        @app.get("/", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/agents", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/data-sources", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/tools", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/agent-templates", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/human-templates", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/settings/profile", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+        @app.get("/agents/{agent-id}/chat", include_in_schema=False)
+        async def serve_spa():
+            return FileResponse(os.path.join(static_files_path, "index.html"))
+
+
+# def mount_static_files(app: FastAPI):
+#     static_files_path = os.path.join(os.path.dirname(importlib.util.find_spec("memgpt").origin), "server", "static_files")
+#     if os.path.exists(static_files_path):
+
+#         @app.get("/{full_path:path}")
+#         async def serve_spa(full_path: str):
+#             if full_path.startswith("v1"):
+#                 raise HTTPException(status_code=404, detail="Not found")
+#             file_path = os.path.join(static_files_path, full_path)
+#             if os.path.isfile(file_path):
+#                 return FileResponse(file_path)
+#             return FileResponse(os.path.join(static_files_path, "index.html"))


### PR DESCRIPTION
tldr of bug is:
- enable static file mounting, the website works fine (and API routes via the website work fine), but the RESTClient unit tests start failing with "Method Not Allowed", indicating that the request is getting hijacked by the static files mount
- disable static file mounting (can even try just commenting it out), and the RESTClient unit tests pass again

To check if the website is working: `memgpt server` then `localhost:8283` should spawn the SPA

To check if the RESTClient unit tests are working, run `pytest -s -vvv tests/test_client.py::test_agent`