### PR TITLE
fix: remove extra logger param

### DIFF
--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -536,9 +536,7 @@ async def attach_source(
 
     if agent_state.enable_sleeptime:
         source = await server.source_manager.get_source_by_id(source_id=source_id)
-        safe_create_task(
-            server.sleeptime_document_ingest_async(agent_state, source, actor), logger=logger, label="sleeptime_document_ingest_async"
-        )
+        safe_create_task(server.sleeptime_document_ingest_async(agent_state, source, actor), label="sleeptime_document_ingest_async")
 
     return agent_state
 
@@ -565,9 +563,7 @@ async def attach_folder_to_agent(
 
     if agent_state.enable_sleeptime:
         source = await server.source_manager.get_source_by_id(source_id=folder_id)
-        safe_create_task(
-            server.sleeptime_document_ingest_async(agent_state, source, actor), logger=logger, label="sleeptime_document_ingest_async"
-        )
+        safe_create_task(server.sleeptime_document_ingest_async(agent_state, source, actor), label="sleeptime_document_ingest_async")
 
     return agent_state
 


### PR DESCRIPTION
Stacktrace:
```
Traceback (most recent call last): File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 151, in call_next message = await recv_stream.receive() ^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/anyio/streams/memory.py", line 126, in receive raise EndOfStream from None anyio.EndOfStream  During handling of the above exception, another exception occurred:  Traceback (most recent call last): File "/app/letta/otel/tracing.py", line 47, in _trace_request_middleware response = await call_next(request) ^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 159, in call_next raise app_exc File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro await self.app(scope, receive_or_disconnect, send_no_error) File "/app/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/starlette.py", line 200, in _create_span_call return await old_call(app, scope, new_receive, new_send, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 93, in __call__ await self.simple_response(scope, receive, send, request_headers=headers) File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 144, in simple_response await self.app(scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/starlette.py", line 200, in _create_span_call return await old_call(app, scope, new_receive, new_send, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__ with recv_stream, send_stream, collapse_excgroups(): File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__ self.gen.throw(value) File "/app/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 85, in collapse_excgroups raise exc File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__ response = await self.dispatch_func(request, call_next) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/letta/server/rest_api/middleware/profiler_context.py", line 21, in dispatch return await call_next(request) ^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 159, in call_next raise app_exc File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro await self.app(scope, receive_or_disconnect, send_no_error) File "/app/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/starlette.py", line 298, in _sentry_exceptionmiddleware_call await old_call(self, scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/starlette.py", line 200, in _create_span_call return await old_call(app, scope, new_receive, new_send, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__ await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app raise exc File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app await app(scope, receive, sender) File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 716, in __call__ await self.middleware_stack(scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 736, in app await route.handle(scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 290, in handle await self.app(scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 78, in app await wrap_app_handling_exceptions(app, request)(scope, receive, send) File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app raise exc File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app await app(scope, receive, sender) File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 75, in app response = await f(request) ^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/fastapi.py", line 143, in _sentry_app return await old_app(*args, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 302, in app raw_response = await run_endpoint_function( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 213, in run_endpoint_function return await dependant.call(**values) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/app/letta/server/rest_api/routers/v1/agents.py", line 539, in attach_source safe_create_task( File "/app/letta/otel/tracing.py", line 251, in sync_wrapper result = func(*args, **kwargs) ^^^^^^^^^^^^^^^^^^^^^ 
safe_create_task() got an unexpected keyword argument 'logger'
```