### PR TITLE
fix: Check that content is not None before setting to internal_monologue

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -551,6 +551,10 @@ class Agent(BaseAgent):
             )  # extend conversation with assistant's reply
             printd(f"Function call message: {messages[-1]}")
 
+            if response_message.content:
+                # The content if then internal monologue, not chat
+                self.interface.internal_monologue(response_message.content, msg_obj=messages[-1])
+
             # Step 3: call the function
             # Note: the JSON response may not always be valid; be sure to handle errors
             function_call = (
@@ -603,13 +607,6 @@ class Agent(BaseAgent):
                 )  # extend conversation with function response
                 self.interface.function_message(f"Error: {error_msg}", msg_obj=messages[-1])
                 return messages, False, True  # force a heartbeat to allow agent to handle error
-
-            # Community noted that inner thoughts can sometimes appear in the function args
-            if "inner_thoughts" in function_args:
-                response_message.content = function_args.pop("inner_thoughts")
-            if response_message.content:
-                # The content if then internal monologue, not chat
-                self.interface.internal_monologue(response_message.content, msg_obj=messages[-1])
 
             # (Still parsing function args)
             # Handle requests for immediate heartbeat


### PR DESCRIPTION
Check that content is not None before setting to internal_monologue. This is causing intermittent errors sometimes with our testing, where sometimes the model does not use the `content` field:

```
=========================== short test summary info ============================
FAILED tests/test_tools.py::test_create_agent_tool[client0] - ValueError: Failed to send message: {"detail":"1 validation error for InternalMonologue\ninternal_monologue\n  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\n    For further information visit https://errors.pydantic.dev/2.9/v/string_type"}
================== 1 failed, 2 passed, 36 warnings in 16.10s ===================
```

Additionally, we also search for `inner_thoughts` in the function args - community members noted that inner thoughts can sometimes appear in function args instead of the content field for function calls.