### PR TITLE
feat: replace query_text with name for list tags

### DIFF
--- a/letta/server/rest_api/routers/v1/tags.py
+++ b/letta/server/rest_api/routers/v1/tags.py
@@ -24,7 +24,10 @@ async def list_tags(
         "asc", description="Sort order for tags. 'asc' for alphabetical order, 'desc' for reverse alphabetical order"
     ),
     order_by: Literal["name"] = Query("name", description="Field to sort by"),
-    query_text: Optional[str] = Query(None, description="Filter tags by text search"),
+    query_text: Optional[str] = Query(
+        None, description="Filter tags by text search. Deprecated, please use name field instead", deprecated=True
+    ),
+    name: Optional[str] = Query(None, description="Filter tags by name"),
     server: "SyncServer" = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),
 ):
@@ -32,7 +35,8 @@ async def list_tags(
     Get the list of all agent tags that have been created.
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=headers.actor_id)
+    text_filter = name or query_text
     tags = await server.agent_manager.list_tags_async(
-        actor=actor, before=before, after=after, limit=limit, query_text=query_text, ascending=(order == "asc")
+        actor=actor, before=before, after=after, limit=limit, query_text=text_filter, ascending=(order == "asc")
     )
     return tags


### PR DESCRIPTION
## This PR

**Implementation Details:**

Rename `query_text` param to `name` so it's a little bit more user friendly and also matches all of our other list endpoint query params.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.