### PR TITLE
feat: auto register mcp server tools as letta tools

### DIFF
--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -738,7 +738,8 @@ async def add_mcp_server_to_config(
                     custom_headers=request.custom_headers,
                 )
 
-            await server.mcp_manager.create_mcp_server(mapped_request, actor=actor)
+            # Create MCP server and optimistically sync tools
+            await server.mcp_manager.create_mcp_server_with_tools(mapped_request, actor=actor)
 
             # TODO: don't do this in the future (just return MCPServer)
             all_servers = await server.mcp_manager.list_mcp_servers(actor=actor)


### PR DESCRIPTION
##  Purpose
  This PR adds automatic tool synchronization when creating MCP (Model
  Context Protocol) servers. Previously, when adding an MCP server
  configuration, tools had to be manually registered one-by-one. Now, the
  system automatically connects to the MCP server, fetches all available
  tools, and persists them in parallel.

 
## Key Changes
  - Added create_mcp_server_with_tools() method to MCPManager that:
    - Creates the MCP server record
    - Optimistically attempts to connect and fetch tools
    - Filters out invalid tools (schema validation failures)
    - Persists valid tools in parallel using asyncio.gather()
    - Logs success/failure metrics without failing the main operation
  - Updated /mcp/servers POST endpoint to use the new method
  - Added comprehensive test coverage for both success and failure scenarios

##   How to Test
```  # Run the new tests
  poetry run pytest tests/test_managers.py::test_create_mcp_server_with_tools
   -xvs
  poetry run pytest tests/test_managers.py::test_create_mcp_server_with_tools
  _connection_failure -xvs

  # Test via API (database mode)
  curl -X POST http://localhost:8283/v1/tools/mcp/servers \
    -H "Content-Type: application/json" \
    -d '{
      "server_name": "test_server",
      "type": "sse",
      "server_url": "https://example.com/mcp"
    }'
    ```