### PR TITLE
chore: Move ID generation logic out of the ORM layer and into the Pydantic model layer

### DIFF
--- a/alembic/versions/91b25c1cb0ae_reset_id_field_to_old_ids.py
+++ b/alembic/versions/91b25c1cb0ae_reset_id_field_to_old_ids.py
@@ -1,0 +1,69 @@
+"""Reset id field to old ids
+
+Revision ID: 91b25c1cb0ae
+Revises: eff245f340f9
+Create Date: 2024-11-05 11:07:49.862962
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "91b25c1cb0ae"
+down_revision: Union[str, None] = "eff245f340f9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop foreign keys that depend on `_id` in `organization`
+    op.drop_constraint("tool__organization_id_fkey", "tool", type_="foreignkey")
+    op.drop_constraint("user__organization_id_fkey", "user", type_="foreignkey")
+
+    # Add new `id` column with unique constraint and drop `_id` column in `organization`
+    op.add_column("organization", sa.Column("id", sa.String(), nullable=False))
+    op.create_unique_constraint("uq_organization_id", "organization", ["id"])
+    op.drop_column("organization", "_id")
+
+    # Modify `tool` table to use new `organization_id` with updated foreign key
+    op.add_column("tool", sa.Column("id", sa.String(), nullable=False))
+    op.add_column("tool", sa.Column("organization_id", sa.String(), nullable=False))
+    op.drop_column("tool", "_id")
+    op.drop_column("tool", "_organization_id")
+    op.create_foreign_key(None, "tool", "organization", ["organization_id"], ["id"])
+
+    # Modify `user` table to use new `organization_id` with updated foreign key
+    op.add_column("user", sa.Column("id", sa.String(), nullable=False))
+    op.add_column("user", sa.Column("organization_id", sa.String(), nullable=False))
+    op.drop_column("user", "_id")
+    op.drop_column("user", "_organization_id")
+    op.create_foreign_key(None, "user", "organization", ["organization_id"], ["id"])
+
+
+def downgrade() -> None:
+    # Drop foreign keys that depend on `organization_id` in `organization`
+    op.drop_constraint(None, "tool", type_="foreignkey")
+    op.drop_constraint(None, "user", type_="foreignkey")
+
+    # Revert changes in `user` table
+    op.add_column("user", sa.Column("_organization_id", sa.VARCHAR(), autoincrement=False, nullable=False))
+    op.add_column("user", sa.Column("_id", sa.VARCHAR(), autoincrement=False, nullable=False))
+    op.drop_column("user", "organization_id")
+    op.drop_column("user", "id")
+    op.create_foreign_key("user__organization_id_fkey", "user", "organization", ["_organization_id"], ["_id"])
+
+    # Revert changes in `tool` table
+    op.add_column("tool", sa.Column("_organization_id", sa.VARCHAR(), autoincrement=False, nullable=False))
+    op.add_column("tool", sa.Column("_id", sa.VARCHAR(), autoincrement=False, nullable=False))
+    op.drop_column("tool", "organization_id")
+    op.drop_column("tool", "id")
+    op.create_foreign_key("tool__organization_id_fkey", "tool", "organization", ["_organization_id"], ["_id"])
+
+    # Revert changes in `organization` table
+    op.add_column("organization", sa.Column("_id", sa.VARCHAR(), autoincrement=False, nullable=False))
+    op.drop_constraint("uq_organization_id", "organization", type_="unique")
+    op.drop_column("organization", "id")

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2267,18 +2267,18 @@ class LocalClient(AbstractClient):
             langchain_tool=langchain_tool,
             additional_imports_module_attr_map=additional_imports_module_attr_map,
         )
-        return self.server.tool_manager.create_or_update_tool(tool_create, actor=self.user)
+        return self.server.tool_manager.create_or_update_tool(pydantic_tool=Tool(**tool_create.model_dump()), actor=self.user)
 
     def load_crewai_tool(self, crewai_tool: "CrewAIBaseTool", additional_imports_module_attr_map: dict[str, str] = None) -> Tool:
         tool_create = ToolCreate.from_crewai(
             crewai_tool=crewai_tool,
             additional_imports_module_attr_map=additional_imports_module_attr_map,
         )
-        return self.server.tool_manager.create_or_update_tool(tool_create, actor=self.user)
+        return self.server.tool_manager.create_or_update_tool(pydantic_tool=Tool(**tool_create.model_dump()), actor=self.user)
 
     def load_composio_tool(self, action: "ActionType") -> Tool:
         tool_create = ToolCreate.from_composio(action=action)
-        return self.server.tool_manager.create_or_update_tool(tool_create, actor=self.user)
+        return self.server.tool_manager.create_or_update_tool(pydantic_tool=Tool(**tool_create.model_dump()), actor=self.user)
 
     # TODO: Use the above function `add_tool` here as there is duplicate logic
     def create_tool(
@@ -2310,7 +2310,7 @@ class LocalClient(AbstractClient):
 
         # call server function
         return self.server.tool_manager.create_or_update_tool(
-            ToolCreate(
+            Tool(
                 source_type=source_type,
                 source_code=source_code,
                 name=name,
@@ -2738,7 +2738,7 @@ class LocalClient(AbstractClient):
         return self.server.list_embedding_models()
 
     def create_org(self, name: Optional[str] = None) -> Organization:
-        return self.server.organization_manager.create_organization(name=name)
+        return self.server.organization_manager.create_organization(pydantic_org=Organization(name=name))
 
     def list_orgs(self, cursor: Optional[str] = None, limit: Optional[int] = 50) -> List[Organization]:
         return self.server.organization_manager.list_organizations(cursor=cursor, limit=limit)

--- a/letta/orm/base.py
+++ b/letta/orm/base.py
@@ -67,7 +67,7 @@ class CommonSqlalchemyMetaMixins(Base):
         prop_value = getattr(self, full_prop, None)
         if not prop_value:
             return
-        return f"user-{prop_value}"
+        return prop_value
 
     def _user_id_setter(self, prop: str, value: str) -> None:
         """returns the user id for the specified property"""
@@ -75,6 +75,9 @@ class CommonSqlalchemyMetaMixins(Base):
         if not value:
             setattr(self, full_prop, None)
             return
+        # Safety check
         prefix, id_ = value.split("-", 1)
         assert prefix == "user", f"{prefix} is not a valid id prefix for a user id"
-        setattr(self, full_prop, id_)
+
+        # Set the full value
+        setattr(self, full_prop, value)

--- a/letta/orm/mixins.py
+++ b/letta/orm/mixins.py
@@ -1,11 +1,9 @@
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from letta.orm.base import Base
-from letta.orm.errors import MalformedIdError
 
 
 def is_valid_uuid4(uuid_string: str) -> bool:
@@ -17,53 +15,12 @@ def is_valid_uuid4(uuid_string: str) -> bool:
         return False
 
 
-def _relation_getter(instance: "Base", prop: str) -> Optional[str]:
-    """Get relation and return id with prefix as a string."""
-    prefix = prop.replace("_", "")
-    formatted_prop = f"_{prop}_id"
-    try:
-        id_ = getattr(instance, formatted_prop)  # Get the string id directly
-        return f"{prefix}-{id_}"
-    except AttributeError:
-        return None
-
-
-def _relation_setter(instance: "Base", prop: str, value: str) -> None:
-    """Set relation using the id with prefix, ensuring the id is a valid UUIDv4."""
-    formatted_prop = f"_{prop}_id"
-    prefix = prop.replace("_", "")
-    if not value:
-        setattr(instance, formatted_prop, None)
-        return
-    try:
-        found_prefix, id_ = value.split("-", 1)
-    except ValueError as e:
-        raise MalformedIdError(f"{value} is not a valid ID.") from e
-
-    # Ensure prefix matches
-    assert found_prefix == prefix, f"{found_prefix} is not a valid id prefix, expecting {prefix}"
-
-    # Validate that the id is a valid UUID4 string
-    if not is_valid_uuid4(id_):
-        raise MalformedIdError(f"Hash segment of {value} is not a valid UUID4")
-
-    setattr(instance, formatted_prop, id_)  # Store id as a string
-
-
 class OrganizationMixin(Base):
     """Mixin for models that belong to an organization."""
 
     __abstract__ = True
 
-    _organization_id: Mapped[str] = mapped_column(String, ForeignKey("organization._id"))
-
-    @property
-    def organization_id(self) -> str:
-        return _relation_getter(self, "organization")
-
-    @organization_id.setter
-    def organization_id(self, value: str) -> None:
-        _relation_setter(self, "organization", value)
+    organization_id: Mapped[str] = mapped_column(String, ForeignKey("organization.id"))
 
 
 class UserMixin(Base):
@@ -71,12 +28,4 @@ class UserMixin(Base):
 
     __abstract__ = True
 
-    _user_id: Mapped[str] = mapped_column(String, ForeignKey("user._id"))
-
-    @property
-    def user_id(self) -> str:
-        return _relation_getter(self, "user")
-
-    @user_id.setter
-    def user_id(self, value: str) -> None:
-        _relation_setter(self, "user", value)
+    user_id: Mapped[str] = mapped_column(String, ForeignKey("user.id"))

--- a/letta/orm/organization.py
+++ b/letta/orm/organization.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, List
+from uuid import uuid4
 
+from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from letta.orm.sqlalchemy_base import SqlalchemyBase
@@ -17,6 +19,7 @@ class Organization(SqlalchemyBase):
     __tablename__ = "organization"
     __pydantic_model__ = PydanticOrganization
 
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"org-{uuid4()}")
     name: Mapped[str] = mapped_column(doc="The display name of the organization.")
 
     users: Mapped[List["User"]] = relationship("User", back_populates="organization", cascade="all, delete-orphan")

--- a/letta/orm/organization.py
+++ b/letta/orm/organization.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, List
-from uuid import uuid4
 
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -19,7 +18,7 @@ class Organization(SqlalchemyBase):
     __tablename__ = "organization"
     __pydantic_model__ = PydanticOrganization
 
-    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"org-{uuid4()}")
+    id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(doc="The display name of the organization.")
 
     users: Mapped[List["User"]] = relationship("User", back_populates="organization", cascade="all, delete-orphan")

--- a/letta/orm/sqlalchemy_base.py
+++ b/letta/orm/sqlalchemy_base.py
@@ -1,14 +1,11 @@
 from typing import TYPE_CHECKING, List, Literal, Optional, Type
-from uuid import uuid4
 
-from humps import depascalize
 from sqlalchemy import Boolean, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from letta.log import get_logger
 from letta.orm.base import Base, CommonSqlalchemyMetaMixins
 from letta.orm.errors import NoResultFound
-from letta.orm.mixins import is_valid_uuid4
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -24,27 +21,9 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
 
     __order_by_default__ = "created_at"
 
-    _id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"{uuid4()}")
+    id: Mapped[str] = mapped_column(String, primary_key=True)
 
     deleted: Mapped[bool] = mapped_column(Boolean, default=False, doc="Is this record deleted? Used for universal soft deletes.")
-
-    @classmethod
-    def __prefix__(cls) -> str:
-        return depascalize(cls.__name__)
-
-    @property
-    def id(self) -> Optional[str]:
-        if self._id:
-            return f"{self.__prefix__()}-{self._id}"
-
-    @id.setter
-    def id(self, value: str) -> None:
-        if not value:
-            return
-        prefix, id_ = value.split("-", 1)
-        assert prefix == self.__prefix__(), f"{prefix} is not a valid id prefix for {self.__class__.__name__}"
-        assert is_valid_uuid4(id_), f"{id_} is not a valid uuid4"
-        self._id = id_
 
     @classmethod
     def list(
@@ -57,11 +36,10 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
 
             # Add a cursor condition if provided
             if cursor:
-                cursor_uuid = cls.get_uid_from_identifier(cursor)  # Assuming the cursor is an _id value
-                query = query.where(cls._id > cursor_uuid)
+                query = query.where(cls.id > cursor)
 
             # Add a limit to the query if provided
-            query = query.order_by(cls._id).limit(limit)
+            query = query.order_by(cls.id).limit(limit)
 
             # Handle soft deletes if the class has the 'is_deleted' attribute
             if hasattr(cls, "is_deleted"):
@@ -69,20 +47,6 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
 
             # Execute the query and return the results as a list of model instances
             return list(session.execute(query).scalars())
-
-    @classmethod
-    def get_uid_from_identifier(cls, identifier: str, indifferent: Optional[bool] = False) -> str:
-        """converts the id into a uuid object
-        Args:
-            identifier: the string identifier, such as `organization-xxxx-xx...`
-            indifferent: if True, will not enforce the prefix check
-        """
-        try:
-            uuid_string = identifier.split("-", 1)[1] if indifferent else identifier.replace(f"{cls.__prefix__()}-", "")
-            assert is_valid_uuid4(uuid_string)
-            return uuid_string
-        except ValueError as e:
-            raise ValueError(f"{identifier} is not a valid identifier for class {cls.__name__}") from e
 
     @classmethod
     def read(
@@ -112,8 +76,7 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
 
         # If an identifier is provided, add it to the query conditions
         if identifier is not None:
-            identifier = cls.get_uid_from_identifier(identifier)
-            query = query.where(cls._id == identifier)
+            query = query.where(cls.id == identifier)
             query_conditions.append(f"id='{identifier}'")
 
         if kwargs:
@@ -183,7 +146,7 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
         org_id = getattr(actor, "organization_id", None)
         if not org_id:
             raise ValueError(f"object {actor} has no organization accessor")
-        return query.where(cls._organization_id == cls.get_uid_from_identifier(org_id, indifferent=True), cls.is_deleted == False)
+        return query.where(cls.organization_id == org_id, cls.is_deleted == False)
 
     @property
     def __pydantic_model__(self) -> Type["BaseModel"]:

--- a/letta/orm/tool.py
+++ b/letta/orm/tool.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, List, Optional
-from uuid import uuid4
 
 from sqlalchemy import JSON, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -29,7 +28,7 @@ class Tool(SqlalchemyBase, OrganizationMixin):
     # An organization should not have multiple tools with the same name
     __table_args__ = (UniqueConstraint("name", "organization_id", name="uix_name_organization"),)
 
-    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"tool-{uuid4()}")
+    id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(doc="The display name of the tool.")
     description: Mapped[Optional[str]] = mapped_column(nullable=True, doc="The description of the tool.")
     tags: Mapped[List] = mapped_column(JSON, doc="Metadata tags used to filter tools.")

--- a/letta/orm/tool.py
+++ b/letta/orm/tool.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, List, Optional
+from uuid import uuid4
 
 from sqlalchemy import JSON, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -26,8 +27,9 @@ class Tool(SqlalchemyBase, OrganizationMixin):
 
     # Add unique constraint on (name, _organization_id)
     # An organization should not have multiple tools with the same name
-    __table_args__ = (UniqueConstraint("name", "_organization_id", name="uix_name_organization"),)
+    __table_args__ = (UniqueConstraint("name", "organization_id", name="uix_name_organization"),)
 
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"tool-{uuid4()}")
     name: Mapped[str] = mapped_column(doc="The display name of the tool.")
     description: Mapped[Optional[str]] = mapped_column(nullable=True, doc="The description of the tool.")
     tags: Mapped[List] = mapped_column(JSON, doc="Metadata tags used to filter tools.")

--- a/letta/orm/user.py
+++ b/letta/orm/user.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
+from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from letta.orm.mixins import OrganizationMixin
@@ -16,6 +18,7 @@ class User(SqlalchemyBase, OrganizationMixin):
     __tablename__ = "user"
     __pydantic_model__ = PydanticUser
 
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"user-{uuid4()}")
     name: Mapped[str] = mapped_column(nullable=False, doc="The display name of the user.")
 
     # relationships

--- a/letta/orm/user.py
+++ b/letta/orm/user.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -18,7 +17,7 @@ class User(SqlalchemyBase, OrganizationMixin):
     __tablename__ = "user"
     __pydantic_model__ = PydanticUser
 
-    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: f"user-{uuid4()}")
+    id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(nullable=False, doc="The display name of the user.")
 
     # relationships

--- a/letta/schemas/organization.py
+++ b/letta/schemas/organization.py
@@ -8,7 +8,7 @@ from letta.utils import get_utc_time
 
 
 class OrganizationBase(LettaBase):
-    __id_prefix__ = "organization"
+    __id_prefix__ = "org"
 
 
 class Organization(OrganizationBase):

--- a/letta/schemas/organization.py
+++ b/letta/schemas/organization.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic import Field
 
 from letta.schemas.letta_base import LettaBase
-from letta.utils import get_utc_time
+from letta.utils import create_random_username, get_utc_time
 
 
 class OrganizationBase(LettaBase):
@@ -12,8 +12,8 @@ class OrganizationBase(LettaBase):
 
 
 class Organization(OrganizationBase):
-    id: str = Field(..., description="The id of the organization.")
-    name: str = Field(..., description="The name of the organization.")
+    id: str = OrganizationBase.generate_id_field()
+    name: str = Field(create_random_username(), description="The name of the organization.")
     created_at: Optional[datetime] = Field(default_factory=get_utc_time, description="The creation date of the organization.")
 
 

--- a/letta/schemas/tool.py
+++ b/letta/schemas/tool.py
@@ -33,12 +33,12 @@ class Tool(BaseTool):
 
     """
 
-    id: str = Field(..., description="The id of the tool.")
+    id: str = BaseTool.generate_id_field()
     description: Optional[str] = Field(None, description="The description of the tool.")
     source_type: Optional[str] = Field(None, description="The type of the source code.")
     module: Optional[str] = Field(None, description="The module of the function.")
-    organization_id: str = Field(..., description="The unique identifier of the organization associated with the tool.")
-    name: str = Field(..., description="The name of the function.")
+    organization_id: Optional[str] = Field(None, description="The unique identifier of the organization associated with the tool.")
+    name: Optional[str] = Field(None, description="The name of the function.")
     tags: List[str] = Field(..., description="Metadata tags.")
 
     # code
@@ -46,8 +46,8 @@ class Tool(BaseTool):
     json_schema: Dict = Field(default_factory=dict, description="The JSON schema of the function.")
 
     # metadata fields
-    created_by_id: str = Field(..., description="The id of the user that made this Tool.")
-    last_updated_by_id: str = Field(..., description="The id of the user that made this Tool.")
+    created_by_id: Optional[str] = Field(None, description="The id of the user that made this Tool.")
+    last_updated_by_id: Optional[str] = Field(None, description="The id of the user that made this Tool.")
 
     def to_dict(self):
         """

--- a/letta/schemas/user.py
+++ b/letta/schemas/user.py
@@ -21,7 +21,7 @@ class User(UserBase):
         created_at (datetime): The creation date of the user.
     """
 
-    id: str = Field(..., description="The id of the user.")
+    id: str = UserBase.generate_id_field()
     organization_id: Optional[str] = Field(OrganizationManager.DEFAULT_ORG_ID, description="The organization id of the user")
     name: str = Field(..., description="The name of the user.")
     created_at: Optional[datetime] = Field(default_factory=datetime.utcnow, description="The creation date of the user.")

--- a/letta/server/rest_api/routers/v1/organizations.py
+++ b/letta/server/rest_api/routers/v1/organizations.py
@@ -38,7 +38,8 @@ def create_org(
     """
     Create a new org in the database
     """
-    org = server.organization_manager.create_organization(name=request.name)
+    org = Organization(**request.model_dump())
+    org = server.organization_manager.create_organization(pydantic_org=org)
     return org
 
 

--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -89,7 +89,8 @@ def create_tool(
     actor = server.get_user_or_default(user_id=user_id)
 
     # Send request to create the tool
-    return server.tool_manager.create_or_update_tool(tool_create=request, actor=actor)
+    tool = Tool(**request.model_dump())
+    return server.tool_manager.create_or_update_tool(pydantic_tool=tool, actor=actor)
 
 
 @router.patch("/{tool_id}", response_model=Tool, operation_id="update_tool")

--- a/letta/server/rest_api/routers/v1/users.py
+++ b/letta/server/rest_api/routers/v1/users.py
@@ -51,8 +51,8 @@ def create_user(
     """
     Create a new user in the database
     """
-
-    user = server.user_manager.create_user(request)
+    user = User(**request.model_dump())
+    user = server.user_manager.create_user(user)
     return user
 
 

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -824,7 +824,7 @@ class SyncServer(Server):
                 source_type = "python"
                 tags = ["memory", "memgpt-base"]
                 tool = self.tool_manager.create_or_update_tool(
-                    ToolCreate(
+                    Tool(
                         source_code=source_code,
                         source_type=source_type,
                         tags=tags,
@@ -1766,7 +1766,7 @@ class SyncServer(Server):
             tool_creates += ToolCreate.load_default_composio_tools()
         for tool_create in tool_creates:
             try:
-                self.tool_manager.create_or_update_tool(tool_create, actor=actor)
+                self.tool_manager.create_or_update_tool(Tool(**tool_create.model_dump()), actor=actor)
             except Exception as e:
                 warnings.warn(f"An error occurred while creating tool {tool_create}: {e}")
                 warnings.warn(traceback.format_exc())

--- a/letta/services/organization_manager.py
+++ b/letta/services/organization_manager.py
@@ -3,13 +3,13 @@ from typing import List, Optional
 from letta.orm.errors import NoResultFound
 from letta.orm.organization import Organization as OrganizationModel
 from letta.schemas.organization import Organization as PydanticOrganization
-from letta.utils import create_random_username, enforce_types
+from letta.utils import enforce_types
 
 
 class OrganizationManager:
     """Manager class to handle business logic related to Organizations."""
 
-    DEFAULT_ORG_ID = "organization-00000000-0000-4000-8000-000000000000"
+    DEFAULT_ORG_ID = "org-00000000-0000-4000-8000-000000000000"
     DEFAULT_ORG_NAME = "default_org"
 
     def __init__(self):
@@ -37,10 +37,10 @@ class OrganizationManager:
                 raise ValueError(f"Organization with id {org_id} not found.")
 
     @enforce_types
-    def create_organization(self, name: Optional[str] = None) -> PydanticOrganization:
+    def create_organization(self, pydantic_org: PydanticOrganization) -> PydanticOrganization:
         """Create a new organization. If a name is provided, it is used, otherwise, a random one is generated."""
         with self.session_maker() as session:
-            org = OrganizationModel(name=name if name else create_random_username())
+            org = OrganizationModel(**pydantic_org.model_dump())
             org.create(session)
             return org.to_pydantic()
 

--- a/letta/services/tool_manager.py
+++ b/letta/services/tool_manager.py
@@ -7,7 +7,6 @@ from letta.functions.functions import derive_openai_json_schema, load_function_s
 
 # TODO: Remove this once we translate all of these to the ORM
 from letta.orm.errors import NoResultFound
-from letta.orm.organization import Organization as OrganizationModel
 from letta.orm.tool import Tool as ToolModel
 from letta.schemas.tool import Tool as PydanticTool
 from letta.schemas.tool import ToolCreate, ToolUpdate
@@ -99,7 +98,7 @@ class ToolManager:
                 db_session=session,
                 cursor=cursor,
                 limit=limit,
-                _organization_id=OrganizationModel.get_uid_from_identifier(actor.organization_id),
+                organization_id=actor.organization_id,
             )
             return [tool.to_pydantic() for tool in tools]
 

--- a/letta/services/tool_manager.py
+++ b/letta/services/tool_manager.py
@@ -9,7 +9,7 @@ from letta.functions.functions import derive_openai_json_schema, load_function_s
 from letta.orm.errors import NoResultFound
 from letta.orm.tool import Tool as ToolModel
 from letta.schemas.tool import Tool as PydanticTool
-from letta.schemas.tool import ToolCreate, ToolUpdate
+from letta.schemas.tool import ToolUpdate
 from letta.schemas.user import User as PydanticUser
 from letta.utils import enforce_types, printd
 
@@ -32,20 +32,20 @@ class ToolManager:
         self.session_maker = db_context
 
     @enforce_types
-    def create_or_update_tool(self, tool_create: ToolCreate, actor: PydanticUser) -> PydanticTool:
+    def create_or_update_tool(self, pydantic_tool: PydanticTool, actor: PydanticUser) -> PydanticTool:
         """Create a new tool based on the ToolCreate schema."""
         # Derive json_schema
-        derived_json_schema = tool_create.json_schema or derive_openai_json_schema(
-            source_code=tool_create.source_code, name=tool_create.name
+        derived_json_schema = pydantic_tool.json_schema or derive_openai_json_schema(
+            source_code=pydantic_tool.source_code, name=pydantic_tool.name
         )
-        derived_name = tool_create.name or derived_json_schema["name"]
+        derived_name = pydantic_tool.name or derived_json_schema["name"]
 
         try:
             # NOTE: We use the organization id here
             # This is important, because even if it's a different user, adding the same tool to the org should not happen
             tool = self.get_tool_by_name(tool_name=derived_name, actor=actor)
             # Put to dict and remove fields that should not be reset
-            update_data = tool_create.model_dump(exclude={"module"}, exclude_unset=True)
+            update_data = pydantic_tool.model_dump(exclude={"module"}, exclude_unset=True, exclude_none=True)
             # Remove redundant update fields
             update_data = {key: value for key, value in update_data.items() if getattr(tool, key) != value}
 
@@ -54,22 +54,24 @@ class ToolManager:
                 self.update_tool_by_id(tool.id, ToolUpdate(**update_data), actor)
             else:
                 printd(
-                    f"`create_or_update_tool` was called with user_id={actor.id}, organization_id={actor.organization_id}, name={tool_create.name}, but found existing tool with nothing to update."
+                    f"`create_or_update_tool` was called with user_id={actor.id}, organization_id={actor.organization_id}, name={pydantic_tool.name}, but found existing tool with nothing to update."
                 )
         except NoResultFound:
-            tool_create.json_schema = derived_json_schema
-            tool_create.name = derived_name
-            tool = self.create_tool(tool_create, actor=actor)
+            pydantic_tool.json_schema = derived_json_schema
+            pydantic_tool.name = derived_name
+            tool = self.create_tool(pydantic_tool, actor=actor)
 
         return tool
 
     @enforce_types
-    def create_tool(self, tool_create: ToolCreate, actor: PydanticUser) -> PydanticTool:
+    def create_tool(self, pydantic_tool: PydanticTool, actor: PydanticUser) -> PydanticTool:
         """Create a new tool based on the ToolCreate schema."""
         # Create the tool
         with self.session_maker() as session:
-            create_data = tool_create.model_dump()
-            tool = ToolModel(**create_data, organization_id=actor.organization_id)  # Unpack everything directly into ToolModel
+            # Set the organization id at the ORM layer
+            pydantic_tool.organization_id = actor.organization_id
+            tool_data = pydantic_tool.model_dump()
+            tool = ToolModel(**tool_data)
             tool.create(session, actor=actor)
 
         return tool.to_pydantic()

--- a/letta/services/user_manager.py
+++ b/letta/services/user_manager.py
@@ -4,7 +4,7 @@ from letta.orm.errors import NoResultFound
 from letta.orm.organization import Organization as OrganizationModel
 from letta.orm.user import User as UserModel
 from letta.schemas.user import User as PydanticUser
-from letta.schemas.user import UserCreate, UserUpdate
+from letta.schemas.user import UserUpdate
 from letta.services.organization_manager import OrganizationManager
 from letta.utils import enforce_types
 
@@ -42,10 +42,10 @@ class UserManager:
             return user.to_pydantic()
 
     @enforce_types
-    def create_user(self, user_create: UserCreate) -> PydanticUser:
+    def create_user(self, pydantic_user: PydanticUser) -> PydanticUser:
         """Create a new user if it doesn't already exist."""
         with self.session_maker() as session:
-            new_user = UserModel(**user_create.model_dump())
+            new_user = UserModel(**pydantic_user.model_dump())
             new_user.create(session)
             return new_user.to_pydantic()
 


### PR DESCRIPTION
## Description:

Move ID generation logic out of the ORM layer and into the Pydantic model layer. This is done so people can generate free-floating Pydantic objects with IDs without needing to persist anything to the ORM. 

## Testing:

Rely on existing tests as this is a refactor.