### PR TITLE
fix: add missing hardcodings for popular OpenAI models

### DIFF
--- a/letta/constants.py
+++ b/letta/constants.py
@@ -75,6 +75,27 @@ NON_USER_MSG_PREFIX = "[This is an automated system message hidden from the user
 LLM_MAX_TOKENS = {
     "DEFAULT": 8192,
     ## OpenAI models: https://platform.openai.com/docs/models/overview
+    # "o1-preview
+    "chatgpt-4o-latest": 128000,
+    # "o1-preview-2024-09-12
+    "gpt-4o-2024-08-06": 128000,
+    "gpt-4-turbo-preview": 128000,
+    "gpt-4o": 128000,
+    "gpt-3.5-turbo-instruct": 16385,
+    "gpt-4-0125-preview": 128000,
+    "gpt-3.5-turbo-0125": 16385,
+    # "babbage-002": 128000,
+    # "davinci-002": 128000,
+    "gpt-4-turbo-2024-04-09": 128000,
+    # "gpt-4o-realtime-preview-2024-10-01
+    "gpt-4-turbo": 8192,
+    "gpt-4o-2024-05-13": 128000,
+    # "o1-mini
+    # "o1-mini-2024-09-12
+    # "gpt-3.5-turbo-instruct-0914
+    "gpt-4o-mini": 128000,
+    # "gpt-4o-realtime-preview
+    "gpt-4o-mini-2024-07-18": 128000,
     # gpt-4
     "gpt-4-1106-preview": 128000,
     "gpt-4": 8192,

--- a/letta/providers.py
+++ b/letta/providers.py
@@ -70,6 +70,12 @@ class OpenAIProvider(Provider):
             configs.append(
                 LLMConfig(model=model_name, model_endpoint_type="openai", model_endpoint=self.base_url, context_window=context_window_size)
             )
+
+        # for OpenAI, sort in reverse order
+        if self.base_url == "https://api.openai.com/v1":
+            # alphnumeric sort
+            configs.sort(key=lambda x: x.model, reverse=True)
+
         return configs
 
     def list_embedding_models(self) -> List[EmbeddingConfig]:


### PR DESCRIPTION
Before:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/f5051bbf-7dff-4901-878f-15ff305e493c">

After:
<img width="336" alt="image" src="https://github.com/user-attachments/assets/85fcdbbb-c838-4dd1-9359-fae0ef725974">
