### PR TITLE
feat: add support for `user_id` in header

### DIFF
--- a/memgpt/server/rest_api/app.py
+++ b/memgpt/server/rest_api/app.py
@@ -6,7 +6,8 @@ from typing import Optional
 
 import typer
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
 from memgpt.server.constants import REST_DEFAULT_PORT
@@ -83,7 +84,8 @@ def create_application() -> "FastAPI":
                 server.set_current_user(user_id)
             except ValueError as e:
                 # Return an HTTP 401 Unauthorized response
-                raise HTTPException(status_code=401, detail=str(e))
+                # raise HTTPException(status_code=401, detail=str(e))
+                return JSONResponse(status_code=401, content={"detail": str(e)})
         else:
             server.set_current_user(None)
         response = await call_next(request)

--- a/memgpt/server/rest_api/app.py
+++ b/memgpt/server/rest_api/app.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import typer
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from starlette.middleware.cors import CORSMiddleware
 
 from memgpt.server.constants import REST_DEFAULT_PORT
@@ -79,7 +79,11 @@ def create_application() -> "FastAPI":
     async def set_current_user_middleware(request: Request, call_next):
         user_id = request.headers.get("user_id")
         if user_id:
-            server.set_current_user(user_id)
+            try:
+                server.set_current_user(user_id)
+            except ValueError as e:
+                # Return an HTTP 401 Unauthorized response
+                raise HTTPException(status_code=401, detail=str(e))
         else:
             server.set_current_user(None)
         response = await call_next(request)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -1777,6 +1777,12 @@ class SyncServer(Server):
         NOTE: clearly not thread-safe, only exists to provide basic user_id support for REST API for now
         """
 
+        # Make sure the user_id actually exists
+        if user_id is not None:
+            user_obj = self.get_user(user_id)
+            if not user_obj:
+                raise ValueError(f"User with id {user_id} not found")
+
         self._current_user = user_id
 
     # TODO(ethan) wire back to real method in future ORM PR


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Adds basic support for reading `user_id` from the header of the HTTP request.

Note: implementation is not thread safe and will be / needs to be refactored alongside the stateless server refactor.

**How to test.**

Test no header:
```sh
$ curl --request GET \
     --url http://localhost:8283/v1/models/ \
     --header 'accept: application/json'
[{"model":"gpt-4","model_endpoint_type":"openai","model_endpoint":"https://api.openai.com/v1","model_wrapper":null,"context_window":8192}]%
```
Test header with bad ID (no user exists):
```sh
$ curl --request GET \
     --url http://localhost:8283/v1/models/ \
     --header 'accept: application/json' \
     --header 'user_id: 0x0'
{"detail":"User with id 0x0 not found"}%
```

Test header with existing ID (the config one):
```yaml
[client]
anon_clientid = user-6122fbc6-ef57-413e-a84c-7965f42151fe
```
```sh
$  curl --request GET \
     --url http://localhost:8283/v1/models/ \
     --header 'accept: application/json' \
     --header 'user_id: user-6122fbc6-ef57-413e-a84c-7965f42151fe'
[{"model":"gpt-4","model_endpoint_type":"openai","model_endpoint":"https://api.openai.com/v1","model_wrapper":null,"context_window":8192}]%
```
