### PR TITLE
fix: patch recall error

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -340,8 +340,18 @@ class Agent(BaseAgent):
         """Load a list of messages from recall storage"""
 
         # Pull the message objects from the database
-        message_objs = [self.persistence_manager.recall_memory.storage.get(msg_id) for msg_id in message_ids]
-        assert all([isinstance(msg, Message) for msg in message_objs]), [type(msg) for msg in message_objs]
+        message_objs = []
+        for msg_id in message_ids:
+            msg_obj = self.persistence_manager.recall_memory.storage.get(msg_id)
+            if msg_obj:
+                if isinstance(msg_obj, Message):
+                    message_objs.append(msg_obj)
+                else:
+                    printd(f"Warning - message ID {msg_id} is not a Message object")
+                    warnings.warn(f"Warning - message ID {msg_id} is not a Message object")
+            else:
+                printd(f"Warning - message ID {msg_id} not found in recall storage")
+                warnings.warn(f"Warning - message ID {msg_id} not found in recall storage")
 
         return message_objs
 

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -341,7 +341,7 @@ class Agent(BaseAgent):
 
         # Pull the message objects from the database
         message_objs = [self.persistence_manager.recall_memory.storage.get(msg_id) for msg_id in message_ids]
-        assert all([isinstance(msg, Message) for msg in message_objs])
+        assert all([isinstance(msg, Message) for msg in message_objs]), [type(msg) for msg in message_objs]
 
         return message_objs
 

--- a/memgpt/agent_store/chroma.py
+++ b/memgpt/agent_store/chroma.py
@@ -131,7 +131,7 @@ class ChromaStorageConnector(StorageConnector):
             results = self.collection.get(ids=ids, include=self.include, where=filters)
         return self.results_to_records(results)
 
-    def get(self, id):
+    def get(self, id: str):
         results = self.collection.get(ids=[str(id)])
         if len(results["ids"]) == 0:
             return None

--- a/memgpt/agent_store/milvus.py
+++ b/memgpt/agent_store/milvus.py
@@ -91,7 +91,7 @@ class MilvusStorageConnector(StorageConnector):
         )
         return self._list_to_records(query_res)
 
-    def get(self, id: uuid.UUID) -> Optional[RecordType]:
+    def get(self, id: str) -> Optional[RecordType]:
         res = self.client.get(collection_name=self.table_name, ids=str(id))
         return self._list_to_records(res)[0] if res else None
 

--- a/memgpt/agent_store/qdrant.py
+++ b/memgpt/agent_store/qdrant.py
@@ -73,7 +73,7 @@ class QdrantStorageConnector(StorageConnector):
         )
         return self.to_records(results)
 
-    def get(self, id: uuid.UUID) -> Optional[RecordType]:
+    def get(self, id: str) -> Optional[RecordType]:
         results = self.qdrant_client.retrieve(
             collection_name=self.table_name,
             ids=[str(id)],


### PR DESCRIPTION
There's a weird bug @4shub encountered where some messages are `None` / don't exist in recall:

```sh
  File "/Users/shub/Developer/MemGPT/memgpt/server/rest_api/routers/v1/agents.py", line 88, in get_agent_state
    return server.get_agent_state(user_id=actor.id, agent_id=agent_id)
  File "/Users/shub/Developer/MemGPT/memgpt/server/server.py", line 1172, in get_agent_state
    memgpt_agent = self._get_or_load_agent(agent_id=agent_id)
  File "/Users/shub/Developer/MemGPT/memgpt/server/server.py", line 298, in _get_or_load_agent
    memgpt_agent = self._load_agent(user_id=user_id, agent_id=agent_id)
  File "/Users/shub/Developer/MemGPT/memgpt/server/server.py", line 275, in _load_agent
    memgpt_agent = Agent(agent_state=agent_state, interface=interface, tools=tool_objs)
  File "/Users/shub/Developer/MemGPT/memgpt/agent.py", line 265, in __init__
    self.set_message_buffer(message_ids=self.agent_state.message_ids)
  File "/Users/shub/Developer/MemGPT/memgpt/agent.py", line 361, in set_message_buffer
    message_objs = self._load_messages_from_recall(message_ids=message_ids)
  File "/Users/shub/Developer/MemGPT/memgpt/agent.py", line 344, in _load_messages_from_recall
    assert all([isinstance(msg, Message) for msg in message_objs]), [type(msg) for msg in message_objs]
AssertionError: [<class 'memgpt.schemas.message.Message'>, <class 'NoneType'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>, <class 'memgpt.schemas.message.Message'>]
```

This is a hotfix that turns these runtime errors into `warnings.warn` to avoid breaking things.