### PR TITLE
feat: rename folders metadata endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/folders.py
+++ b/letta/server/rest_api/routers/v1/folders.py
@@ -92,8 +92,8 @@ async def get_folder_id_by_name(
     return folder.id
 
 
-@router.get("/metadata", response_model=OrganizationSourcesStats, operation_id="get_folders_metadata")
-async def get_folders_metadata(
+@router.get("/metadata", response_model=OrganizationSourcesStats, operation_id="retrieve_metadata")
+async def retrieve_metadata(
     server: "SyncServer" = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),
     include_detailed_per_source_metadata: bool = False,


### PR DESCRIPTION
## This PR

**Implementation Details:**

Rename `client.folders.get_folders_metadata` to `client.folders.retrieve_metadata`.

**Notes:**

This change should be backwards compatible since the underlying url of the endpoint doesn't change.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.