### PR TITLE
fix: stop running the PR title validation on main, only on PRs

### DIFF
--- a/.github/workflows/code_style_checks.yml
+++ b/.github/workflows/code_style_checks.yml
@@ -28,6 +28,7 @@ jobs:
         install-args: "-E dev -E postgres -E milvus -E external-tools -E tests"  # Adjust as necessary
 
     - name: Validate PR Title
+      if: github.event_name == 'pull_request'
       uses: amannn/action-semantic-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trying to patch failing tests on main