### PR TITLE
refactor: clean up `agent.step()`

### DIFF
--- a/memgpt/agent.py
+++ b/memgpt/agent.py
@@ -607,7 +607,7 @@ class Agent(BaseAgent):
             # (Still parsing function args)
             # Handle requests for immediate heartbeat
             heartbeat_request = function_args.pop("request_heartbeat", None)
-            if not (isinstance(heartbeat_request, bool) or heartbeat_request is None):
+            if not isinstance(heartbeat_request, bool) or heartbeat_request is None:
                 printd(
                     f"{CLI_WARNING_PREFIX}'request_heartbeat' arg parsed was not a bool or None, type={type(heartbeat_request)}, value={heartbeat_request}"
                 )

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -366,7 +366,7 @@ def run_agent_loop(
         skip_next_user_input = False
 
         def process_agent_step(user_message, no_verify):
-            new_messages, heartbeat_request, function_failed, token_warning, tokens_accumulated = memgpt_agent.step(
+            step_response = memgpt_agent.step(
                 user_message,
                 first_message=False,
                 skip_verify=no_verify,
@@ -374,6 +374,11 @@ def run_agent_loop(
                 inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
                 ms=ms,
             )
+            new_messages = step_response.messages
+            heartbeat_request = step_response.heartbeat_request
+            function_failed = step_response.function_failed
+            token_warning = step_response.in_context_memory_warning
+            step_response.usage
 
             agent.save_agent(memgpt_agent, ms)
             skip_next_user_input = False

--- a/memgpt/schemas/agent.py
+++ b/memgpt/schemas/agent.py
@@ -1,13 +1,15 @@
 import uuid
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
-from pydantic import Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from memgpt.schemas.embedding_config import EmbeddingConfig
 from memgpt.schemas.llm_config import LLMConfig
 from memgpt.schemas.memgpt_base import MemGPTBase
 from memgpt.schemas.memory import Memory
+from memgpt.schemas.message import Message
+from memgpt.schemas.openai.chat_completion_response import UsageStatistics
 
 
 class BaseAgent(MemGPTBase, validate_assignment=True):
@@ -102,3 +104,14 @@ class UpdateAgentState(BaseAgent):
     # TODO: determine if these should be editable via this schema?
     message_ids: Optional[List[str]] = Field(None, description="The ids of the messages in the agent's in-context memory.")
     memory: Optional[Memory] = Field(None, description="The in-context memory of the agent.")
+
+
+class AgentStepResponse(BaseModel):
+    # TODO remove support for list of dicts
+    messages: Union[List[Message], List[dict]] = Field(..., description="The messages generated during the agent's step.")
+    heartbeat_request: bool = Field(..., description="Whether the agent requested a heartbeat (i.e. follow-up execution).")
+    function_failed: bool = Field(..., description="Whether the agent step ended because a function call failed.")
+    in_context_memory_warning: bool = Field(
+        ..., description="Whether the agent step ended because the in-context memory is near its limit."
+    )
+    usage: UsageStatistics = Field(..., description="Usage statistics of the LLM call during the agent's step.")

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -320,7 +320,7 @@ class SyncServer(Server):
             total_usage = UsageStatistics()
             step_count = 0
             while True:
-                new_messages, heartbeat_request, function_failed, token_warning, usage = memgpt_agent.step(
+                step_response = memgpt_agent.step(
                     next_input_message,
                     first_message=False,
                     skip_verify=no_verify,
@@ -329,6 +329,12 @@ class SyncServer(Server):
                     timestamp=timestamp,
                     ms=self.ms,
                 )
+                step_response.messages
+                heartbeat_request = step_response.heartbeat_request
+                function_failed = step_response.function_failed
+                token_warning = step_response.in_context_memory_warning
+                usage = step_response.usage
+
                 step_count += 1
                 total_usage += usage
                 counter += 1


### PR DESCRIPTION
Initial stab at cleaning up the agent step by removing dead code + turning the response into a response model instead of a tuple.

Follow-up PRs should do the following cleanup:

- [ ] Unify the type going into `step` (probably should drop support for `str`, make it `None` or `Message`?)
- [ ] Move unnecessary kwargs into configs
- [ ] Strip out `ms` (replace with `session`)
- [ ] Move input validation out of `step` and into the loop handler
  - This ensures that `step` corresponds to a single LLM call (unless a summarization happens, in which case we probably want to return a dual usage? or put a summarization event into the response model?)
- [ ] Potentially change the input of step to be a model as well (probably cleaner if we don't do this)