### PR TITLE
feat: use LLMServerError to distinguish provider errors

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -497,7 +497,7 @@ class AnthropicClient(LLMClientBase):
                         try:
                             args_json = json.loads(arguments)
                             if not isinstance(args_json, dict):
-                                raise ValueError("Expected parseable json object for arguments")
+                                raise LLMServerError("Expected parseable json object for arguments")
                         except:
                             arguments = str(tool_input["function"]["arguments"])
                     else:
@@ -854,7 +854,7 @@ def remap_finish_reason(stop_reason: str) -> str:
     elif stop_reason == "tool_use":
         return "function_call"
     else:
-        raise ValueError(f"Unexpected stop_reason: {stop_reason}")
+        raise LLMServerError(f"Unexpected stop_reason: {stop_reason}")
 
 
 def strip_xml_tags(string: str, tag: Optional[str]) -> str:

--- a/letta/llm_api/google_vertex_client.py
+++ b/letta/llm_api/google_vertex_client.py
@@ -379,11 +379,10 @@ class GoogleVertexClient(LLMClientBase):
 
                 if content is None or content.role is None or content.parts is None:
                     # This means the response is malformed like MALFORMED_FUNCTION_CALL
-                    # NOTE: must be a ValueError to trigger a retry
                     if candidate.finish_reason == "MALFORMED_FUNCTION_CALL":
-                        raise ValueError(f"Error in response data from LLM: {candidate.finish_reason}")
+                        raise LLMServerError(f"Malformed response from Google Vertex: {candidate.finish_reason}")
                     else:
-                        raise ValueError(f"Error in response data from LLM: {candidate.model_dump()}")
+                        raise LLMServerError(f"Invalid response data from Google Vertex: {candidate.model_dump()}")
 
                 role = content.role
                 assert role == "model", f"Unknown role in response: {role}"
@@ -477,7 +476,7 @@ class GoogleVertexClient(LLMClientBase):
 
                         except json.decoder.JSONDecodeError:
                             if candidate.finish_reason == "MAX_TOKENS":
-                                raise ValueError("Could not parse response data from LLM: exceeded max token limit")
+                                raise LLMServerError("Could not parse response data from LLM: exceeded max token limit")
                             # Inner thoughts are the content by default
                             inner_thoughts = response_message.text
 
@@ -506,7 +505,7 @@ class GoogleVertexClient(LLMClientBase):
                     elif finish_reason == "RECITATION":
                         openai_finish_reason = "content_filter"
                     else:
-                        raise ValueError(f"Unrecognized finish reason in Google AI response: {finish_reason}")
+                        raise LLMServerError(f"Unrecognized finish reason in Google AI response: {finish_reason}")
 
                     choices.append(
                         Choice(


### PR DESCRIPTION
## This PR

**Implementation Details:**

Introduce a new error type called `LLMServerError` to the agent loop implementation. This error specifically identifies issues that occur on the LLM provider's end that prevent Letta from parsing a suitable response. Previously we were using ValueError, which isn't super helpful.

**Notes:**

This new error type significantly improves our ability to diagnose issues by clearly distinguishing between problems in our code versus problems with external LLM providers. Previously, all errors from LLM interactions were lumped together, making it difficult to identify patterns in provider-specific failures or to set up appropriate retry policies. The `LLMServerError` provides more granular information about what went wrong, helping both our internal debugging processes and giving users clearer feedback about the nature of failures. This change supports our ongoing efforts to improve observability and resilience in the agent loop.

## This Project

**Background:**

The Agent Loop Refactor is a project to redesign the core execution engine of our agents. It aims to create a more modular, testable, and extensible architecture that can better accommodate complex features like human-in-the-loop approvals, parallel tool execution, and advanced conversation management.

The new design is built around these key principles:
1. Separation of concerns between different aspects of agent execution
2. Unified handling of streaming and blocking requests
3. Pluggable components that can be composed to support different use cases
4. Clear state management throughout the execution lifecycle
5. Improved testability through smaller, more focused components

This approach will reduce technical debt, improve performance, and enable faster development of new features while maintaining backward compatibility with existing clients.