### PR TITLE
fix: Update run to errored terminal state if streaming errors

### DIFF
--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -1348,6 +1348,8 @@ async def send_message_streaming(
                         stream_generator=raw_stream,
                         redis_client=redis_client,
                         run_id=run.id,
+                        job_manager=server.job_manager,
+                        actor=actor,
                     ),
                     label=f"background_stream_processor_{run.id}",
                 )


### PR DESCRIPTION
In background mode, the errored run does NOT get updated when the streaming errors, which causes infinite hanging "Agent Thinking" bugs on ADE.