### PR TITLE
feat: add pagination to folders passages endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/folders.py
+++ b/letta/server/rest_api/routers/v1/folders.py
@@ -358,9 +358,19 @@ async def list_agents_for_folder(
 @router.get("/{folder_id}/passages", response_model=List[Passage], operation_id="list_folder_passages")
 async def list_folder_passages(
     folder_id: str,
-    after: Optional[str] = Query(None, description="Message after which to retrieve the returned messages."),
-    before: Optional[str] = Query(None, description="Message before which to retrieve the returned messages."),
-    limit: int = Query(100, description="Maximum number of messages to retrieve."),
+    before: Optional[str] = Query(
+        None,
+        description="Passage ID cursor for pagination. Returns passages that come before this passage ID in the specified sort order",
+    ),
+    after: Optional[str] = Query(
+        None,
+        description="Passage ID cursor for pagination. Returns passages that come after this passage ID in the specified sort order",
+    ),
+    limit: Optional[int] = Query(100, description="Maximum number of passages to return"),
+    order: Literal["asc", "desc"] = Query(
+        "desc", description="Sort order for passages by creation time. 'asc' for oldest first, 'desc' for newest first"
+    ),
+    order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
     server: SyncServer = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),
 ):
@@ -374,6 +384,7 @@ async def list_folder_passages(
         after=after,
         before=before,
         limit=limit,
+        ascending=(order == "asc"),
     )
 
 


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `client.folders.passages.list` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

While `order_by` is not currently used, adding to document the default behavior, and keep consistent with other endpoints.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.