### PR TITLE
add docker compose ollama

### DIFF
--- a/docker-compose-ollama.yaml
+++ b/docker-compose-ollama.yaml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  letta:
+    image: lettaai/letta:latest
+    ports:
+      - "8083:8083"
+    environment:
+      - LETTA_LLM_ENDPOINT=http://ollama:11434 
+      - LETTA_LLM_ENDPOINT_TYPE=ollama
+      - LETTA_LLM_MODEL=${LETTA_LLM_MODEL}  # Use env variable for model
+      - LETTA_LLM_CONTEXT_WINDOW=8192
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    container_name: ollama
+    volumes:
+      - ollama:/root/.ollama
+    ports:
+      - "11434:11434"
+    entrypoint: ["/bin/ollama"]
+    command: |
+        serve && pull llama3.2
+    ipc: host
+volumes:
+  ollama:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?
- Enable running Letta with ollama powered model with one command

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

1. Run the containers: `export LETTA_LLM_MODEL=llama3; docker compose -f docker-compose-ollama.yaml up --remove-orphans`. Replace llama3 with your own model id` 
2. Once the container is running, pull a model by running the `docker exec -it ollama ollama run llama3`. Replace llama3 with your model here.
3. Open http://localhost:8083/
4. Create an agent and chat with the agent. Note that the model running here is small so it is much less powerful than gpt-4o

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

Yes, Able to create an agent and have conversations.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/Letta/issues) or [PRs](https://github.com/cpacker/Letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
