### PR TITLE
feat: support filtering out approval messages for gemini

### DIFF
--- a/letta/agents/letta_agent_v2.py
+++ b/letta/agents/letta_agent_v2.py
@@ -850,7 +850,7 @@ class LettaAgentV2(BaseAgentV2):
             tool_call_messages = create_letta_messages_from_llm_response(
                 agent_id=agent_state.id,
                 model=agent_state.llm_config.model,
-                function_name="",
+                function_name=tool_call.function.name,
                 function_arguments={},
                 tool_execution_result=ToolExecutionResult(status="error"),
                 tool_call_id=tool_call_id,

--- a/letta/llm_api/google_vertex_client.py
+++ b/letta/llm_api/google_vertex_client.py
@@ -272,7 +272,7 @@ class GoogleVertexClient(LLMClientBase):
             tool_names = []
 
         contents = self.add_dummy_model_messages(
-            [m.to_google_ai_dict() for m in messages],
+            PydanticMessage.to_google_dicts_from_list(messages),
         )
 
         request_data = {


### PR DESCRIPTION
## This PR

**Implementation Details:**

Update the google client integration to filter out approval-related messages before sending to the Anthropic API. This ensures that HITL functionality works end-to-end with gemini models by preventing approval messages from breaking the expected message sequence.

Letta message to LLM message mapping:
1. Message with role = "user" -> Maps to normal user message in llm API 
2. Message with  role = "approval" (request) -> Maps to tool call message in llm API 
3. Message with role = "approval" (response) -> Maps to None (THIS NEEDS TO BE FILTERED OUT NOW)
4. Message with role = "tool" -> Maps to tool response message in llm API 

**Testing:**

Replace line `tests/integration_test_human_in_the_loop.py#142` with:
```
        model="google_vertex/gemini-2.5-flash",
```

Then run test:
```
(letta-py3.13) caren@caren-mac core % poetry run pytest -s -vv tests/integration_test_human_in_the_loop.py
```

## This Project

**Background:**

Human In The Loop (HITL) is a pattern where certain tool calls invoked by an agent may require explicit human approval before execution. This creates a checkpoint mechanism for sensitive operations.
The core HITL flow works by:
1. Allowing user to mark a tool as requiring approval
2. Detecting when a tool requiring approval is called
3. Pausing agent execution and notifying the user
4. Waiting for explicit approval/denial from the user
5. Continuing execution based on the user's decision

This approach is needed for operations with significant side effects or in scenarios where oversight or additional input may be needed. It maintains the efficiency of automation while adding a control point for human judgment.