### PR TITLE
feat: Adapt crewAI to also accept parameterized tools and add example

### DIFF
--- a/examples/crewai_tool_usage.py
+++ b/examples/crewai_tool_usage.py
@@ -1,0 +1,73 @@
+import json
+import uuid
+
+from letta import create_client
+from letta.schemas.memory import ChatMemory
+from letta.schemas.tool import Tool
+
+"""
+This example show how you can add CrewAI tools .
+
+First, make sure you have CrewAI and some of the extras downloaded.
+```
+poetry install --extras "external-tools"
+```
+then setup letta with `letta configure`.
+"""
+
+
+def main():
+    from crewai_tools import ScrapeWebsiteTool
+
+    crewai_tool = ScrapeWebsiteTool(website_url="https://www.example.com")
+
+    example_website_scrape_tool = Tool.from_crewai(crewai_tool)
+    tool_name = example_website_scrape_tool.name
+
+    # Create a `LocalClient` (you can also use a `RESTClient`, see the letta_rest_client.py example)
+    client = create_client()
+
+    # create tool
+    client.add_tool(example_website_scrape_tool)
+
+    # Confirm that the tool is in
+    tools = client.list_tools()
+    assert example_website_scrape_tool.name in [t.name for t in tools]
+
+    # Generate uuid for agent name for this example
+    namespace = uuid.NAMESPACE_DNS
+    agent_uuid = str(uuid.uuid5(namespace, "letta-crewai-tooling-example"))
+
+    # Clear all agents
+    for agent_state in client.list_agents():
+        if agent_state.name == agent_uuid:
+            client.delete_agent(agent_id=agent_state.id)
+            print(f"Deleted agent: {agent_state.name} with ID {str(agent_state.id)}")
+
+    # google search persona
+    persona = f"""
+
+    My name is Letta.
+
+    I am a personal assistant who answers a user's questions about a website `example.com`. When a user asks me a question about `example.com`, I will use a tool called {tool_name} which will search `example.com` and answer the relevant question.
+
+    Don’t forget - inner monologue / inner thoughts should always be different than the contents of send_message! send_message is how you communicate with the user, whereas inner thoughts are your own personal inner thoughts.
+    """
+
+    # Create an agent
+    agent_state = client.create_agent(name=agent_uuid, memory=ChatMemory(human="My name is Matt.", persona=persona), tools=[tool_name])
+    print(f"Created agent: {agent_state.name} with ID {str(agent_state.id)}")
+
+    # Send a message to the agent
+    send_message_response = client.user_message(agent_id=agent_state.id, message="What's on the example.com website?")
+    for message in send_message_response.messages:
+        response_json = json.dumps(message.model_dump(), indent=4)
+        print(f"{response_json}\n")
+
+    # Delete agent
+    client.delete_agent(agent_id=agent_state.id)
+    print(f"Deleted agent: {agent_state.name} with ID {str(agent_state.id)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langchain_tool_usage.py
+++ b/examples/langchain_tool_usage.py
@@ -11,8 +11,7 @@ This example show how you can add LangChain tools .
 First, make sure you have LangChain and some of the extras downloaded.
 For this specific example, you will need `wikipedia` installed.
 ```
-poetry install --extras "tests"
-poetry install langchain
+poetry install --extras "external-tools"
 ```
 then setup letta with `letta configure`.
 """

--- a/letta/schemas/tool.py
+++ b/letta/schemas/tool.py
@@ -93,7 +93,7 @@ class Tool(BaseTool):
         )
 
     @classmethod
-    def from_crewai(cls, crewai_tool: "CrewAIBaseTool") -> "Tool":
+    def from_crewai(cls, crewai_tool: "CrewAIBaseTool", additional_imports_module_attr_map: dict[str, str] = None) -> "Tool":
         """
         Class method to create an instance of Tool from a crewAI BaseTool object.
 
@@ -106,7 +106,7 @@ class Tool(BaseTool):
         description = crewai_tool.description
         source_type = "python"
         tags = ["crew-ai"]
-        wrapper_func_name, wrapper_function_str = generate_crewai_tool_wrapper(crewai_tool)
+        wrapper_func_name, wrapper_function_str = generate_crewai_tool_wrapper(crewai_tool, additional_imports_module_attr_map)
         json_schema = generate_schema_from_args_schema(crewai_tool.args_schema, name=wrapper_func_name, description=description)
 
         # append heartbeat (necessary for triggering another reasoning step after this tool call)


### PR DESCRIPTION
## Description

Adapt crewAI to also accept parameterized tools and add example. 

```
crewai_tool = ScrapeWebsiteTool(website_url="https://www.example.com")
example_website_scrape_tool = Tool.from_crewai(crewai_tool)
```

## Testing
Wrote tests covering:
- Use a crewAI tool with a parameter
- Adapt existing crewAI tests to use a more stable example website
- E2E example of an agent invoking a `ScrapeWebsiteTool` from crewAI and run it manually

