### PR TITLE
docs: Add posthog analytics

### DIFF
--- a/.github/workflows/fern-docs-preview.yml
+++ b/.github/workflows/fern-docs-preview.yml
@@ -24,6 +24,7 @@ jobs:
         working-directory: fern
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: |
           OUTPUT=$(fern generate --docs --preview 2>&1) || true
           echo "$OUTPUT"

--- a/.github/workflows/fern-docs-publish.yml
+++ b/.github/workflows/fern-docs-publish.yml
@@ -18,4 +18,5 @@ jobs:
         working-directory: .
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: fern generate --docs --log-level debug

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -554,6 +554,11 @@ js:
     strategy: lazyOnload
     # strategy: afterInteractive
 
+analytics:
+  posthog:
+    api-key: ${POSTHOG_API_KEY}
+    endpoint: https://us.i.posthog.com
+
 favicon: assets/favicon.png
 
 logo:


### PR DESCRIPTION
Adds PostHog analytics configuration to Fern documentation:

- Configures PostHog analytics in fern/docs.yml with API key and endpoint
- Updates GitHub Actions workflows to include POSTHOG_API_KEY environment variable
- Enables tracking of documentation usage and user behavior

This is a clean re-creation after the main branch force push, containing only the analytics configuration changes.