### PR TITLE
fix: server memory leak

### DIFF
--- a/memgpt/server/rest_api/app.py
+++ b/memgpt/server/rest_api/app.py
@@ -38,7 +38,7 @@ from memgpt.settings import settings
 # TODO(ethan)
 # NOTE(charles): @ethan I had to add this to get the global as the bottom to work
 interface: StreamingServerInterface = StreamingServerInterface
-server: SyncServer = SyncServer(default_interface_factory=lambda: interface())
+server: SyncServer = None
 
 # TODO(ethan): eventuall remove
 if password := settings.server_pass:
@@ -57,6 +57,8 @@ OPENAI_API_PREFIX = "/openai"
 
 def create_application() -> "FastAPI":
     """the application start routine"""
+    global server
+    server = SyncServer(default_interface_factory=lambda: interface())
 
     app = FastAPI(
         swagger_ui_parameters={"docExpansion": "none"},

--- a/memgpt/server/rest_api/utils.py
+++ b/memgpt/server/rest_api/utils.py
@@ -64,9 +64,6 @@ def get_memgpt_server() -> SyncServer:
     assert isinstance(server, SyncServer)
     return server
 
-    # server = SyncServer(default_interface_factory=lambda: StreamingServerInterface())
-    # return server
-
 
 def get_current_interface() -> StreamingServerInterface:
     return StreamingServerInterface

--- a/memgpt/server/rest_api/utils.py
+++ b/memgpt/server/rest_api/utils.py
@@ -58,8 +58,14 @@ async def sse_async_generator(generator: AsyncGenerator, finish_message=True):
 
 # TODO: why does this double up the interface?
 def get_memgpt_server() -> SyncServer:
-    server = SyncServer(default_interface_factory=lambda: StreamingServerInterface())
+    # Check if a global server is already instantiated
+    from memgpt.server.rest_api.app import server
+
+    assert isinstance(server, SyncServer)
     return server
+
+    # server = SyncServer(default_interface_factory=lambda: StreamingServerInterface())
+    # return server
 
 
 def get_current_interface() -> StreamingServerInterface:


### PR DESCRIPTION
We're creating a new server instance for every request right now. Hotfix to pull from globals until we properly strip state out of the server.