### PR TITLE
fix: calling link_tools doesnt update agent.tools

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -339,6 +339,9 @@ class Agent(BaseAgent):
         for tool_name in self.agent_state.tools:
             assert tool_name in [tool.name for tool in tools], f"Tool name {tool_name} not included in agent tool list"
 
+        # Update tools
+        self.tools = tools
+
         # Store the functions schemas (this is passed as an argument to ChatCompletion)
         self.functions = []
         self.functions_python = {}


### PR DESCRIPTION
#1847 added the ability to modify an agent's tools after it's been created, but calling the `link_tools` function does not update the `tools` attribute, causing a database error (since it never ends up getting written to db) when doing so. This PR addresses this by updating the `tools` attribute in `link_tools`.