### PR TITLE
feat: Add `put_inner_thoughts_in_kwargs` as a config setting for the LLM

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -30,7 +30,7 @@ from letta.persistence_manager import LocalStateManager
 from letta.schemas.agent import AgentState, AgentStepResponse
 from letta.schemas.block import Block
 from letta.schemas.embedding_config import EmbeddingConfig
-from letta.schemas.enums import MessageRole, OptionState
+from letta.schemas.enums import MessageRole
 from letta.schemas.memory import ContextWindowOverview, Memory
 from letta.schemas.message import Message, UpdateMessage
 from letta.schemas.openai.chat_completion_response import ChatCompletionResponse
@@ -463,15 +463,14 @@ class Agent(BaseAgent):
         function_call: str = "auto",
         first_message: bool = False,  # hint
         stream: bool = False,  # TODO move to config?
-        inner_thoughts_in_kwargs_option: OptionState = OptionState.DEFAULT,
     ) -> ChatCompletionResponse:
         """Get response from LLM API"""
         try:
             response = create(
                 # agent_state=self.agent_state,
                 llm_config=self.agent_state.llm_config,
-                user_id=self.agent_state.user_id,
                 messages=message_sequence,
+                user_id=self.agent_state.user_id,
                 functions=self.functions,
                 functions_python=self.functions_python,
                 function_call=function_call,
@@ -480,8 +479,6 @@ class Agent(BaseAgent):
                 # streaming
                 stream=stream,
                 stream_interface=self.interface,
-                # putting inner thoughts in func args or not
-                inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs_option,
             )
 
             if len(response.choices) == 0 or response.choices[0] is None:
@@ -822,7 +819,6 @@ class Agent(BaseAgent):
         first_message_retry_limit: int = FIRST_MESSAGE_ATTEMPTS,
         skip_verify: bool = False,
         stream: bool = False,  # TODO move to config?
-        inner_thoughts_in_kwargs_option: OptionState = OptionState.DEFAULT,
         ms: Optional[MetadataStore] = None,
     ) -> AgentStepResponse:
         """Runs a single step in the agent loop (generates at most one LLM call)"""
@@ -861,10 +857,7 @@ class Agent(BaseAgent):
                 counter = 0
                 while True:
                     response = self._get_ai_reply(
-                        message_sequence=input_message_sequence,
-                        first_message=True,  # passed through to the prompt formatter
-                        stream=stream,
-                        inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs_option,
+                        message_sequence=input_message_sequence, first_message=True, stream=stream  # passed through to the prompt formatter
                     )
                     if verify_first_message_correctness(response, require_monologue=self.first_message_verify_mono):
                         break
@@ -877,7 +870,6 @@ class Agent(BaseAgent):
                 response = self._get_ai_reply(
                     message_sequence=input_message_sequence,
                     stream=stream,
-                    inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs_option,
                 )
 
             # Step 3: check if LLM wanted to call a function
@@ -954,7 +946,6 @@ class Agent(BaseAgent):
                     first_message_retry_limit=first_message_retry_limit,
                     skip_verify=skip_verify,
                     stream=stream,
-                    inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs_option,
                     ms=ms,
                 )
 

--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -320,7 +320,6 @@ def run(
         ms=ms,
         no_verify=no_verify,
         stream=stream,
-        inner_thoughts_in_kwargs=no_content,
     )  # TODO: add back no_verify
 
 

--- a/letta/llm_api/anthropic.py
+++ b/letta/llm_api/anthropic.py
@@ -53,7 +53,7 @@ def anthropic_get_model_list(url: str, api_key: Union[str, None]) -> dict:
     return MODEL_LIST
 
 
-def convert_tools_to_anthropic_format(tools: List[Tool], inner_thoughts_in_kwargs: Optional[bool] = True) -> List[dict]:
+def convert_tools_to_anthropic_format(tools: List[Tool]) -> List[dict]:
     """See: https://docs.anthropic.com/claude/docs/tool-use
 
     OpenAI style:

--- a/letta/llm_api/helpers.py
+++ b/letta/llm_api/helpers.py
@@ -6,7 +6,6 @@ from typing import Any, List, Union
 import requests
 
 from letta.constants import OPENAI_CONTEXT_WINDOW_ERROR_SUBSTRING
-from letta.schemas.enums import OptionState
 from letta.schemas.openai.chat_completion_response import ChatCompletionResponse, Choice
 from letta.utils import json_dumps, printd
 
@@ -200,17 +199,3 @@ def is_context_overflow_error(exception: Union[requests.exceptions.RequestExcept
     # Generic fail
     else:
         return False
-
-
-def derive_inner_thoughts_in_kwargs(inner_thoughts_in_kwargs_option: OptionState, model: str):
-    if inner_thoughts_in_kwargs_option == OptionState.DEFAULT:
-        # model that are known to not use `content` fields on tool calls
-        inner_thoughts_in_kwargs = "gpt-4o" in model or "gpt-4-turbo" in model or "gpt-3.5-turbo" in model
-    else:
-        inner_thoughts_in_kwargs = True if inner_thoughts_in_kwargs_option == OptionState.YES else False
-
-    if not isinstance(inner_thoughts_in_kwargs, bool):
-        warnings.warn(f"Bad type detected: {type(inner_thoughts_in_kwargs)}")
-        inner_thoughts_in_kwargs = bool(inner_thoughts_in_kwargs)
-
-    return inner_thoughts_in_kwargs

--- a/letta/llm_api/openai.py
+++ b/letta/llm_api/openai.py
@@ -105,10 +105,9 @@ def build_openai_chat_completions_request(
     functions: Optional[list],
     function_call: str,
     use_tool_naming: bool,
-    inner_thoughts_in_kwargs: bool,
     max_tokens: Optional[int],
 ) -> ChatCompletionRequest:
-    if inner_thoughts_in_kwargs:
+    if llm_config.put_inner_thoughts_in_kwargs:
         functions = add_inner_thoughts_to_functions(
             functions=functions,
             inner_thoughts_key=INNER_THOUGHTS_KWARG,
@@ -116,7 +115,7 @@ def build_openai_chat_completions_request(
         )
 
     openai_message_list = [
-        cast_message_to_subtype(m.to_openai_dict(put_inner_thoughts_in_kwargs=inner_thoughts_in_kwargs)) for m in messages
+        cast_message_to_subtype(m.to_openai_dict(put_inner_thoughts_in_kwargs=llm_config.put_inner_thoughts_in_kwargs)) for m in messages
     ]
     if llm_config.model:
         model = llm_config.model

--- a/letta/main.py
+++ b/letta/main.py
@@ -20,7 +20,6 @@ from letta.cli.cli_load import app as load_app
 from letta.config import LettaConfig
 from letta.constants import FUNC_FAILED_HEARTBEAT_MESSAGE, REQ_HEARTBEAT_MESSAGE
 from letta.metadata import MetadataStore
-from letta.schemas.enums import OptionState
 
 # from letta.interface import CLIInterface as interface  # for printing to terminal
 from letta.streaming_interface import AgentRefreshStreamingInterface
@@ -64,7 +63,6 @@ def run_agent_loop(
     no_verify: bool = False,
     strip_ui: bool = False,
     stream: bool = False,
-    inner_thoughts_in_kwargs: OptionState = OptionState.DEFAULT,
 ):
     if isinstance(letta_agent.interface, AgentRefreshStreamingInterface):
         # letta_agent.interface.toggle_streaming(on=stream)
@@ -369,7 +367,6 @@ def run_agent_loop(
                     first_message=False,
                     skip_verify=no_verify,
                     stream=stream,
-                    inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs,
                     ms=ms,
                 )
             else:
@@ -378,7 +375,6 @@ def run_agent_loop(
                     first_message=False,
                     skip_verify=no_verify,
                     stream=stream,
-                    inner_thoughts_in_kwargs_option=inner_thoughts_in_kwargs,
                     ms=ms,
                 )
             new_messages = step_response.messages

--- a/letta/schemas/llm_config.py
+++ b/letta/schemas/llm_config.py
@@ -13,6 +13,7 @@ class LLMConfig(BaseModel):
         model_endpoint (str): The endpoint for the model.
         model_wrapper (str): The wrapper for the model. This is used to wrap additional text around the input/output of the model. This is useful for text-to-text completions, such as the Completions API in OpenAI.
         context_window (int): The context window size for the model.
+        put_inner_thoughts_in_kwargs (bool): Puts 'inner_thoughts' as a kwarg in the function call if this is set to True. This helps with function calling performance and also the generation of inner thoughts.
     """
 
     # TODO: 🤮 don't default to a vendor! bug city!
@@ -38,6 +39,10 @@ class LLMConfig(BaseModel):
     model_endpoint: Optional[str] = Field(None, description="The endpoint for the model.")
     model_wrapper: Optional[str] = Field(None, description="The wrapper for the model.")
     context_window: int = Field(..., description="The context window size for the model.")
+    put_inner_thoughts_in_kwargs: Optional[bool] = Field(
+        True,
+        description="Puts 'inner_thoughts' as a kwarg in the function call if this is set to True. This helps with function calling performance and also the generation of inner thoughts.",
+    )
 
     # FIXME hack to silence pydantic protected namespace warning
     model_config = ConfigDict(protected_namespaces=())

--- a/letta/schemas/llm_config.py
+++ b/letta/schemas/llm_config.py
@@ -56,6 +56,7 @@ class LLMConfig(BaseModel):
                 model_endpoint="https://api.openai.com/v1",
                 model_wrapper=None,
                 context_window=8192,
+                put_inner_thoughts_in_kwargs=False,
             )
         elif model_name == "gpt-4o-mini":
             return cls(
@@ -64,6 +65,7 @@ class LLMConfig(BaseModel):
                 model_endpoint="https://api.openai.com/v1",
                 model_wrapper=None,
                 context_window=128000,
+                put_inner_thoughts_in_kwargs=True,
             )
         elif model_name == "letta":
             return cls(
@@ -71,6 +73,7 @@ class LLMConfig(BaseModel):
                 model_endpoint_type="openai",
                 model_endpoint="https://inference.memgpt.ai",
                 context_window=16384,
+                put_inner_thoughts_in_kwargs=True,
             )
         else:
             raise ValueError(f"Model {model_name} not supported.")

--- a/tests/configs/llm_model_configs/azure-gpt-4o-mini.json
+++ b/tests/configs/llm_model_configs/azure-gpt-4o-mini.json
@@ -2,5 +2,6 @@
     "context_window": 128000,
     "model": "gpt-4o-mini",
     "model_endpoint_type": "azure",
-    "model_wrapper": null
+    "model_wrapper": null,
+    "put_inner_thoughts_in_kwargs": true
 }

--- a/tests/configs/llm_model_configs/claude-3-opus.json
+++ b/tests/configs/llm_model_configs/claude-3-opus.json
@@ -3,5 +3,6 @@
     "model": "claude-3-opus-20240229",
     "model_endpoint_type": "anthropic",
     "model_endpoint": "https://api.anthropic.com/v1",
-    "model_wrapper": null
+    "model_wrapper": null,
+    "put_inner_thoughts_in_kwargs": true
 }

--- a/tests/configs/llm_model_configs/gemini-pro.json
+++ b/tests/configs/llm_model_configs/gemini-pro.json
@@ -3,5 +3,6 @@
     "model": "gemini-1.5-pro-latest",
     "model_endpoint_type": "google_ai",
     "model_endpoint": "https://generativelanguage.googleapis.com",
-    "model_wrapper": null
+    "model_wrapper": null,
+    "put_inner_thoughts_in_kwargs": true
 }

--- a/tests/configs/llm_model_configs/gpt-4.json
+++ b/tests/configs/llm_model_configs/gpt-4.json
@@ -3,5 +3,6 @@
     "model": "gpt-4",
     "model_endpoint_type": "openai",
     "model_endpoint": "https://api.openai.com/v1",
-    "model_wrapper": null
+    "model_wrapper": null,
+    "put_inner_thoughts_in_kwargs": false
 }

--- a/tests/configs/llm_model_configs/groq.json
+++ b/tests/configs/llm_model_configs/groq.json
@@ -3,5 +3,6 @@
     "model": "llama-3.1-70b-versatile",
     "model_endpoint_type": "groq",
     "model_endpoint": "https://api.groq.com/openai/v1",
-    "model_wrapper": null
+    "model_wrapper": null,
+    "put_inner_thoughts_in_kwargs": true
 }

--- a/tests/configs/llm_model_configs/letta-hosted.json
+++ b/tests/configs/llm_model_configs/letta-hosted.json
@@ -2,5 +2,6 @@
     "context_window": 16384,
     "model_endpoint_type": "openai",
     "model_endpoint": "https://inference.memgpt.ai",
-    "model": "memgpt-openai"
+    "model": "memgpt-openai",
+    "put_inner_thoughts_in_kwargs": true
 }

--- a/tests/configs/llm_model_configs/ollama.json
+++ b/tests/configs/llm_model_configs/ollama.json
@@ -2,5 +2,6 @@
     "context_window": 8192,
     "model_endpoint_type": "ollama",
     "model_endpoint": "http://127.0.0.1:11434",
-    "model": "dolphin2.2-mistral:7b-q6_K"
+    "model": "dolphin2.2-mistral:7b-q6_K",
+    "put_inner_thoughts_in_kwargs": true
 }

--- a/tests/helpers/endpoints_helper.py
+++ b/tests/helpers/endpoints_helper.py
@@ -3,11 +3,7 @@ import logging
 import uuid
 from typing import Callable, List, Optional, Union
 
-from letta.llm_api.helpers import (
-    derive_inner_thoughts_in_kwargs,
-    unpack_inner_thoughts_from_kwargs,
-)
-from letta.schemas.enums import OptionState
+from letta.llm_api.helpers import unpack_inner_thoughts_from_kwargs
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -130,10 +126,8 @@ def check_first_response_is_valid_for_llm_endpoint(filename: str) -> ChatComplet
     validator_func = lambda function_call: function_call.name == "send_message" or function_call.name == "archival_memory_search"
     assert_contains_valid_function_call(choice.message, validator_func)
 
-    # Get inner_thoughts_in_kwargs
-    inner_thoughts_in_kwargs = derive_inner_thoughts_in_kwargs(OptionState.DEFAULT, agent_state.llm_config.model)
     # Assert that the message has an inner monologue
-    assert_contains_correct_inner_monologue(choice, inner_thoughts_in_kwargs)
+    assert_contains_correct_inner_monologue(choice, agent_state.llm_config.put_inner_thoughts_in_kwargs)
 
     return response
 


### PR DESCRIPTION
## Description:

Add `put_inner_thoughts_in_kwargs` as a config that can be set by users per LLM config. This reduces the opacity of "deriving" this value or hardcoding this value in logic for different providers in the `create` function. 

## Testing:

Ran `test_endpoints.py` for a variety of LLM configs and confirmed passed.

We also run `poetry run pytest -s -vv tests/test_client.py::test_streaming_send_message` to test the `root_validator`:

> the `root_validator` auto-populates the `put_inner_thoughts_in_kwargs` field with some conditions on the model name. To perform that this works, we note that without the `root_validator`, the `test_streaming_send_message` fails, and with it, it passes, meaning that `gpt-4` has the field correctly set to `False`, not the default `True`. 

Finally, we run letta run with an existing agent to ensure that the llm configs can be correctly loaded in.