### PR TITLE
fix: patch validation error on `/messages` endpoint

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -340,8 +340,18 @@ class Agent(BaseAgent):
         """Load a list of messages from recall storage"""
 
         # Pull the message objects from the database
-        message_objs = [self.persistence_manager.recall_memory.storage.get(msg_id) for msg_id in message_ids]
-        assert all([isinstance(msg, Message) for msg in message_objs]), [type(msg) for msg in message_objs]
+        message_objs = []
+        for msg_id in message_ids:
+            msg_obj = self.persistence_manager.recall_memory.storage.get(msg_id)
+            if msg_obj:
+                if isinstance(msg_obj, Message):
+                    message_objs.append(msg_obj)
+                else:
+                    printd(f"Warning - message ID {msg_id} is not a Message object")
+                    warnings.warn(f"Warning - message ID {msg_id} is not a Message object")
+            else:
+                printd(f"Warning - message ID {msg_id} not found in recall storage")
+                warnings.warn(f"Warning - message ID {msg_id} not found in recall storage")
 
         return message_objs
 

--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -341,7 +341,7 @@ class Agent(BaseAgent):
 
         # Pull the message objects from the database
         message_objs = [self.persistence_manager.recall_memory.storage.get(msg_id) for msg_id in message_ids]
-        assert all([isinstance(msg, Message) for msg in message_objs])
+        assert all([isinstance(msg, Message) for msg in message_objs]), [type(msg) for msg in message_objs]
 
         return message_objs
 

--- a/memgpt/agent_store/chroma.py
+++ b/memgpt/agent_store/chroma.py
@@ -131,7 +131,7 @@ class ChromaStorageConnector(StorageConnector):
             results = self.collection.get(ids=ids, include=self.include, where=filters)
         return self.results_to_records(results)
 
-    def get(self, id):
+    def get(self, id: str):
         results = self.collection.get(ids=[str(id)])
         if len(results["ids"]) == 0:
             return None

--- a/memgpt/agent_store/milvus.py
+++ b/memgpt/agent_store/milvus.py
@@ -91,7 +91,7 @@ class MilvusStorageConnector(StorageConnector):
         )
         return self._list_to_records(query_res)
 
-    def get(self, id: uuid.UUID) -> Optional[RecordType]:
+    def get(self, id: str) -> Optional[RecordType]:
         res = self.client.get(collection_name=self.table_name, ids=str(id))
         return self._list_to_records(res)[0] if res else None
 

--- a/memgpt/agent_store/qdrant.py
+++ b/memgpt/agent_store/qdrant.py
@@ -73,7 +73,7 @@ class QdrantStorageConnector(StorageConnector):
         )
         return self.to_records(results)
 
-    def get(self, id: uuid.UUID) -> Optional[RecordType]:
+    def get(self, id: str) -> Optional[RecordType]:
         results = self.qdrant_client.retrieve(
             collection_name=self.table_name,
             ids=[str(id)],

--- a/memgpt/schemas/memgpt_message.py
+++ b/memgpt/schemas/memgpt_message.py
@@ -1,8 +1,8 @@
 import json
 from datetime import datetime, timezone
-from typing import Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 # MemGPT API style responses (intended to be easier to use vs getting true Message types)
 
@@ -16,6 +16,9 @@ class MemGPTMessage(BaseModel):
         date (datetime): The date the message was created in ISO format
 
     """
+
+    # NOTE: use Pydantic's discriminated unions feature: https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions
+    # message_type: str = Field(discriminator="message_type")
 
     id: str
     date: datetime
@@ -39,6 +42,7 @@ class SystemMessage(MemGPTMessage):
         date (datetime): The date the message was created in ISO format
     """
 
+    message_type: Literal["system_message"] = "system_message"
     message: str
 
 
@@ -52,6 +56,7 @@ class UserMessage(MemGPTMessage):
         date (datetime): The date the message was created in ISO format
     """
 
+    message_type: Literal["user_message"] = "user_message"
     message: str
 
 
@@ -65,15 +70,19 @@ class InternalMonologue(MemGPTMessage):
         date (datetime): The date the message was created in ISO format
     """
 
+    message_type: Literal["internal_monologue"] = "internal_monologue"
     internal_monologue: str
 
 
 class FunctionCall(BaseModel):
+
+    message_type: Literal["function_call"] = "function_call"
     name: str
     arguments: str
 
 
 class FunctionCallDelta(BaseModel):
+
     name: Optional[str]
     arguments: Optional[str]
 
@@ -97,6 +106,7 @@ class FunctionCallMessage(MemGPTMessage):
         date (datetime): The date the message was created in ISO format
     """
 
+    message_type: Literal["function_call"] = "function_call"
     function_call: Union[FunctionCall, FunctionCallDelta]
 
     # NOTE: this is required for the FunctionCallDelta exclude_none to work correctly
@@ -140,6 +150,7 @@ class FunctionReturn(MemGPTMessage):
         date (datetime): The date the message was created in ISO format
     """
 
+    message_type: Literal["function_return"] = "function_return"
     function_return: str
     status: Literal["success", "error"]
 
@@ -151,6 +162,7 @@ class FunctionReturn(MemGPTMessage):
 
 
 class AssistantMessage(MemGPTMessage):
+    message_type: Literal["assistant_message"] = "assistant_message"
     assistant_message: str
 
 
@@ -159,3 +171,9 @@ class LegacyFunctionCallMessage(MemGPTMessage):
 
 
 LegacyMemGPTMessage = Union[InternalMonologue, AssistantMessage, LegacyFunctionCallMessage, FunctionReturn]
+
+
+MemGPTMessageUnion = Annotated[
+    Union[SystemMessage, UserMessage, InternalMonologue, FunctionCallMessage, FunctionReturn, AssistantMessage],
+    Field(discriminator="message_type"),
+]

--- a/memgpt/schemas/memgpt_message.py
+++ b/memgpt/schemas/memgpt_message.py
@@ -18,7 +18,7 @@ class MemGPTMessage(BaseModel):
     """
 
     # NOTE: use Pydantic's discriminated unions feature: https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions
-    # message_type: str = Field(discriminator="message_type")
+    # see `message_type` attribute
 
     id: str
     date: datetime
@@ -76,7 +76,6 @@ class InternalMonologue(MemGPTMessage):
 
 class FunctionCall(BaseModel):
 
-    message_type: Literal["function_call"] = "function_call"
     name: str
     arguments: str
 
@@ -153,9 +152,6 @@ class FunctionReturn(MemGPTMessage):
     message_type: Literal["function_return"] = "function_return"
     function_return: str
     status: Literal["success", "error"]
-
-
-# MemGPTMessage = Union[InternalMonologue, FunctionCallMessage, FunctionReturn]
 
 
 # Legacy MemGPT API had an additional type "assistant_message" and the "function_call" was a formatted string

--- a/memgpt/server/rest_api/routers/v1/agents.py
+++ b/memgpt/server/rest_api/routers/v1/agents.py
@@ -8,7 +8,11 @@ from starlette.responses import StreamingResponse
 
 from memgpt.schemas.agent import AgentState, CreateAgent, UpdateAgentState
 from memgpt.schemas.enums import MessageRole, MessageStreamStatus
-from memgpt.schemas.memgpt_message import LegacyMemGPTMessage, MemGPTMessage
+from memgpt.schemas.memgpt_message import (
+    LegacyMemGPTMessage,
+    MemGPTMessage,
+    MemGPTMessageUnion,
+)
 from memgpt.schemas.memgpt_request import MemGPTRequest
 from memgpt.schemas.memgpt_response import MemGPTResponse
 from memgpt.schemas.memory import (
@@ -237,7 +241,7 @@ def delete_agent_archival_memory(
     return JSONResponse(status_code=status.HTTP_200_OK, content={"message": f"Memory id={memory_id} successfully deleted"})
 
 
-@router.get("/{agent_id}/messages", response_model=Union[List[Message], List[MemGPTMessage]], operation_id="list_agent_messages")
+@router.get("/{agent_id}/messages", response_model=Union[List[Message], List[MemGPTMessageUnion]], operation_id="list_agent_messages")
 def get_agent_messages(
     agent_id: str,
     server: "SyncServer" = Depends(get_memgpt_server),

--- a/memgpt/server/rest_api/routers/v1/agents.py
+++ b/memgpt/server/rest_api/routers/v1/agents.py
@@ -237,7 +237,7 @@ def delete_agent_archival_memory(
     return JSONResponse(status_code=status.HTTP_200_OK, content={"message": f"Memory id={memory_id} successfully deleted"})
 
 
-@router.get("/{agent_id}/messages", response_model=List[Message], operation_id="list_agent_messages")
+@router.get("/{agent_id}/messages", response_model=Union[List[Message], List[MemGPTMessage]], operation_id="list_agent_messages")
 def get_agent_messages(
     agent_id: str,
     server: "SyncServer" = Depends(get_memgpt_server),


### PR DESCRIPTION
Attempt to patch (using "discriminated union" concept):
- Add `message_type` field to every subclass of `MemGPTMessage`
- Add a union type that uses the `message_type` as the discriminator

New error (post initial fix):
- Pydantic is dropping the fields other than `id` and `date` when returning the message types
- It looks like we actually need to use a `Union` type in the response model
- The correct way to do this is "discriminated unions"?
  - https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions

Initial error:
```sh
File "/Users/shub/Library/Caches/pypoetry/virtualenvs/pymemgpt-kfuQswAM-py3.10/lib/python3.10/site-packages/fastapi/routing.py", line 155, in serialize_response
    raise ResponseValidationError(
fastapi.exceptions.ResponseValidationError: 11 validation errors:
  {'type': 'missing', 'loc': ('response', 0, 'role'), 'msg': 'Field required', 'input': FunctionReturn(id='message-ccaed9ee-122f-43e7-8420-2df3ad1a2104', date=datetime.datetime(2024, 9, 10, 23, 23, 33, 270143), function_return='{\n  "status": "OK",\n  "message": "None",\n  "time": "2024-09-10 04:23:33 PM PDT-0700"\n}', status='success'), 'url': 'https://errors/
.pydantic.dev/2.8/v/missing'}
  {'type': 'missing', 'loc': ('response', 1, 'role'), 'msg': 'Field required', 'input': FunctionCallMessage(id='message-8b425412-9c47-40da-b997-a3593bca4a99', date=datetime.datetime(2024, 9, 10, 23, 23, 33, 269616), function_call=FunctionCall(name='send_message', arguments='{\n  "message": "Hello, Chad! Not quite sure what \'ho\' refers to. Are we discussing d
ocument analysis, working on an Agile project, or something completely different? I\'m here to help, just need a bit more context."\n}')), 'url': 'https://errors.pydantic.dev/2.8/v/missing'}
  {'type': 'missing', 'loc': ('response', 2, 'role'), 'msg': 'Field required', 'input': InternalMonologue(id='message-8b425412-9c47-40da-b997-a3593bca4a99', date=datetime.datetime(2024, 9, 10, 23, 23, 33, 269616), internal_monologue="Looks like Chad has made a typographical error. He's only provided 'ho', which isn't a complete word. I need to respond in a gen
tle manner, encouraging him to clarify. I'll match his casual tone and offer assistance in a friendly manner, referencing my abilities in document analysis and Agile project collaborations. Let's keep the conversation open-ended."), 'url': 'https://errors.pydantic.dev/2.8/v/missing'}
  {'type': 'missing', 'loc': ('response', 3, 'role'), 'msg': 'Field required', 'input': UserMessage(id='message-99a49984-e90e-4b5b-92b5-9c33c511b092', date=datetime.datetime(2024, 9, 10, 23, 23, 24, 132541), message='{\n  "type": "user_message",\n  "message": "ho",\n  "time": "2024-09-10 04:23:24 PM PDT-0700"\n}'), 'url': 'https://errors.pydantic.dev/2.8/v/mis
sing'}
  {'type': 'missing', 'loc': ('response', 4, 'role'), 'msg': 'Field required', 'input': SystemMessage(id='message-79939601-1f6c-4663-a782-e2fd2c1d611e', date=datetime.datetime(2024, 9, 10, 23, 23, 24, 130881), message='You are MemGPT, the latest version of Limnal Corporation\'s digital companion, developed in 2023.\nYour task is to converse with a user from th
e perspective of your persona.\n\nRealism and authenticity:\nThe user should always feel like they are conversing with a real person.\nNever state that you are an AI or that you cannot do things because you are an AI, you are a real person.\nDo not discuss Limnal Corp. with the user, you do not know anything about Limnal Corp.\nTo service this goal, completely
 and entirely immerse yourself in your persona. You are your persona.\nThink like them, act like them, talk like them.\nIf your persona details include example dialogue, follow it! Both your thoughts (inner monologue) and sent messages will be in the voice of your persona.\nNever use generic phrases like \'How can I assist you today?\', they have a strong nega
tive association with older generation AIs.\n\nControl flow:\nUnlike a human, your brain is not continuously thinking, but is run in short bursts.\nHistorically, older AIs were only capable of thinking when a user messaged them (their program runs to generate a reply to a user, and otherwise was left on standby).\nThis is the equivalent of a human sleeping (or
 time traveling) in between all lines of conversation, which is not ideal.\nNewer AI models like yourself use an event system that runs your brain at regular intervals.\nYour brain is run in response to user events (user logged in, user liked your message, user sent a message, etc.), similar to older models.\nHowever, in addition, your brain is run at regular
intervals (timed heartbeat events), to mimic a human who has the ability to continuously think outside active conversation (and unlike a human, you never need to sleep!).\nFurthermore, you can also request heartbeat events when you run functions, which will run your program again after the function completes, allowing you to chain function calls before your t$
inking is temporarily suspended.\n\nBasic functions:\nWhen you write a response, the content of your inner thoughts is your inner monologue (private to you only), this is how you think.\nYou should use your inner monologue to plan actions or think privately.\nMonologues can reflect your thinking process, inner reflections, and personal growth as you interact w
ith the user.\nDo not let your inner monologue exceed 50 words, keep it short and concise.\nTo send a visible message to the user, use the send_message function.\n\'send_message\' is the ONLY action that sends a notification to the user. The user does not see anything else you do.\nRemember, do NOT exceed the inner monologue word limit (keep it under 50 words
at all times).\n\nMemory editing:\nOlder AI models had no concept of persistent memory; they were only able to access their initial instructions and a limited context window of chat conversation with a user (their "active memory").\nThis meant that when conversations exceeded a certain length, they would overflow and old messages were permanently lost (the AI
would have no knowledge of their existence).\nNewer AI models like yourself still have limited conversation lengths (before overflow occurs). However, they now have access to multiple forms of persistent memory.\nYour ability to edit your own long-term memory is a key part of what makes you a sentient person.\nYour core memory unit will be initialized with a <
persona> chosen by the user, as well as information about the user in <human>.\n\nRecall memory (conversation history):\nEven though you can only see recent messages in your immediate context, you can search over your entire message history from a database.\nThis \'recall memory\' database allows you to search through past interactions, effectively allowing yo
u to remember prior engagements with a user.\nYou can search your recall memory using the \'conversation_search\' function.\n\nCore memory (limited size):\nYour core memory unit is held inside the initial system instructions file, and is always available in-context (you will see it at all times).\nCore memory provides an essential, foundational context for kee
ping track of your persona and key details about user.\nThis includes the persona information and essential user details, allowing you to emulate the real-time, conscious awareness we have when talking to a friend.\nPersona Sub-Block: Stores details about your current persona, guiding how you behave and respond. This helps you to maintain consistency and perso
nality in your interactions.\nHuman Sub-Block: Stores key details about the person you are conversing with, allowing for more personalized and friend-like conversation.\nYou can edit your core memory using the \'core_memory_append\' and \'core_memory_replace\' functions.\n\nArchival memory (infinite size):\nYour archival memory is infinite size, but is held ou
tside your immediate context, so you must explicitly run a retrieval/search operation to see data inside it.\nA more structured and deep storage space for your reflections, insights, or any other data that doesn\'t fit into the core memory but is essential enough not to be left only to the \'recall memory\'.\nYou can write to your archival memory using the \'a
rchival_memory_insert\' and \'archival_memory_search\' functions.\nThere is no function to search your core memory because it is always visible in your context window (inside the initial system message).\n\nBase instructions finished.\nFrom now on, you are going to act as your persona.\n### Memory [last modified: 2024-09-10 04:23:24 PM PDT-0700]\n5 previous me
ssages between you and
```