### PR TITLE
feat: refactor the `POST` `agent/messages` API to take multiple messages

### DIFF
--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -1,13 +1,13 @@
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel, Field
 
 from letta.constants import DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
-from letta.schemas.message import MessageCreate
+from letta.schemas.message import Message, MessageCreate
 
 
 class LettaRequest(BaseModel):
-    messages: List[MessageCreate] = Field(..., description="The messages to be sent to the agent.")
+    messages: Union[List[MessageCreate], List[Message]] = Field(..., description="The messages to be sent to the agent.")
     run_async: bool = Field(default=False, description="Whether to asynchronously send the messages to the agent.")  # TODO: implement
 
     stream_steps: bool = Field(

--- a/letta/schemas/message.py
+++ b/letta/schemas/message.py
@@ -2,7 +2,7 @@ import copy
 import json
 import warnings
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import Field, field_validator
 
@@ -57,7 +57,11 @@ class BaseMessage(LettaBase):
 class MessageCreate(BaseMessage):
     """Request to create a message"""
 
-    role: MessageRole = Field(..., description="The role of the participant.")
+    # In the simplified format, only allow simple roles
+    role: Literal[
+        MessageRole.user,
+        MessageRole.system,
+    ] = Field(..., description="The role of the participant.")
     text: str = Field(..., description="The text of the message.")
     name: Optional[str] = Field(None, description="The name of the participant.")
 


### PR DESCRIPTION
- `POST /agents/messages` now hits `server.send_messages` which accepts a list properly
- `POST /agents/messages` now accepts types `List[Message]` in addition to `List[MessageCreate]`
- `MessageCreate` has been limited to only accepting roles `user` and `system`, because it's too complex to allow the user to create other roles on the `POST` (might as well just require them to create `Message`s instead)
  - for example, user wants to send an `assistant` message in the list that has a message "hey how's it going chad", but they don't realize that they can't put that in `content`, but need to put it inside `tool_calls` as the kwarg to a `send_message` function, etc...

---

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/Letta/issues) or [PRs](https://github.com/cpacker/Letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
