### PR TITLE
fix: fix bug triggered by using ada embeddings

### DIFF
--- a/letta/llm_api/openai.py
+++ b/letta/llm_api/openai.py
@@ -314,11 +314,17 @@ def openai_chat_completions_process_stream(
                             for _ in range(len(tool_calls_delta))
                         ]
 
+                    # There may be many tool calls in a tool calls delta (e.g. parallel tool calls)
                     for tool_call_delta in tool_calls_delta:
                         if tool_call_delta.id is not None:
                             # TODO assert that we're not overwriting?
                             # TODO += instead of =?
-                            accum_message.tool_calls[tool_call_delta.index].id = tool_call_delta.id
+                            if tool_call_delta.index not in range(len(accum_message.tool_calls)):
+                                warnings.warn(
+                                    f"Tool call index out of range ({tool_call_delta.index})\ncurrent tool calls: {accum_message.tool_calls}\ncurrent delta: {tool_call_delta}"
+                                )
+                            else:
+                                accum_message.tool_calls[tool_call_delta.index].id = tool_call_delta.id
                         if tool_call_delta.function is not None:
                             if tool_call_delta.function.name is not None:
                                 # TODO assert that we're not overwriting?

--- a/letta/server/rest_api/interface.py
+++ b/letta/server/rest_api/interface.py
@@ -526,7 +526,11 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
                             processed_chunk = FunctionCallMessage(
                                 id=message_id,
                                 date=message_date,
-                                function_call=FunctionCallDelta(name=self.function_name_buffer, arguments=None),
+                                function_call=FunctionCallDelta(
+                                    name=self.function_name_buffer,
+                                    arguments=None,
+                                    function_call_id=tool_call.id,
+                                ),
                             )
                             # Clear the buffer
                             self.function_name_buffer = None
@@ -550,7 +554,11 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
                                 processed_chunk = FunctionCallMessage(
                                     id=message_id,
                                     date=message_date,
-                                    function_call=FunctionCallDelta(name=None, arguments=combined_chunk),
+                                    function_call=FunctionCallDelta(
+                                        name=None,
+                                        arguments=combined_chunk,
+                                        function_call_id=tool_call.id,
+                                    ),
                                 )
                                 # clear buffer
                                 self.function_args_buffer = None
@@ -559,7 +567,11 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
                                 processed_chunk = FunctionCallMessage(
                                     id=message_id,
                                     date=message_date,
-                                    function_call=FunctionCallDelta(name=None, arguments=updates_main_json),
+                                    function_call=FunctionCallDelta(
+                                        name=None,
+                                        arguments=updates_main_json,
+                                        function_call_id=tool_call.id,
+                                    ),
                                 )
 
                         # # If there's something in the main_json buffer, we should add if to the arguments and release it together

--- a/tests/test_stream_buffer_readers.py
+++ b/tests/test_stream_buffer_readers.py
@@ -1,10 +1,12 @@
+import json
+
 import pytest
 
 from letta.streaming_utils import JSONInnerThoughtsExtractor
 
 
 @pytest.mark.parametrize("wait_for_first_key", [True, False])
-def test_inner_thoughts_in_args(wait_for_first_key):
+def test_inner_thoughts_in_args_simple(wait_for_first_key):
     """Test case where the function_delta.arguments contains inner_thoughts
 
     Correct output should be inner_thoughts VALUE (not KEY) being written to one buffer
@@ -17,7 +19,7 @@ def test_inner_thoughts_in_args(wait_for_first_key):
         """"inner_thoughts":"Chad's x2 tradition""",
         " is going strong! 😂 I love the enthusiasm!",
         " Time to delve into something imaginative:",
-        """ If you could swap lives with any fictional character for a day, who would it be?",""",
+        """ If you could swap lives with any fictional character for a day, who would it be?\"""",
         ",",
         """"message":"Here we are again, with 'x2'!""",
         " 🎉 Let's take this chance: If you could swap",
@@ -25,6 +27,9 @@ def test_inner_thoughts_in_args(wait_for_first_key):
         ''' who would it be?"''',
         "}",
     ]
+    print("Basic inner thoughts testcase:", fragments1, "".join(fragments1))
+    # Make sure the string is valid JSON
+    _ = json.loads("".join(fragments1))
 
     if wait_for_first_key:
         # If we're waiting for the first key, then the first opening brace should be buffered/held back
@@ -78,6 +83,99 @@ def test_inner_thoughts_in_args(wait_for_first_key):
         ), f"Test Case 1, Fragment {idx+1}: Inner Thoughts update mismatch.\nExpected: '{expected['inner_thoughts_update']}'\nGot: '{updates_inner_thoughts}'"
 
 
+@pytest.mark.parametrize("wait_for_first_key", [True, False])
+def test_inner_thoughts_in_args_trailing_quote(wait_for_first_key):
+    # Another test case where there's a function call that has a chunk that ends with a double quote
+    print("Running Test Case: chunk ends with double quote")
+    handler1 = JSONInnerThoughtsExtractor(inner_thoughts_key="inner_thoughts", wait_for_first_key=wait_for_first_key)
+    fragments1 = [
+        # 1
+        "{",
+        # 2
+        """\"inner_thoughts\":\"User wants to add 'banana' again for a fourth time; I'll track another addition.""",
+        # 3
+        '",',
+        # 4
+        """\"content\":\"banana""",
+        # 5
+        """\",\"""",
+        # 6
+        """request_heartbeat\":\"""",
+        # 7
+        """true\"""",
+        # 8
+        "}",
+    ]
+    print("Double quote test case:", fragments1, "".join(fragments1))
+    # Make sure the string is valid JSON
+    _ = json.loads("".join(fragments1))
+
+    if wait_for_first_key:
+        # If we're waiting for the first key, then the first opening brace should be buffered/held back
+        # until after the inner thoughts are finished
+        expected_updates1 = [
+            {"main_json_update": "", "inner_thoughts_update": ""},  # Fragment 1 (NOTE: different)
+            {
+                "main_json_update": "",
+                "inner_thoughts_update": "User wants to add 'banana' again for a fourth time; I'll track another addition.",
+            },  # Fragment 2
+            {"main_json_update": "", "inner_thoughts_update": ""},  # Fragment 3
+            {
+                "main_json_update": '{"content":"banana',
+                "inner_thoughts_update": "",
+            },  # Fragment 4
+            {
+                "main_json_update": '","',
+                "inner_thoughts_update": "",
+            },  # Fragment 5
+            {
+                "main_json_update": 'request_heartbeat":"',
+                "inner_thoughts_update": "",
+            },  # Fragment 6
+            {
+                "main_json_update": 'true"',
+                "inner_thoughts_update": "",
+            },  # Fragment 7
+        ]
+    else:
+        pass
+        # If we're not waiting for the first key, then the first opening brace should be written immediately
+        expected_updates1 = [
+            {"main_json_update": "{", "inner_thoughts_update": ""},  # Fragment 1 (NOTE: different)
+            {
+                "main_json_update": "",
+                "inner_thoughts_update": "User wants to add 'banana' again for a fourth time; I'll track another addition.",
+            },  # Fragment 2
+            {"main_json_update": "", "inner_thoughts_update": ""},  # Fragment 3
+            {
+                "main_json_update": '"content":"banana',
+                "inner_thoughts_update": "",
+            },  # Fragment 4
+            {
+                "main_json_update": '","',
+                "inner_thoughts_update": "",
+            },  # Fragment 5
+            {
+                "main_json_update": 'request_heartbeat":"',
+                "inner_thoughts_update": "",
+            },  # Fragment 6
+            {
+                "main_json_update": 'true"',
+                "inner_thoughts_update": "",
+            },  # Fragment 7
+        ]
+
+    for idx, (fragment, expected) in enumerate(zip(fragments1, expected_updates1)):
+        updates_main_json, updates_inner_thoughts = handler1.process_fragment(fragment)
+        # Assertions
+        assert (
+            updates_main_json == expected["main_json_update"]
+        ), f"Test Case 1, Fragment {idx+1}: Main JSON update mismatch.\nExpected: '{expected['main_json_update']}'\nGot: '{updates_main_json}'"
+        assert (
+            updates_inner_thoughts == expected["inner_thoughts_update"]
+        ), f"Test Case 1, Fragment {idx+1}: Inner Thoughts update mismatch.\nExpected: '{expected['inner_thoughts_update']}'\nGot: '{updates_inner_thoughts}'"
+
+
 def test_inner_thoughts_not_in_args():
     """Test case where the function_delta.arguments does not contain inner_thoughts
 
@@ -93,6 +191,9 @@ def test_inner_thoughts_not_in_args():
         ''' who would it be?"''',
         "}",
     ]
+    print("Basic inner thoughts not in kwargs testcase:", fragments2, "".join(fragments2))
+    # Make sure the string is valid JSON
+    _ = json.loads("".join(fragments2))
 
     expected_updates2 = [
         {"main_json_update": "{", "inner_thoughts_update": ""},  # Fragment 1

--- a/tests/test_stream_buffer_readers.py
+++ b/tests/test_stream_buffer_readers.py
@@ -125,17 +125,23 @@ def test_inner_thoughts_in_args_trailing_quote(wait_for_first_key):
                 "inner_thoughts_update": "",
             },  # Fragment 4
             {
-                "main_json_update": '","',
+                # "main_json_update": '","',
+                "main_json_update": '",',
                 "inner_thoughts_update": "",
             },  # Fragment 5
             {
-                "main_json_update": 'request_heartbeat":"',
+                # "main_json_update": 'request_heartbeat":"',
+                "main_json_update": '"request_heartbeat":"',
                 "inner_thoughts_update": "",
             },  # Fragment 6
             {
                 "main_json_update": 'true"',
                 "inner_thoughts_update": "",
             },  # Fragment 7
+            {
+                "main_json_update": "}",
+                "inner_thoughts_update": "",
+            },  # Fragment 8
         ]
     else:
         pass
@@ -152,28 +158,42 @@ def test_inner_thoughts_in_args_trailing_quote(wait_for_first_key):
                 "inner_thoughts_update": "",
             },  # Fragment 4
             {
-                "main_json_update": '","',
+                # "main_json_update": '","',
+                "main_json_update": '",',
                 "inner_thoughts_update": "",
             },  # Fragment 5
             {
-                "main_json_update": 'request_heartbeat":"',
+                # "main_json_update": 'request_heartbeat":"',
+                "main_json_update": '"request_heartbeat":"',
                 "inner_thoughts_update": "",
             },  # Fragment 6
             {
                 "main_json_update": 'true"',
                 "inner_thoughts_update": "",
             },  # Fragment 7
+            {
+                "main_json_update": "}",
+                "inner_thoughts_update": "",
+            },  # Fragment 8
         ]
 
+    current_inner_thoughts = ""
+    current_main_json = ""
     for idx, (fragment, expected) in enumerate(zip(fragments1, expected_updates1)):
         updates_main_json, updates_inner_thoughts = handler1.process_fragment(fragment)
         # Assertions
         assert (
             updates_main_json == expected["main_json_update"]
-        ), f"Test Case 1, Fragment {idx+1}: Main JSON update mismatch.\nExpected: '{expected['main_json_update']}'\nGot: '{updates_main_json}'"
+        ), f"Test Case 1, Fragment {idx+1}: Main JSON update mismatch.\nFragment: '{fragment}'\nExpected: '{expected['main_json_update']}'\nGot: '{updates_main_json}'\nCurrent JSON: '{current_main_json}'\nCurrent Inner Thoughts: '{current_inner_thoughts}'"
         assert (
             updates_inner_thoughts == expected["inner_thoughts_update"]
-        ), f"Test Case 1, Fragment {idx+1}: Inner Thoughts update mismatch.\nExpected: '{expected['inner_thoughts_update']}'\nGot: '{updates_inner_thoughts}'"
+        ), f"Test Case 1, Fragment {idx+1}: Inner Thoughts update mismatch.\nExpected: '{expected['inner_thoughts_update']}'\nGot: '{updates_inner_thoughts}'\nCurrent JSON: '{current_main_json}'\nCurrent Inner Thoughts: '{current_inner_thoughts}'"
+        current_main_json += updates_main_json
+        current_inner_thoughts += updates_inner_thoughts
+
+    print(f"Final JSON: '{current_main_json}'")
+    print(f"Final Inner Thoughts: '{current_inner_thoughts}'")
+    _ = json.loads(current_main_json)
 
 
 def test_inner_thoughts_not_in_args():


### PR DESCRIPTION
To reproduce bug:
1. Open ADE, create agent w/ `gpt-4o-mini` backend + `text-embeddings-ada-002` embeddings backend
2. Ask agent to `add "banana" to your archival memory`
3. Error should trigger server side (on the client, the message will just stall after the inner thoughts)

<img width="1583" alt="image" src="https://github.com/user-attachments/assets/51012932-ac20-4288-982f-b3fd988ea3ca">

```sh
Task exception was never retrieved
future: <Task finished name='Task-25' coro=<to_thread() done, defined at /Users/loaner/miniconda3/lib/python3.10/asyncio/threads.py:12> exception=1 validation error for FunctionCallDelta
function_call_id
  Field required [type=missing, input_value={'name': 'archival_memory...ert', 'arguments': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.9/v/missing>
Traceback (most recent call last):
  File "/Users/loaner/miniconda3/lib/python3.10/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
  File "/Users/loaner/miniconda3/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/loaner/dev/MemGPT-fresh/letta/server/server.py", line 737, in send_messages
    return self._step(user_id=user_id, agent_id=agent_id, input_messages=message_objects)
  File "/Users/loaner/dev/MemGPT-fresh/letta/server/server.py", line 430, in _step
    usage_stats = letta_agent.step(
  File "/Users/loaner/dev/MemGPT-fresh/letta/agent.py", line 749, in step
    step_response = self.inner_step(
  File "/Users/loaner/dev/MemGPT-fresh/letta/agent.py", line 958, in inner_step
    raise e
  File "/Users/loaner/dev/MemGPT-fresh/letta/agent.py", line 874, in inner_step
    response = self._get_ai_reply(
  File "/Users/loaner/dev/MemGPT-fresh/letta/agent.py", line 501, in _get_ai_reply
    raise e
  File "/Users/loaner/dev/MemGPT-fresh/letta/agent.py", line 472, in _get_ai_reply
    response = create(
  File "/Users/loaner/dev/MemGPT-fresh/letta/llm_api/llm_api_tools.py", line 97, in wrapper
    raise e
  File "/Users/loaner/dev/MemGPT-fresh/letta/llm_api/llm_api_tools.py", line 66, in wrapper
    return func(*args, **kwargs)
  File "/Users/loaner/dev/MemGPT-fresh/letta/llm_api/llm_api_tools.py", line 149, in create
    response = openai_chat_completions_process_stream(
  File "/Users/loaner/dev/MemGPT-fresh/letta/llm_api/openai.py", line 348, in openai_chat_completions_process_stream
    raise e
  File "/Users/loaner/dev/MemGPT-fresh/letta/llm_api/openai.py", line 262, in openai_chat_completions_process_stream
    stream_interface.process_chunk(
  File "/Users/loaner/dev/MemGPT-fresh/letta/server/rest_api/interface.py", line 773, in process_chunk
    processed_chunk = self._process_chunk_to_letta_style(chunk=chunk, message_id=message_id, message_date=message_date)
  File "/Users/loaner/dev/MemGPT-fresh/letta/server/rest_api/interface.py", line 529, in _process_chunk_to_letta_style
    function_call=FunctionCallDelta(name=self.function_name_buffer, arguments=None),
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/letta-JSsUGnlY-py3.10/lib/python3.10/site-packages/pydantic/main.py", line 212, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for FunctionCallDelta
function_call_id
  Field required [type=missing, input_value={'name': 'archival_memory...ert', 'arguments': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.9/v/missing
```
