### PR TITLE
fix: Fix config bug in alembic

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,7 +5,10 @@ from sqlalchemy import engine_from_config, pool
 
 from alembic import context
 from letta.base import Base
+from letta.config import LettaConfig
 from letta.settings import settings
+
+letta_config = LettaConfig.load()
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -15,7 +18,7 @@ print(settings.letta_pg_uri_no_default)
 if settings.letta_pg_uri_no_default:
     config.set_main_option("sqlalchemy.url", settings.letta_pg_uri)
 else:
-    config.set_main_option("sqlalchemy.url", "sqlite:///" + os.path.join(config.recall_storage_path, "sqlite.db"))
+    config.set_main_option("sqlalchemy.url", "sqlite:///" + os.path.join(letta_config.recall_storage_path, "sqlite.db"))
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.


### PR DESCRIPTION
## Description

Found a bug where the incorrect config object was being used:

```
(letta-py3.12) mattzhou@Matts-MacBook-Pro MemGPT % poetry run alembic upgrade head   

Initializing database...
None
Traceback (most recent call last):
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/bin/alembic", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/config.py", line 636, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/config.py", line 626, in main
    self.run_cmd(cfg, options)
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/config.py", line 603, in run_cmd
    fn(
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/command.py", line 406, in upgrade
    script.run_env()
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/script/base.py", line 582, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/util/pyfiles.py", line 95, in load_python_file
    module = load_module_py(module_id, path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/lib/python3.12/site-packages/alembic/util/pyfiles.py", line 113, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/mattzhou/MemGPT/alembic/env.py", line 18, in <module>
    config.set_main_option("sqlalchemy.url", "sqlite:///" + os.path.join(config.recall_storage_path, "sqlite.db"))
                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Config' object has no attribute 'recall_storage_path'
```

## Testing
Ran `poetry run alembic upgrade head` locally to ensure that error no longer pops up.