### PR TITLE
feat: Enable base constructs to automatically populate "created_by" and "last_updated_by" fields for relevant objects

### DIFF
--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -219,7 +219,8 @@ def run(
 
         # create agent
         tools = [
-            server.tool_manager.get_tool_by_name_and_org_id(tool_name=tool_name, org_id=client.org_id) for tool_name in agent_state.tools
+            server.tool_manager.get_tool_by_name_and_org_id(tool_name=tool_name, organization_id=client.org_id)
+            for tool_name in agent_state.tools
         ]
         letta_agent = Agent(agent_state=agent_state, interface=interface(), tools=tools)
 
@@ -300,7 +301,9 @@ def run(
         )
         assert isinstance(agent_state.memory, Memory), f"Expected Memory, got {type(agent_state.memory)}"
         typer.secho(f"->  🛠️  {len(agent_state.tools)} tools: {', '.join([t for t in agent_state.tools])}", fg=typer.colors.WHITE)
-        tools = [server.tool_manager.get_tool_by_name_and_org_id(tool_name, org_id=client.org_id) for tool_name in agent_state.tools]
+        tools = [
+            server.tool_manager.get_tool_by_name_and_org_id(tool_name, organization_id=client.org_id) for tool_name in agent_state.tools
+        ]
 
         letta_agent = Agent(
             interface=interface(),

--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -219,7 +219,7 @@ def run(
 
         # create agent
         tools = [
-            server.tool_manager.get_tool_by_name_and_user_id(tool_name=tool_name, user_id=client.user_id) for tool_name in agent_state.tools
+            server.tool_manager.get_tool_by_name_and_org_id(tool_name=tool_name, org_id=client.org_id) for tool_name in agent_state.tools
         ]
         letta_agent = Agent(agent_state=agent_state, interface=interface(), tools=tools)
 
@@ -300,7 +300,7 @@ def run(
         )
         assert isinstance(agent_state.memory, Memory), f"Expected Memory, got {type(agent_state.memory)}"
         typer.secho(f"->  🛠️  {len(agent_state.tools)} tools: {', '.join([t for t in agent_state.tools])}", fg=typer.colors.WHITE)
-        tools = [server.tool_manager.get_tool_by_name_and_user_id(tool_name, user_id=client.user_id) for tool_name in agent_state.tools]
+        tools = [server.tool_manager.get_tool_by_name_and_org_id(tool_name, org_id=client.org_id) for tool_name in agent_state.tools]
 
         letta_agent = Agent(
             interface=interface(),

--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -218,10 +218,7 @@ def run(
         )
 
         # create agent
-        tools = [
-            server.tool_manager.get_tool_by_name_and_org_id(tool_name=tool_name, organization_id=client.org_id)
-            for tool_name in agent_state.tools
-        ]
+        tools = [server.tool_manager.get_tool_by_name(tool_name=tool_name, actor=client.user) for tool_name in agent_state.tools]
         letta_agent = Agent(agent_state=agent_state, interface=interface(), tools=tools)
 
     else:  # create new agent
@@ -301,9 +298,7 @@ def run(
         )
         assert isinstance(agent_state.memory, Memory), f"Expected Memory, got {type(agent_state.memory)}"
         typer.secho(f"->  🛠️  {len(agent_state.tools)} tools: {', '.join([t for t in agent_state.tools])}", fg=typer.colors.WHITE)
-        tools = [
-            server.tool_manager.get_tool_by_name_and_org_id(tool_name, organization_id=client.org_id) for tool_name in agent_state.tools
-        ]
+        tools = [server.tool_manager.get_tool_by_name(tool_name, actor=client.user) for tool_name in agent_state.tools]
 
         letta_agent = Agent(
             interface=interface(),

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2198,7 +2198,6 @@ class LocalClient(AbstractClient):
     def load_langchain_tool(self, langchain_tool: "LangChainBaseTool", additional_imports_module_attr_map: dict[str, str] = None) -> Tool:
         tool_create = ToolCreate.from_langchain(
             langchain_tool=langchain_tool,
-            user_id=self.user_id,
             organization_id=self.org_id,
             additional_imports_module_attr_map=additional_imports_module_attr_map,
         )
@@ -2208,13 +2207,12 @@ class LocalClient(AbstractClient):
         tool_create = ToolCreate.from_crewai(
             crewai_tool=crewai_tool,
             additional_imports_module_attr_map=additional_imports_module_attr_map,
-            user_id=self.user_id,
             organization_id=self.org_id,
         )
         return self.server.tool_manager.create_or_update_tool(tool_create)
 
     def load_composio_tool(self, action: "ActionType") -> Tool:
-        tool_create = ToolCreate.from_composio(action=action, user_id=self.user_id, organization_id=self.org_id)
+        tool_create = ToolCreate.from_composio(action=action, organization_id=self.org_id)
         return self.server.tool_manager.create_or_update_tool(tool_create)
 
     # TODO: Use the above function `add_tool` here as there is duplicate logic

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2204,7 +2204,7 @@ class LocalClient(AbstractClient):
             organization_id=self.org_id,
             additional_imports_module_attr_map=additional_imports_module_attr_map,
         )
-        return self.server.tool_manager.create_or_update_tool(tool_create, user_id=self.user_id)
+        return self.server.tool_manager.create_or_update_tool(tool_create, actor=self.user)
 
     def load_crewai_tool(self, crewai_tool: "CrewAIBaseTool", additional_imports_module_attr_map: dict[str, str] = None) -> Tool:
         tool_create = ToolCreate.from_crewai(
@@ -2212,11 +2212,11 @@ class LocalClient(AbstractClient):
             additional_imports_module_attr_map=additional_imports_module_attr_map,
             organization_id=self.org_id,
         )
-        return self.server.tool_manager.create_or_update_tool(tool_create, user_id=self.user_id)
+        return self.server.tool_manager.create_or_update_tool(tool_create, actor=self.user)
 
     def load_composio_tool(self, action: "ActionType") -> Tool:
         tool_create = ToolCreate.from_composio(action=action, organization_id=self.org_id)
-        return self.server.tool_manager.create_or_update_tool(tool_create, user_id=self.user_id)
+        return self.server.tool_manager.create_or_update_tool(tool_create, actor=self.user)
 
     # TODO: Use the above function `add_tool` here as there is duplicate logic
     def create_tool(
@@ -2257,7 +2257,7 @@ class LocalClient(AbstractClient):
                 tags=tags,
                 terminal=terminal,
             ),
-            user_id=self.user_id,
+            actor=self.user,
         )
 
     def update_tool(
@@ -2289,7 +2289,7 @@ class LocalClient(AbstractClient):
         # Filter out any None values from the dictionary
         update_data = {key: value for key, value in update_data.items() if value is not None}
 
-        return self.server.tool_manager.update_tool_by_id(id, self.user_id, ToolUpdate(**update_data))
+        return self.server.tool_manager.update_tool_by_id(tool_id=id, tool_update=ToolUpdate(**update_data), actor=self.user)
 
     def list_tools(self, cursor: Optional[str] = None, limit: Optional[int] = 50) -> List[Tool]:
         """
@@ -2310,7 +2310,7 @@ class LocalClient(AbstractClient):
         Returns:
             tool (Tool): Tool
         """
-        return self.server.tool_manager.get_tool_by_id(id)
+        return self.server.tool_manager.get_tool_by_id(id, actor=self.user)
 
     def delete_tool(self, id: str):
         """

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2201,7 +2201,7 @@ class LocalClient(AbstractClient):
             organization_id=self.org_id,
             additional_imports_module_attr_map=additional_imports_module_attr_map,
         )
-        return self.server.tool_manager.create_or_update_tool(tool_create)
+        return self.server.tool_manager.create_or_update_tool(tool_create, user_id=self.user_id)
 
     def load_crewai_tool(self, crewai_tool: "CrewAIBaseTool", additional_imports_module_attr_map: dict[str, str] = None) -> Tool:
         tool_create = ToolCreate.from_crewai(
@@ -2209,11 +2209,11 @@ class LocalClient(AbstractClient):
             additional_imports_module_attr_map=additional_imports_module_attr_map,
             organization_id=self.org_id,
         )
-        return self.server.tool_manager.create_or_update_tool(tool_create)
+        return self.server.tool_manager.create_or_update_tool(tool_create, user_id=self.user_id)
 
     def load_composio_tool(self, action: "ActionType") -> Tool:
         tool_create = ToolCreate.from_composio(action=action, organization_id=self.org_id)
-        return self.server.tool_manager.create_or_update_tool(tool_create)
+        return self.server.tool_manager.create_or_update_tool(tool_create, user_id=self.user_id)
 
     # TODO: Use the above function `add_tool` here as there is duplicate logic
     def create_tool(

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -1546,6 +1546,9 @@ class LocalClient(AbstractClient):
             # get default user
             self.user_id = self.server.user_manager.DEFAULT_USER_ID
 
+        self.user = self.server.get_user_or_default(self.user_id)
+        self.organization = self.server.get_organization_or_default(self.org_id)
+
     # agents
     def list_agents(self) -> List[AgentState]:
         self.interface.clear()
@@ -1648,7 +1651,7 @@ class LocalClient(AbstractClient):
                 llm_config=llm_config if llm_config else self._default_llm_config,
                 embedding_config=embedding_config if embedding_config else self._default_embedding_config,
             ),
-            user_id=self.user_id,
+            actor=self.user,
         )
         return agent_state
 
@@ -1720,7 +1723,7 @@ class LocalClient(AbstractClient):
                 message_ids=message_ids,
                 memory=memory,
             ),
-            user_id=self.user_id,
+            actor=self.user,
         )
         return agent_state
 
@@ -2248,7 +2251,6 @@ class LocalClient(AbstractClient):
         # call server function
         return self.server.tool_manager.create_or_update_tool(
             ToolCreate(
-                organization_id=self.org_id,
                 source_type=source_type,
                 source_code=source_code,
                 name=name,
@@ -2296,7 +2298,7 @@ class LocalClient(AbstractClient):
         Returns:
             tools (List[Tool]): List of tools
         """
-        return self.server.tool_manager.list_tools_for_org(cursor=cursor, limit=limit, organization_id=self.org_id)
+        return self.server.tool_manager.list_tools(cursor=cursor, limit=limit, actor=self.user)
 
     def get_tool(self, id: str) -> Optional[Tool]:
         """
@@ -2329,7 +2331,7 @@ class LocalClient(AbstractClient):
         Returns:
             id (str): ID of the tool (`None` if not found)
         """
-        tool = self.server.tool_manager.get_tool_by_name_and_org_id(tool_name=name, organization_id=self.org_id)
+        tool = self.server.tool_manager.get_tool_by_name(tool_name=name, actor=self.user)
         return tool.id
 
     def load_data(self, connector: DataConnector, source_name: str):

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2250,7 +2250,6 @@ class LocalClient(AbstractClient):
         # call server function
         return self.server.tool_manager.create_or_update_tool(
             ToolCreate(
-                user_id=self.user_id,
                 organization_id=self.org_id,
                 source_type=source_type,
                 source_code=source_code,
@@ -2258,6 +2257,7 @@ class LocalClient(AbstractClient):
                 tags=tags,
                 terminal=terminal,
             ),
+            user_id=self.user_id,
         )
 
     def update_tool(
@@ -2289,7 +2289,7 @@ class LocalClient(AbstractClient):
         # Filter out any None values from the dictionary
         update_data = {key: value for key, value in update_data.items() if value is not None}
 
-        return self.server.tool_manager.update_tool_by_id(id, ToolUpdate(**update_data))
+        return self.server.tool_manager.update_tool_by_id(id, self.user_id, ToolUpdate(**update_data))
 
     def list_tools(self, cursor: Optional[str] = None, limit: Optional[int] = 50) -> List[Tool]:
         """

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2317,7 +2317,7 @@ class LocalClient(AbstractClient):
         Args:
             id (str): ID of the tool
         """
-        return self.server.tool_manager.delete_tool_by_id(id)
+        return self.server.tool_manager.delete_tool_by_id(id, user_id=self.user_id)
 
     def get_tool_id(self, name: str) -> Optional[str]:
         """

--- a/letta/orm/sqlalchemy_base.py
+++ b/letta/orm/sqlalchemy_base.py
@@ -126,7 +126,10 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
             session.refresh(self)
             return self
 
-    def delete(self, db_session: "Session") -> Type["SqlalchemyBase"]:
+    def delete(self, db_session: "Session", actor_id: Optional[str] = None) -> Type["SqlalchemyBase"]:
+        if actor_id:
+            self._set_created_and_updated_by_fields(actor_id)
+
         self.is_deleted = True
         return self.update(db_session)
 

--- a/letta/orm/sqlalchemy_base.py
+++ b/letta/orm/sqlalchemy_base.py
@@ -140,15 +140,6 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
             session.refresh(self)
             return self
 
-    @classmethod
-    def read_or_create(cls, *, db_session: "Session", **kwargs) -> Type["SqlalchemyBase"]:
-        """get an instance by search criteria or create it if it doesn't exist"""
-        try:
-            return cls.read(db_session=db_session, identifier=kwargs.get("id", None))
-        except NoResultFound:
-            clean_kwargs = {k: v for k, v in kwargs.items() if k in cls.__table__.columns}
-            return cls(**clean_kwargs).create(db_session=db_session)
-
     # TODO: Add back later when access predicates are actually important
     # The idea behind this is that you can add a WHERE clause restricting the actions you can take, e.g. R/W
     # @classmethod

--- a/letta/orm/tool.py
+++ b/letta/orm/tool.py
@@ -5,18 +5,15 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 # TODO everything in functions should live in this model
 from letta.orm.enums import ToolSourceType
-from letta.orm.mixins import OrganizationMixin, UserMixin
+from letta.orm.mixins import OrganizationMixin
 from letta.orm.sqlalchemy_base import SqlalchemyBase
 from letta.schemas.tool import Tool as PydanticTool
 
 if TYPE_CHECKING:
-    pass
-
     from letta.orm.organization import Organization
-    from letta.orm.user import User
 
 
-class Tool(SqlalchemyBase, OrganizationMixin, UserMixin):
+class Tool(SqlalchemyBase, OrganizationMixin):
     """Represents an available tool that the LLM can invoke.
 
     NOTE: polymorphic inheritance makes more sense here as a TODO. We want a superset of tools
@@ -29,10 +26,7 @@ class Tool(SqlalchemyBase, OrganizationMixin, UserMixin):
 
     # Add unique constraint on (name, _organization_id)
     # An organization should not have multiple tools with the same name
-    __table_args__ = (
-        UniqueConstraint("name", "_organization_id", name="uix_name_organization"),
-        UniqueConstraint("name", "_user_id", name="uix_name_user"),
-    )
+    __table_args__ = (UniqueConstraint("name", "_organization_id", name="uix_name_organization"),)
 
     name: Mapped[str] = mapped_column(doc="The display name of the tool.")
     description: Mapped[Optional[str]] = mapped_column(nullable=True, doc="The description of the tool.")
@@ -48,7 +42,4 @@ class Tool(SqlalchemyBase, OrganizationMixin, UserMixin):
     # This was an intentional decision by Sarah
 
     # relationships
-    # TODO: Possibly add in user in the future
-    # This will require some more thought and justification to add this in.
-    user: Mapped["User"] = relationship("User", back_populates="tools", lazy="selectin")
     organization: Mapped["Organization"] = relationship("Organization", back_populates="tools", lazy="selectin")

--- a/letta/orm/user.py
+++ b/letta/orm/user.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -8,7 +8,6 @@ from letta.schemas.user import User as PydanticUser
 
 if TYPE_CHECKING:
     from letta.orm.organization import Organization
-    from letta.orm.tool import Tool
 
 
 class User(SqlalchemyBase, OrganizationMixin):
@@ -21,7 +20,6 @@ class User(SqlalchemyBase, OrganizationMixin):
 
     # relationships
     organization: Mapped["Organization"] = relationship("Organization", back_populates="users")
-    tools: Mapped[List["Tool"]] = relationship("Tool", back_populates="user", cascade="all, delete-orphan")
 
     # TODO: Add this back later potentially
     # agents: Mapped[List["Agent"]] = relationship(

--- a/letta/schemas/tool.py
+++ b/letta/schemas/tool.py
@@ -60,10 +60,6 @@ class Tool(BaseTool):
 
 
 class ToolCreate(LettaBase):
-    organization_id: str = Field(
-        OrganizationManager.DEFAULT_ORG_ID,
-        description="The organization that this tool belongs to. Defaults to the default organization ID.",
-    )
     name: Optional[str] = Field(None, description="The name of the function (auto-generated from source_code if not provided).")
     description: Optional[str] = Field(None, description="The description of the tool.")
     tags: List[str] = Field([], description="Metadata tags.")

--- a/letta/schemas/tool.py
+++ b/letta/schemas/tool.py
@@ -101,7 +101,6 @@ class ToolCreate(LettaBase):
         json_schema = generate_schema_from_args_schema(composio_tool.args_schema, name=wrapper_func_name, description=description)
 
         return cls(
-            organization_id=organization_id,
             name=wrapper_func_name,
             description=description,
             source_type=source_type,
@@ -135,7 +134,6 @@ class ToolCreate(LettaBase):
         json_schema = generate_schema_from_args_schema(langchain_tool.args_schema, name=wrapper_func_name, description=description)
 
         return cls(
-            organization_id=organization_id,
             name=wrapper_func_name,
             description=description,
             source_type=source_type,
@@ -167,7 +165,6 @@ class ToolCreate(LettaBase):
         json_schema = generate_schema_from_args_schema(crewai_tool.args_schema, name=wrapper_func_name, description=description)
 
         return cls(
-            organization_id=organization_id,
             name=wrapper_func_name,
             description=description,
             source_type=source_type,

--- a/letta/schemas/tool.py
+++ b/letta/schemas/tool.py
@@ -11,7 +11,6 @@ from letta.functions.schema_generator import generate_schema_from_args_schema
 from letta.schemas.letta_base import LettaBase
 from letta.schemas.openai.chat_completions import ToolCall
 from letta.services.organization_manager import OrganizationManager
-from letta.services.user_manager import UserManager
 
 
 class BaseTool(LettaBase):
@@ -35,7 +34,6 @@ class Tool(BaseTool):
     description: Optional[str] = Field(None, description="The description of the tool.")
     source_type: Optional[str] = Field(None, description="The type of the source code.")
     module: Optional[str] = Field(None, description="The module of the function.")
-    user_id: str = Field(..., description="The unique identifier of the user associated with the tool.")
     organization_id: str = Field(..., description="The unique identifier of the organization associated with the tool.")
     name: str = Field(..., description="The name of the function.")
     tags: List[str] = Field(..., description="Metadata tags.")
@@ -43,6 +41,10 @@ class Tool(BaseTool):
     # code
     source_code: str = Field(..., description="The source code of the function.")
     json_schema: Dict = Field(default_factory=dict, description="The JSON schema of the function.")
+
+    # metadata fields
+    created_by_id: str = Field(..., description="The id of the user that made this Tool.")
+    last_updated_by_id: str = Field(..., description="The id of the user that made this Tool.")
 
     def to_dict(self):
         """
@@ -58,7 +60,6 @@ class Tool(BaseTool):
 
 
 class ToolCreate(LettaBase):
-    user_id: str = Field(UserManager.DEFAULT_USER_ID, description="The user that this tool belongs to. Defaults to the default user ID.")
     organization_id: str = Field(
         OrganizationManager.DEFAULT_ORG_ID,
         description="The organization that this tool belongs to. Defaults to the default organization ID.",
@@ -75,9 +76,7 @@ class ToolCreate(LettaBase):
     terminal: Optional[bool] = Field(None, description="Whether the tool is a terminal tool (allow requesting heartbeats).")
 
     @classmethod
-    def from_composio(
-        cls, action: "ActionType", user_id: str = UserManager.DEFAULT_USER_ID, organization_id: str = OrganizationManager.DEFAULT_ORG_ID
-    ) -> "ToolCreate":
+    def from_composio(cls, action: "ActionType", organization_id: str = OrganizationManager.DEFAULT_ORG_ID) -> "ToolCreate":
         """
         Class method to create an instance of Letta-compatible Composio Tool.
         Check https://docs.composio.dev/introduction/intro/overview to look at options for from_composio
@@ -106,7 +105,6 @@ class ToolCreate(LettaBase):
         json_schema = generate_schema_from_args_schema(composio_tool.args_schema, name=wrapper_func_name, description=description)
 
         return cls(
-            user_id=user_id,
             organization_id=organization_id,
             name=wrapper_func_name,
             description=description,
@@ -121,7 +119,6 @@ class ToolCreate(LettaBase):
         cls,
         langchain_tool: "LangChainBaseTool",
         additional_imports_module_attr_map: dict[str, str] = None,
-        user_id: str = UserManager.DEFAULT_USER_ID,
         organization_id: str = OrganizationManager.DEFAULT_ORG_ID,
     ) -> "ToolCreate":
         """
@@ -142,7 +139,6 @@ class ToolCreate(LettaBase):
         json_schema = generate_schema_from_args_schema(langchain_tool.args_schema, name=wrapper_func_name, description=description)
 
         return cls(
-            user_id=user_id,
             organization_id=organization_id,
             name=wrapper_func_name,
             description=description,
@@ -157,7 +153,6 @@ class ToolCreate(LettaBase):
         cls,
         crewai_tool: "CrewAIBaseTool",
         additional_imports_module_attr_map: dict[str, str] = None,
-        user_id: str = UserManager.DEFAULT_USER_ID,
         organization_id: str = OrganizationManager.DEFAULT_ORG_ID,
     ) -> "ToolCreate":
         """
@@ -176,7 +171,6 @@ class ToolCreate(LettaBase):
         json_schema = generate_schema_from_args_schema(crewai_tool.args_schema, name=wrapper_func_name, description=description)
 
         return cls(
-            user_id=user_id,
             organization_id=organization_id,
             name=wrapper_func_name,
             description=description,

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -84,7 +84,7 @@ def create_agent(
     blocks = agent.memory.get_blocks()
     agent.memory = BasicBlockMemory(blocks=blocks)
 
-    return server.create_agent(agent, user_id=actor.id)
+    return server.create_agent(agent, actor=actor)
 
 
 @router.patch("/{agent_id}", response_model=AgentState, operation_id="update_agent")
@@ -96,9 +96,7 @@ def update_agent(
 ):
     """Update an exsiting agent"""
     actor = server.get_user_or_default(user_id=user_id)
-
-    update_agent.id = agent_id
-    return server.update_agent(update_agent, user_id=actor.id)
+    return server.update_agent(update_agent, actor=actor)
 
 
 @router.get("/{agent_id}/tools", response_model=List[Tool], operation_id="get_tools_from_agent")

--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -49,7 +49,7 @@ def get_tool_id(
     actor = server.get_user_or_default(user_id=user_id)
 
     try:
-        tool = server.tool_manager.get_tool_by_name_and_org_id(tool_name=tool_name, organization_id=actor.organization_id)
+        tool = server.tool_manager.get_tool_by_name(tool_name=tool_name, actor=actor)
         return tool.id
     except NoResultFound:
         raise HTTPException(status_code=404, detail=f"Tool with name {tool_name} and organization id {actor.organization_id} not found.")
@@ -67,7 +67,7 @@ def list_tools(
     """
     try:
         actor = server.get_user_or_default(user_id=user_id)
-        return server.tool_manager.list_tools_for_org(organization_id=actor.organization_id, cursor=cursor, limit=limit)
+        return server.tool_manager.list_tools(actor=actor, cursor=cursor, limit=limit)
     except Exception as e:
         # Log or print the full exception here for debugging
         print(f"Error occurred: {e}")

--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -86,12 +86,9 @@ def create_tool(
     # Derive user and org id from actor
     actor = server.get_user_or_default(user_id=user_id)
     request.organization_id = actor.organization_id
-    request.user_id = actor.id
 
     # Send request to create the tool
-    return server.tool_manager.create_or_update_tool(
-        tool_create=request,
-    )
+    return server.tool_manager.create_or_update_tool(tool_create=request, user_id=actor.id)
 
 
 @router.patch("/{tool_id}", response_model=Tool, operation_id="update_tool")
@@ -104,4 +101,5 @@ def update_tool(
     """
     Update an existing tool
     """
-    return server.tool_manager.update_tool_by_id(tool_id, request)
+    actor = server.get_user_or_default(user_id=user_id)
+    return server.tool_manager.update_tool_by_id(tool_id, actor.id, request)

--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -26,11 +26,13 @@ def delete_tool(
 def get_tool(
     tool_id: str,
     server: SyncServer = Depends(get_letta_server),
+    user_id: Optional[str] = Header(None, alias="user_id"),  # Extract user_id from header, default to None if not present
 ):
     """
     Get a tool by ID
     """
-    tool = server.tool_manager.get_tool_by_id(tool_id=tool_id)
+    actor = server.get_user_or_default(user_id=user_id)
+    tool = server.tool_manager.get_tool_by_id(tool_id=tool_id, actor=actor)
     if tool is None:
         # return 404 error
         raise HTTPException(status_code=404, detail=f"Tool with id {tool_id} not found.")
@@ -85,10 +87,9 @@ def create_tool(
     """
     # Derive user and org id from actor
     actor = server.get_user_or_default(user_id=user_id)
-    request.organization_id = actor.organization_id
 
     # Send request to create the tool
-    return server.tool_manager.create_or_update_tool(tool_create=request, user_id=actor.id)
+    return server.tool_manager.create_or_update_tool(tool_create=request, actor=actor)
 
 
 @router.patch("/{tool_id}", response_model=Tool, operation_id="update_tool")

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -822,9 +822,9 @@ class SyncServer(Server):
                         source_type=source_type,
                         tags=tags,
                         json_schema=json_schema,
-                        user_id=user_id,
                         organization_id=user.organization_id,
-                    )
+                    ),
+                    user_id=user_id,
                 )
                 tool_objs.append(tool)
                 if not request.tools:

--- a/letta/services/tool_manager.py
+++ b/letta/services/tool_manager.py
@@ -131,12 +131,12 @@ class ToolManager:
             tool.update(db_session=session, actor_id=user_id)
 
     @enforce_types
-    def delete_tool_by_id(self, tool_id: str) -> None:
+    def delete_tool_by_id(self, tool_id: str, user_id: str) -> None:
         """Delete a tool by its ID."""
         with self.session_maker() as session:
             try:
                 tool = ToolModel.read(db_session=session, identifier=tool_id)
-                tool.delete(db_session=session)
+                tool.delete(db_session=session, actor_id=user_id)
             except NoResultFound:
                 raise ValueError(f"Tool with id {tool_id} not found.")
 

--- a/letta/services/tool_manager.py
+++ b/letta/services/tool_manager.py
@@ -9,9 +9,9 @@ from letta.functions.functions import derive_openai_json_schema, load_function_s
 from letta.orm.errors import NoResultFound
 from letta.orm.organization import Organization as OrganizationModel
 from letta.orm.tool import Tool as ToolModel
-from letta.orm.user import User as UserModel
 from letta.schemas.tool import Tool as PydanticTool
 from letta.schemas.tool import ToolCreate, ToolUpdate
+from letta.schemas.user import User as PydanticUser
 from letta.utils import enforce_types
 
 
@@ -25,7 +25,7 @@ class ToolManager:
         self.session_maker = db_context
 
     @enforce_types
-    def create_or_update_tool(self, tool_create: ToolCreate, user_id: str) -> PydanticTool:
+    def create_or_update_tool(self, tool_create: ToolCreate, actor: PydanticUser) -> PydanticTool:
         """Create a new tool based on the ToolCreate schema."""
         # Derive json_schema
         derived_json_schema = tool_create.json_schema or derive_openai_json_schema(tool_create)
@@ -34,93 +34,79 @@ class ToolManager:
         try:
             # NOTE: We use the organization id here
             # This is important, because even if it's a different user, adding the same tool to the org should not happen
-            tool = self.get_tool_by_name_and_org_id(tool_name=derived_name, organization_id=tool_create.organization_id)
+            tool = self.get_tool_by_name(tool_name=derived_name, actor=actor)
             # Put to dict and remove fields that should not be reset
-            update_data = tool_create.model_dump(exclude={"organization_id", "module", "terminal"}, exclude_unset=True)
+            update_data = tool_create.model_dump(exclude={"module", "terminal"}, exclude_unset=True)
             # Remove redundant update fields
             update_data = {key: value for key, value in update_data.items() if getattr(tool, key) != value}
 
             # If there's anything to update
             if update_data:
-                self.update_tool_by_id(tool.id, user_id, ToolUpdate(**update_data))
+                self.update_tool_by_id(tool.id, ToolUpdate(**update_data), actor)
             else:
                 warnings.warn(
-                    f"`create_or_update_tool` was called with user_id={user_id}, organization_id={tool_create.organization_id}, name={tool_create.name}, but found existing tool with nothing to update."
+                    f"`create_or_update_tool` was called with user_id={actor.id}, organization_id={actor.organization_id}, name={tool_create.name}, but found existing tool with nothing to update."
                 )
         except NoResultFound:
             tool_create.json_schema = derived_json_schema
             tool_create.name = derived_name
-            tool = self.create_tool(tool_create, user_id=user_id)
+            tool = self.create_tool(tool_create, actor=actor)
 
         return tool
 
     @enforce_types
-    def create_tool(self, tool_create: ToolCreate, user_id: str) -> PydanticTool:
+    def create_tool(self, tool_create: ToolCreate, actor: PydanticUser) -> PydanticTool:
         """Create a new tool based on the ToolCreate schema."""
         # Create the tool
         with self.session_maker() as session:
             # Include all fields except `terminal` (which is not part of ToolModel) at the moment
             create_data = tool_create.model_dump(exclude={"terminal"})
-            tool = ToolModel(**create_data)  # Unpack everything directly into ToolModel
-            tool.create(session, actor_id=user_id)
+            tool = ToolModel(**create_data, organization_id=actor.organization_id)  # Unpack everything directly into ToolModel
+            tool.create(session, actor=actor)
 
         return tool.to_pydantic()
 
     @enforce_types
-    def get_tool_by_id(self, tool_id: str) -> PydanticTool:
+    def get_tool_by_id(self, tool_id: str, actor: PydanticUser) -> PydanticTool:
         """Fetch a tool by its ID."""
         with self.session_maker() as session:
             try:
                 # Retrieve tool by id using the Tool model's read method
-                tool = ToolModel.read(db_session=session, identifier=tool_id)
+                tool = ToolModel.read(db_session=session, identifier=tool_id, actor=actor)
                 # Convert the SQLAlchemy Tool object to PydanticTool
                 return tool.to_pydantic()
             except NoResultFound:
                 raise ValueError(f"Tool with id {tool_id} not found.")
 
     @enforce_types
-    def get_tool_by_name_and_user_id(self, tool_name: str, user_id: str) -> PydanticTool:
-        """Retrieve a tool by its name and a user_id. We derive the organization from the user, and retrieve that tool."""
+    def get_tool_by_name(self, tool_name: str, actor: PydanticUser):
+        """Retrieve a tool by its name and a user. We derive the organization from the user, and retrieve that tool."""
         with self.session_maker() as session:
-            user = UserModel.read(db_session=session, identifier=user_id).to_pydantic()
-            return self.get_tool_by_name_and_org_id(tool_name, user.organization_id)
+            try:
+                # Retrieve tool by id using the Tool model's read method
+                tool = ToolModel.read(db_session=session, name=tool_name, actor=actor)
+                return tool.to_pydantic()
+            except NoResultFound:
+                raise ValueError(f"Tool with name {tool_name} not found for user with id {actor.id}.")
 
     @enforce_types
-    def get_tool_by_name_and_org_id(self, tool_name: str, organization_id: str) -> PydanticTool:
-        """Retrieve a tool by its name and organization_id."""
-        with self.session_maker() as session:
-            # Use the list method to apply filters
-            results = ToolModel.list(
-                db_session=session, name=tool_name, _organization_id=OrganizationModel.get_uid_from_identifier(organization_id)
-            )
-
-            # Ensure only one result is returned (since there is a unique constraint)
-            if not results:
-                raise NoResultFound(f"Tool with name {tool_name} and organization_id {organization_id} not found.")
-
-            if len(results) > 1:
-                raise RuntimeError(
-                    f"Multiple tools with name {tool_name} and organization_id {organization_id} were found. This is a serious error, and means that our table does not have uniqueness constraints properly set up. Please reach out to the letta development team if you see this error."
-                )
-
-            # Return the single result
-            return results[0]
-
-    @enforce_types
-    def list_tools_for_org(self, organization_id: str, cursor: Optional[str] = None, limit: Optional[int] = 50) -> List[PydanticTool]:
+    def list_tools(self, actor: PydanticUser, cursor: Optional[str] = None, limit: Optional[int] = 50) -> List[PydanticTool]:
         """List all tools with optional pagination using cursor and limit."""
         with self.session_maker() as session:
             tools = ToolModel.list(
-                db_session=session, cursor=cursor, limit=limit, _organization_id=OrganizationModel.get_uid_from_identifier(organization_id)
+                db_session=session,
+                cursor=cursor,
+                limit=limit,
+                _organization_id=OrganizationModel.get_uid_from_identifier(actor.organization_id),
             )
             return [tool.to_pydantic() for tool in tools]
 
     @enforce_types
-    def update_tool_by_id(self, tool_id: str, user_id: str, tool_update: ToolUpdate) -> None:
+    def update_tool_by_id(self, tool_id: str, tool_update: ToolUpdate, actor: PydanticUser) -> None:
         """Update a tool by its ID with the given ToolUpdate object."""
         with self.session_maker() as session:
             # Fetch the tool by ID
-            tool = ToolModel.read(db_session=session, identifier=tool_id)
+            tool = ToolModel.read(db_session=session, identifier=tool_id, actor=actor)
 
             # Update tool attributes with only the fields that were explicitly set
             update_data = tool_update.model_dump(exclude_unset=True, exclude_none=True)
@@ -128,20 +114,20 @@ class ToolManager:
                 setattr(tool, key, value)
 
             # Save the updated tool to the database
-            tool.update(db_session=session, actor_id=user_id)
+            tool.update(db_session=session, actor=actor)
 
     @enforce_types
-    def delete_tool_by_id(self, tool_id: str, user_id: str) -> None:
+    def delete_tool_by_id(self, tool_id: str, actor: PydanticUser) -> None:
         """Delete a tool by its ID."""
         with self.session_maker() as session:
             try:
                 tool = ToolModel.read(db_session=session, identifier=tool_id)
-                tool.delete(db_session=session, actor_id=user_id)
+                tool.delete(db_session=session, actor=actor)
             except NoResultFound:
                 raise ValueError(f"Tool with id {tool_id} not found.")
 
     @enforce_types
-    def add_default_tools(self, user_id: str, org_id: str, module_name="base"):
+    def add_default_tools(self, actor: PydanticUser, module_name="base"):
         """Add default tools in {module_name}.py"""
         full_module_name = f"letta.functions.function_sets.{module_name}"
         try:
@@ -175,7 +161,6 @@ class ToolManager:
                     module=schema["module"],
                     source_code=source_code,
                     json_schema=schema["json_schema"],
-                    organization_id=org_id,
                 ),
-                user_id=user_id,
+                actor=actor,
             )

--- a/letta/services/tool_manager.py
+++ b/letta/services/tool_manager.py
@@ -70,24 +70,17 @@ class ToolManager:
     def get_tool_by_id(self, tool_id: str, actor: PydanticUser) -> PydanticTool:
         """Fetch a tool by its ID."""
         with self.session_maker() as session:
-            try:
-                # Retrieve tool by id using the Tool model's read method
-                tool = ToolModel.read(db_session=session, identifier=tool_id, actor=actor)
-                # Convert the SQLAlchemy Tool object to PydanticTool
-                return tool.to_pydantic()
-            except NoResultFound:
-                raise ValueError(f"Tool with id {tool_id} not found.")
+            # Retrieve tool by id using the Tool model's read method
+            tool = ToolModel.read(db_session=session, identifier=tool_id, actor=actor)
+            # Convert the SQLAlchemy Tool object to PydanticTool
+            return tool.to_pydantic()
 
     @enforce_types
     def get_tool_by_name(self, tool_name: str, actor: PydanticUser):
         """Retrieve a tool by its name and a user. We derive the organization from the user, and retrieve that tool."""
         with self.session_maker() as session:
-            try:
-                # Retrieve tool by id using the Tool model's read method
-                tool = ToolModel.read(db_session=session, name=tool_name, actor=actor)
-                return tool.to_pydantic()
-            except NoResultFound:
-                raise ValueError(f"Tool with name {tool_name} not found for user with id {actor.id}.")
+            tool = ToolModel.read(db_session=session, name=tool_name, actor=actor)
+            return tool.to_pydantic()
 
     @enforce_types
     def list_tools(self, actor: PydanticUser, cursor: Optional[str] = None, limit: Optional[int] = 50) -> List[PydanticTool]:

--- a/letta/services/user_manager.py
+++ b/letta/services/user_manager.py
@@ -85,11 +85,8 @@ class UserManager:
     def get_user_by_id(self, user_id: str) -> PydanticUser:
         """Fetch a user by ID."""
         with self.session_maker() as session:
-            try:
-                user = UserModel.read(db_session=session, identifier=user_id)
-                return user.to_pydantic()
-            except NoResultFound:
-                raise ValueError(f"User with id {user_id} not found.")
+            user = UserModel.read(db_session=session, identifier=user_id)
+            return user.to_pydantic()
 
     @enforce_types
     def get_default_user(self) -> PydanticUser:

--- a/tests/test_local_client.py
+++ b/tests/test_local_client.py
@@ -135,8 +135,8 @@ def test_agent_add_remove_tools(client: LocalClient, agent):
     assert github_tool.id in [t.id for t in tools]
     assert scrape_website_tool.id in [t.id for t in tools]
 
-    # Assert that all combinations of tool_names, tool_user_ids are unique
-    combinations = [(t.name, t.user_id) for t in tools]
+    # Assert that all combinations of tool_names, organization id are unique
+    combinations = [(t.name, t.organization_id) for t in tools]
     assert len(combinations) == len(set(combinations))
 
     # create agent

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -288,9 +288,10 @@ def test_update_tool_multi_user(server: SyncServer, tool_fixture):
 def test_delete_tool_by_id(server: SyncServer, tool_fixture):
     tool = tool_fixture["tool"]
     org = tool_fixture["organization"]
+    user = tool_fixture["user"]
 
     # Delete the tool using the manager method
-    server.tool_manager.delete_tool_by_id(tool.id)
+    server.tool_manager.delete_tool_by_id(tool.id, user.id)
 
     tools = server.tool_manager.list_tools_for_org(organization_id=org.id)
     assert len(tools) == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -79,7 +79,7 @@ def agent_id(server, user_id):
             llm_config=LLMConfig.default_config("gpt-4"),
             embedding_config=EmbeddingConfig.default_config(provider="openai"),
         ),
-        user_id=user_id,
+        actor=server.get_user_or_default(user_id),
     )
     print(f"Created agent\n{agent_state}")
     yield agent_state.id

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -146,7 +146,7 @@ def test_create_agent_tool(client):
     # create agent with tool
     memory = ChatMemory(human="I am a human", persona="You must clear your memory if the human instructs you")
     agent = client.create_agent(name=test_agent_name, tools=[tool.name], memory=memory)
-    assert str(tool.user_id) == str(agent.user_id), f"Expected {tool.user_id} to be {agent.user_id}"
+    assert str(tool.created_by_id) == str(agent.user_id), f"Expected {tool.user_id} to be {agent.user_id}"
 
     # initial memory
     initial_memory = client.get_in_context_memory(agent.id)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -146,7 +146,7 @@ def test_create_agent_tool(client):
     # create agent with tool
     memory = ChatMemory(human="I am a human", persona="You must clear your memory if the human instructs you")
     agent = client.create_agent(name=test_agent_name, tools=[tool.name], memory=memory)
-    assert str(tool.created_by_id) == str(agent.user_id), f"Expected {tool.user_id} to be {agent.user_id}"
+    assert str(tool.created_by_id) == str(agent.user_id), f"Expected {tool.created_by_id} to be {agent.user_id}"
 
     # initial memory
     initial_memory = client.get_in_context_memory(agent.id)


### PR DESCRIPTION
## Description:

Enable base constructs to automatically populate "created_by" and "last_updated_by" fields for relevant objects. We apply this to Tools, but this will set the foundation for future ORM refactors.

We also change it so we thread the entire actor (`User`) through the requests - this simplifies the API, and also allows us to do some simple access predicate checking where we confirm the actor of the request belongs to the organization the object (Tool, Agent) is associated with.

## Testing:

Ensured existing tests pass and added a new test case:

- Confirms that if multiple users on the same org, and a different user edits the Tool, then the `last_updated_by` field is updated but `created_by` is not