### PR TITLE
feat: move docker run command to use port 8283

### DIFF
--- a/.github/workflows/docker-integration-tests.yaml
+++ b/.github/workflows/docker-integration-tests.yaml
@@ -41,7 +41,7 @@ jobs:
     #    install-args: "--all-extras"
 
     - name: Wait for service
-      run: bash scripts/wait_for_service.sh http://localhost:8083 -- echo "Service is ready"
+      run: bash scripts/wait_for_service.sh http://localhost:8283 -- echo "Service is ready"
 
     - name: Run tests with pytest
       env:

--- a/.github/workflows/docker-integration-tests.yaml
+++ b/.github/workflows/docker-integration-tests.yaml
@@ -50,7 +50,7 @@ jobs:
         LETTA_PG_PASSWORD: letta
         LETTA_PG_PORT: 8888
         LETTA_SERVER_PASS: test_server_token
-        LETTA_SERVER_URL: http://localhost:8083
+        LETTA_SERVER_URL: http://localhost:8283
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         PYTHONPATH: ${{ github.workspace }}:${{ env.PYTHONPATH }}
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 COPY ./letta /letta
 
-EXPOSE 8083
+EXPOSE 8283
 
 CMD ./letta/server/startup.sh
 

--- a/docker-compose-vllm.yaml
+++ b/docker-compose-vllm.yaml
@@ -4,7 +4,7 @@ services:
   letta:
     image: lettaai/letta:latest
     ports:
-      - "8083:8083"
+      - "8283:8283"
     environment:
       - LETTA_LLM_ENDPOINT=http://vllm:8000
       - LETTA_LLM_ENDPOINT_TYPE=vllm

--- a/letta/server/startup.sh
+++ b/letta/server/startup.sh
@@ -2,7 +2,7 @@
 echo "Starting MEMGPT server..."
 if [ "$MEMGPT_ENVIRONMENT" = "DEVELOPMENT" ] ; then
     echo "Starting in development mode!"
-    uvicorn letta.server.rest_api.app:app --reload --reload-dir /letta --host 0.0.0.0 --port 8083
+    uvicorn letta.server.rest_api.app:app --reload --reload-dir /letta --host 0.0.0.0 --port 8283
 else
-    uvicorn letta.server.rest_api.app:app --host 0.0.0.0 --port 8083
+    uvicorn letta.server.rest_api.app:app --host 0.0.0.0 --port 8283
 fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,12 +4,12 @@ http {
     server {
         listen 80;
         listen [::]:80;
-        listen 8083;
-        listen [::]:8083;
+        listen 8283;
+        listen [::]:8283;
         listen 8283;
         listen [::]:8283;
         server_name letta.localhost;
-        set $api_target "http://letta-server:8083";
+        set $api_target "http://letta-server:8283";
         location / {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
You can now spin up letta with 
```
> docker run lettaai/letta:latest

Starting MEMGPT server...
Initializing database...
uvicorn.error - INFO - Started server process [8]
uvicorn.error - INFO - Waiting for application startup.
/app/.venv/lib/python3.12/site-packages/pydantic/json_schema.py:2191: PydanticJsonSchemaWarning: Default value <property object at 0xffff886c54e0> is not JSON serializable; excluding default from JSON schema [non-serializable-default]
  warnings.warn(message, PydanticJsonSchemaWarning)
uvicorn.error - INFO - Application startup complete.
uvicorn.error - INFO - Uvicorn running on http://0.0.0.0:8283 (Press CTRL+C to quit)
```