### PR TITLE
fix: Fix summarizer bug with tool choice

### DIFF
--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -198,14 +198,15 @@ class OpenAIClient(LLMClientBase):
         # TODO(matt) move into LLMConfig
         # TODO: This vllm checking is very brittle and is a patch at most
         tool_choice = None
-        if self.requires_auto_tool_choice(llm_config):
-            tool_choice = "auto"
-        elif tools:
-            # only set if tools is non-Null
-            tool_choice = "required"
+        if tools:  # only set tool_choice if tools exist
+            if self.requires_auto_tool_choice(llm_config):
+                tool_choice = "auto"
+            else:
+                # only set if tools is non-Null
+                tool_choice = "required"
 
-        if force_tool_call is not None:
-            tool_choice = ToolFunctionChoice(type="function", function=ToolFunctionChoiceFunctionCall(name=force_tool_call))
+            if force_tool_call is not None:
+                tool_choice = ToolFunctionChoice(type="function", function=ToolFunctionChoiceFunctionCall(name=force_tool_call))
 
         data = ChatCompletionRequest(
             model=model,


### PR DESCRIPTION
The summarizer can trigger OpenAI:

```
Letta.letta.llm_api.openai_client - WARNING - [OpenAI] Bad request (400): Error code: 400 - {'error': {'message': '[{\'type\': 
  \'value_error\', \'loc\': (\'body\',), \'msg\': \'Value error, When using `tool_choice`, `tools` must be set.\', \'input\': {\'messages\':
   [{\'content\': "Your job is to summarize a history of previous messages in a conversation between an AI persona and a human.\\nThe
  conversation you are given is a from a fixed context window and may not be complete.\\nMessages sent by the AI are marked with the
  \'assistant\' role.\\nThe AI \'assistant\' can also make calls to tools, whose outputs can be seen in messages with the \'tool\'
  role.\\nThings the AI says in the message content are considered inner monolo...
  ```
  
  And this leads to an error on the OpenAI payload.