### PR TITLE
fix: CLI patches - patch runtime error on main loop + duplicate internal monologue

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -556,9 +556,12 @@ class Agent(BaseAgent):
             )  # extend conversation with assistant's reply
             printd(f"Function call message: {messages[-1]}")
 
+            nonnull_content = False
             if response_message.content:
                 # The content if then internal monologue, not chat
                 self.interface.internal_monologue(response_message.content, msg_obj=messages[-1])
+                # Flag to avoid printing a duplicate if inner thoughts get popped from the function call
+                nonnull_content = True
 
             # Step 3: call the function
             # Note: the JSON response may not always be valid; be sure to handle errors
@@ -619,7 +622,7 @@ class Agent(BaseAgent):
             if "inner_thoughts" in function_args:
                 response_message.content = function_args.pop("inner_thoughts")
             # The content if then internal monologue, not chat
-            if response_message.content:
+            if response_message.content and not nonnull_content:
                 self.interface.internal_monologue(response_message.content, msg_obj=messages[-1])
 
             # (Still parsing function args)

--- a/letta/main.py
+++ b/letta/main.py
@@ -366,7 +366,7 @@ def run_agent_loop(
                 first_message=False,
                 skip_verify=no_verify,
                 stream=stream,
-                inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
+                inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs,
                 ms=ms,
             )
             new_messages = step_response.messages


### PR DESCRIPTION
Squashing two CLI `letta run` bugs on main

Bug 1: runtime error (`letta run` totally bricked)
```sh
? Select embedding model: text-embedding-ada-002
->  🤖 Using persona profile: 'sam_pov'
->  🧑 Using human profile: 'basic'
->  🛠️  8 tools: send_message, pause_heartbeats, conversation_search, conversation_search_date, archival_memory_insert, archival_memory_search, core_memory_append, core_memory_replace
🎉 Created new agent 'XenialXenophobia' (id=agent-50a02fce-472b-43c2-a815-8687d14ee952)

Hit enter to begin (will request first Letta message)


An exception occurred when running agent.step(): 
Traceback (most recent call last):
  File "/Users/loaner/dev/MemGPT-fresh/letta/main.py", line 403, in run_agent_loop
    new_messages, user_message, skip_next_user_input = process_agent_step(user_message, no_verify)
  File "/Users/loaner/dev/MemGPT-fresh/letta/main.py", line 364, in process_agent_step
    step_response = letta_agent.step(
TypeError: Agent.step() got an unexpected keyword argument 'inner_thoughts_in_kwargs'
? Retry agent.step()? (Y/n)
```

Bug 2: duplicate internal monologue
<img width="799" alt="image" src="https://github.com/user-attachments/assets/903cb4b3-51e9-4a88-978c-454c6d573512">
