### PR TITLE
refactor: simplify `Agent.step` inputs to `Message` or `List[Message]` only

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -883,6 +883,9 @@ class Agent(BaseAgent):
         -> agent.step(messages=[Message(role='user', text=...)])
         """
         # Wrap with metadata, dumps to JSON
+        assert user_message_str and isinstance(
+            user_message_str, str
+        ), f"user_message_str should be a non-empty string, got {type(user_message_str)}"
         user_message_json_str = package_user_message(user_message_str)
 
         # Validate JSON via save/load

--- a/letta/main.py
+++ b/letta/main.py
@@ -356,12 +356,12 @@ def run_agent_loop(
             else:
                 # If message did not begin with command prefix, pass inputs to Letta
                 # Handle user message and append to messages
-                user_message = system.package_user_message(user_input)
+                user_message = user_input.strip()
 
         skip_next_user_input = False
 
         def process_agent_step(user_message, no_verify):
-            step_response = letta_agent.step(
+            step_response = letta_agent.step_user_message(
                 user_message,
                 first_message=False,
                 skip_verify=no_verify,

--- a/letta/main.py
+++ b/letta/main.py
@@ -356,19 +356,29 @@ def run_agent_loop(
             else:
                 # If message did not begin with command prefix, pass inputs to Letta
                 # Handle user message and append to messages
-                user_message = user_input.strip()
+                user_message = str(user_input)
 
         skip_next_user_input = False
 
         def process_agent_step(user_message, no_verify):
-            step_response = letta_agent.step_user_message(
-                user_message,
-                first_message=False,
-                skip_verify=no_verify,
-                stream=stream,
-                inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs,
-                ms=ms,
-            )
+            if user_message is None:
+                step_response = letta_agent.step(
+                    messages=[],
+                    first_message=False,
+                    skip_verify=no_verify,
+                    stream=stream,
+                    inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs,
+                    ms=ms,
+                )
+            else:
+                step_response = letta_agent.step_user_message(
+                    user_message_str=user_message,
+                    first_message=False,
+                    skip_verify=no_verify,
+                    stream=stream,
+                    inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs,
+                    ms=ms,
+                )
             new_messages = step_response.messages
             heartbeat_request = step_response.heartbeat_request
             function_failed = step_response.function_failed


### PR DESCRIPTION
Simplify `Agent.step` inputs to `Message` or `List[Message]` only

Note: previously `List` was not a valid input, despite the API docs making it seem like passing a list was possible

Added an additional convenience function `Agent.step_user_message` that wraps a user message (eg `"hello"`) in the JSON metadata (eg `{"type": "user_message", "message", "hi"}`)