### PR TITLE
docs: fix API documentation examples for messages endpoints

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -488,6 +488,15 @@ paths:
         - agents
         - messages
       x-fern-sdk-method-name: create
+      requestBody:
+        content:
+          application/json:
+            example:
+              messages:
+                - role: user
+                  content:
+                    - type: text
+                      text: "The sky above the port was the color of television, tuned to a dead channel."
   /v1/agents/{agent_id}/messages/{message_id}:
     patch:
       x-fern-sdk-group-name:
@@ -508,6 +517,15 @@ paths:
         - agents
         - messages
       x-fern-sdk-method-name: create_stream
+      requestBody:
+        content:
+          application/json:
+            example:
+              messages:
+                - role: user
+                  content:
+                    - type: text
+                      text: "The sky above the port was the color of television, tuned to a dead channel."
       responses:
         '200':
           content:
@@ -961,6 +979,15 @@ paths:
         - groups
         - messages
       x-fern-sdk-method-name: create
+      requestBody:
+        content:
+          application/json:
+            example:
+              messages:
+                - role: user
+                  content:
+                    - type: text
+                      text: "The sky above the port was the color of television, tuned to a dead channel."
   /v1/groups/{group_id}/messages/{message_id}:
     patch:
       x-fern-sdk-group-name:
@@ -975,6 +1002,15 @@ paths:
         - groups
         - messages
       x-fern-sdk-method-name: create_stream
+      requestBody:
+        content:
+          application/json:
+            example:
+              messages:
+                - role: user
+                  content:
+                    - type: text
+                      text: "The sky above the port was the color of television, tuned to a dead channel."
       responses:
         '200':
           content:


### PR DESCRIPTION
## Summary

Snippets properly contain type/content fields:

<img width="1379" height="587" alt="image" src="https://github.com/user-attachments/assets/54f3affb-9a65-431b-a510-4ebb3823fb39" />


## Problem
The auto-generated API documentation examples were missing the required `type: "text"` discriminator field in message content objects. This caused validation errors when users tried the curl commands from the docs, as reported in Discord.

## Solution
Added proper `requestBody` examples to the fern openapi-overrides.yml file for:
- `/v1/agents/{agent_id}/messages` (POST)
- `/v1/agents/{agent_id}/messages/stream` (POST)
- `/v1/groups/{group_id}/messages` (POST)
- `/v1/groups/{group_id}/messages/stream` (POST)

All examples now show:
- `content` as an array of objects (not string)
- Required `type: "text"` field for proper union type discrimination
- Consistent example text across all endpoints