### PR TITLE
feat: persist tools to db when saving agent

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -238,6 +238,7 @@ class Agent(BaseAgent):
         assert isinstance(self.agent_state.memory, Memory), f"Memory object is not of type Memory: {type(self.agent_state.memory)}"
 
         # link tools
+        self.tools = tools
         self.link_tools(tools)
 
         # gpt-4, gpt-3.5-turbo, ...
@@ -1342,6 +1343,10 @@ def save_agent(agent: Agent, ms: MetadataStore):
         ms.update_agent(agent_state)
     else:
         ms.create_agent(agent_state)
+
+    for tool in agent.tools:
+        if ms.get_tool(tool_id=tool.id) is None:
+            ms.create_tool(tool)
 
     agent.agent_state = ms.get_agent(agent_id=agent_id)
     assert isinstance(agent.agent_state.memory, Memory), f"Memory is not a Memory object: {type(agent_state.memory)}"

--- a/letta/agent.py
+++ b/letta/agent.py
@@ -1345,7 +1345,7 @@ def save_agent(agent: Agent, ms: MetadataStore):
         ms.create_agent(agent_state)
 
     for tool in agent.tools:
-        if ms.get_tool(tool_id=tool.id) is None:
+        if ms.get_tool(tool_name=tool.name, user_id=tool.user_id) is None:
             ms.create_tool(tool)
 
     agent.agent_state = ms.get_agent(agent_id=agent_id)


### PR DESCRIPTION
When users add tools upon the creation of an agent, the tools are required to be persisted to the DB for functionality. This PR addresses this by saving un-saved tools to the DB while saving the agent.