### PR TITLE
feat: Add MistralProvider

### DIFF
--- a/letta/llm_api/mistral.py
+++ b/letta/llm_api/mistral.py
@@ -1,0 +1,73 @@
+import requests
+
+from letta.utils import printd, smart_urljoin
+
+# https://docs.anthropic.com/claude/docs/models-overview
+# Sadly hardcoded
+MODEL_LIST = [
+    {
+        "name": "claude-3-opus-20240229",
+        "context_window": 200000,
+    },
+    {
+        "name": "claude-3-sonnet-20240229",
+        "context_window": 200000,
+    },
+    {
+        "name": "claude-3-haiku-20240307",
+        "context_window": 200000,
+    },
+]
+
+DUMMY_FIRST_USER_MESSAGE = "User initializing bootup sequence."
+
+
+# def antropic_get_model_context_window(url: str, api_key: Union[str, None], model: str, ) -> int:
+#     for model_dict in anthropic_get_model_list(url=url, api_key=api_key):
+#         if model_dict["name"] == model:
+#             return model_dict["context_window"]
+#     raise ValueError(f"Can't find model '{model}' in Anthropic model list")
+
+
+def mistral_get_model_list(url: str, api_key: str) -> dict:
+    url = smart_urljoin(url, "models")
+
+    headers = {"Content-Type": "application/json"}
+    if api_key is not None:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    printd(f"Sending request to {url}")
+    response = None
+    try:
+        # TODO add query param "tool" to be true
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raises HTTPError for 4XX/5XX status
+        response_json = response.json()  # convert to dict from string
+        return response_json
+    except requests.exceptions.HTTPError as http_err:
+        # Handle HTTP errors (e.g., response 4XX, 5XX)
+        try:
+            if response:
+                response = response.json()
+        except:
+            pass
+        printd(f"Got HTTPError, exception={http_err}, response={response}")
+        raise http_err
+    except requests.exceptions.RequestException as req_err:
+        # Handle other requests-related errors (e.g., connection error)
+        try:
+            if response:
+                response = response.json()
+        except:
+            pass
+        printd(f"Got RequestException, exception={req_err}, response={response}")
+        raise req_err
+    except Exception as e:
+        # Handle other potential errors
+        try:
+            if response:
+                response = response.json()
+        except:
+            pass
+        printd(f"Got unknown Exception, exception={e}, response={response}")
+        raise e

--- a/letta/llm_api/mistral.py
+++ b/letta/llm_api/mistral.py
@@ -2,32 +2,6 @@ import requests
 
 from letta.utils import printd, smart_urljoin
 
-# https://docs.anthropic.com/claude/docs/models-overview
-# Sadly hardcoded
-MODEL_LIST = [
-    {
-        "name": "claude-3-opus-20240229",
-        "context_window": 200000,
-    },
-    {
-        "name": "claude-3-sonnet-20240229",
-        "context_window": 200000,
-    },
-    {
-        "name": "claude-3-haiku-20240307",
-        "context_window": 200000,
-    },
-]
-
-DUMMY_FIRST_USER_MESSAGE = "User initializing bootup sequence."
-
-
-# def antropic_get_model_context_window(url: str, api_key: Union[str, None], model: str, ) -> int:
-#     for model_dict in anthropic_get_model_list(url=url, api_key=api_key):
-#         if model_dict["name"] == model:
-#             return model_dict["context_window"]
-#     raise ValueError(f"Can't find model '{model}' in Anthropic model list")
-
 
 def mistral_get_model_list(url: str, api_key: str) -> dict:
     url = smart_urljoin(url, "models")

--- a/letta/providers.py
+++ b/letta/providers.py
@@ -139,6 +139,50 @@ class AnthropicProvider(Provider):
         return []
 
 
+class MistralProvider(Provider):
+    name: str = "mistral"
+    api_key: str = Field(..., description="API key for the Mistral API.")
+    base_url: str = "https://api.mistral.ai/v1"
+
+    def list_llm_models(self) -> List[LLMConfig]:
+        from letta.llm_api.mistral import mistral_get_model_list
+
+        # Some hardcoded support for OpenRouter (so that we only get models with tool calling support)...
+        # See: https://openrouter.ai/docs/requests
+        response = mistral_get_model_list(self.base_url, api_key=self.api_key)
+
+        assert "data" in response, f"Mistral model query response missing 'data' field: {response}"
+
+        configs = []
+        for model in response["data"]:
+            # If model has chat completions and function calling enabled
+            if model["capabilities"]["completion_chat"] and model["capabilities"]["function_calling"]:
+                configs.append(
+                    LLMConfig(
+                        model=model["id"],
+                        model_endpoint_type="openai",
+                        model_endpoint=self.base_url,
+                        context_window=model["max_context_length"],
+                    )
+                )
+
+        return configs
+
+    def list_embedding_models(self) -> List[EmbeddingConfig]:
+        # Not supported for mistral
+        return []
+
+    def get_model_context_window(self, model_name: str) -> Optional[int]:
+        # Redoing this is fine because it's a pretty lightweight call
+        models = self.list_llm_models()
+
+        for m in models:
+            if model_name in m["id"]:
+                return int(m["max_context_length"])
+
+        return None
+
+
 class OllamaProvider(OpenAIProvider):
     name: str = "ollama"
     base_url: str = Field(..., description="Base URL for the Ollama API.")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,7 +2,9 @@ import os
 
 from letta.providers import (
     AnthropicProvider,
+    AzureProvider,
     GoogleAIProvider,
+    MistralProvider,
     OllamaProvider,
     OpenAIProvider,
 )
@@ -31,10 +33,13 @@ def test_anthropic():
 #
 
 
-# TODO: Add this test
-# https://linear.app/letta/issue/LET-159/add-tests-for-azure-openai-in-test-providerspy-and-test-endpointspy
 def test_azure():
-    pass
+    provider = AzureProvider(api_key=os.getenv("AZURE_API_KEY"), base_url=os.getenv("AZURE_BASE_URL"))
+    models = provider.list_llm_models()
+    print([m.model for m in models])
+
+    embed_models = provider.list_embedding_models()
+    print([m.embedding_model for m in embed_models])
 
 
 def test_ollama():
@@ -52,6 +57,12 @@ def test_googleai():
     print(models)
 
     provider.list_embedding_models()
+
+
+def test_mistral():
+    provider = MistralProvider(api_key=os.getenv("MISTRAL_API_KEY"))
+    models = provider.list_llm_models()
+    print([m.model for m in models])
 
 
 # def test_vllm():


### PR DESCRIPTION
## Description

Add support for MistralProvider. We will create a follow up PR for actually querying the Mistral models.

## Testing

Added unit testing to test listing models.

```
(letta-py3.12) mattzhou@Matts-MacBook-Pro MemGPT % poetry run pytest -s -vv tests/test_providers.py::test_mistral
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.12.6, pytest-8.3.3, pluggy-1.5.0 -- /Users/mattzhou/Library/Caches/pypoetry/virtualenvs/letta-Mdwnr1Ge-py3.12/bin/python
cachedir: .pytest_cache
rootdir: /Users/mattzhou/MemGPT/tests
configfile: pytest.ini
plugins: asyncio-0.23.8, order-1.3.0, anyio-3.7.1
asyncio: mode=Mode.AUTO
collecting ... Initializing database...
collected 1 item                                                                                                                                                                          

tests/test_providers.py::test_mistral ['open-mistral-7b', 'mistral-tiny', 'mistral-tiny-2312', 'open-mistral-nemo', 'open-mistral-nemo-2407', 'mistral-tiny-2407', 'mistral-tiny-latest', 'open-mixtral-8x7b', 'mistral-small', 'mistral-small-2312', 'open-mixtral-8x22b', 'open-mixtral-8x22b-2404', 'mistral-small-2402', 'mistral-small-2409', 'mistral-small-latest', 'mistral-medium-2312', 'mistral-medium', 'mistral-medium-latest', 'mistral-large-2402', 'mistral-large-2407', 'mistral-large-latest', 'codestral-2405', 'codestral-latest', 'codestral-2405-blue', 'codestral-2405', 'codestral-latest', 'codestral-mamba-2407', 'open-codestral-mamba', 'codestral-mamba-latest', 'pixtral-12b-2409', 'pixtral-12b', 'pixtral-12b-latest', 'mistral-embed']
PASSED
```