### PR TITLE
feat: remove organization id from trace object in api

### DIFF
--- a/letta/adapters/letta_llm_request_adapter.py
+++ b/letta/adapters/letta_llm_request_adapter.py
@@ -106,7 +106,6 @@ class LettaLLMRequestAdapter(LettaLLMAdapter):
                     request_json=self.request_data,
                     response_json=self.response_data,
                     step_id=step_id,  # Use original step_id for telemetry
-                    organization_id=actor.organization_id,
                 ),
             ),
             label="create_provider_trace",

--- a/letta/adapters/letta_llm_stream_adapter.py
+++ b/letta/adapters/letta_llm_stream_adapter.py
@@ -164,7 +164,6 @@ class LettaLLMStreamAdapter(LettaLLMAdapter):
                         },
                     },
                     step_id=step_id,  # Use original step_id for telemetry
-                    organization_id=actor.organization_id,
                 ),
             ),
             label="create_provider_trace",

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -405,7 +405,6 @@ class LettaAgent(BaseAgent):
                                 request_json=request_data,
                                 response_json=response_data,
                                 step_id=step_id,  # Use original step_id for telemetry
-                                organization_id=self.actor.organization_id,
                             ),
                         )
                         step_progression = StepProgression.LOGGED_TRACE
@@ -751,7 +750,6 @@ class LettaAgent(BaseAgent):
                                 request_json=request_data,
                                 response_json=response_data,
                                 step_id=step_id,  # Use original step_id for telemetry
-                                organization_id=self.actor.organization_id,
                             ),
                         )
                         step_progression = StepProgression.LOGGED_TRACE
@@ -1173,7 +1171,6 @@ class LettaAgent(BaseAgent):
                                     },
                                 },
                                 step_id=step_id,  # Use original step_id for telemetry
-                                organization_id=self.actor.organization_id,
                             ),
                         )
                         step_progression = StepProgression.LOGGED_TRACE

--- a/letta/llm_api/llm_api_tools.py
+++ b/letta/llm_api/llm_api_tools.py
@@ -235,7 +235,6 @@ def create(
                 request_json=prepare_openai_payload(data),
                 response_json=response.model_json_schema(),
                 step_id=step_id,
-                organization_id=actor.organization_id,
             ),
         )
 

--- a/letta/llm_api/llm_client_base.py
+++ b/letta/llm_api/llm_client_base.py
@@ -64,7 +64,6 @@ class LLMClientBase:
                         request_json=request_data,
                         response_json=response_data,
                         step_id=step_id,
-                        organization_id=self.actor.organization_id,
                     ),
                 )
             log_event(name="llm_response_received", attributes=response_data)
@@ -98,7 +97,6 @@ class LLMClientBase:
                         request_json=request_data,
                         response_json=response_data,
                         step_id=step_id,
-                        organization_id=self.actor.organization_id,
                     ),
                 )
 

--- a/letta/schemas/provider_trace.py
+++ b/letta/schemas/provider_trace.py
@@ -19,7 +19,6 @@ class ProviderTraceCreate(BaseModel):
     request_json: dict[str, Any] = Field(..., description="JSON content of the provider request")
     response_json: dict[str, Any] = Field(..., description="JSON content of the provider response")
     step_id: str = Field(None, description="ID of the step that this trace is associated with")
-    organization_id: str = Field(..., description="The unique identifier of the organization.")
 
 
 class ProviderTrace(BaseProviderTrace):
@@ -39,5 +38,4 @@ class ProviderTrace(BaseProviderTrace):
     request_json: Dict[str, Any] = Field(..., description="JSON content of the provider request")
     response_json: Dict[str, Any] = Field(..., description="JSON content of the provider response")
     step_id: Optional[str] = Field(None, description="ID of the step that this trace is associated with")
-    organization_id: str = Field(..., description="The unique identifier of the organization.")
     created_at: datetime = Field(default_factory=get_utc_time, description="The timestamp when the object was created.")

--- a/letta/services/telemetry_manager.py
+++ b/letta/services/telemetry_manager.py
@@ -26,6 +26,7 @@ class TelemetryManager:
     async def create_provider_trace_async(self, actor: PydanticUser, provider_trace_create: ProviderTraceCreate) -> PydanticProviderTrace:
         async with db_registry.async_session() as session:
             provider_trace = ProviderTraceModel(**provider_trace_create.model_dump())
+            provider_trace.organization_id = actor.organization_id
             if provider_trace_create.request_json:
                 request_json_str = json_dumps(provider_trace_create.request_json)
                 provider_trace.request_json = json_loads(request_json_str)
@@ -43,6 +44,7 @@ class TelemetryManager:
     def create_provider_trace(self, actor: PydanticUser, provider_trace_create: ProviderTraceCreate) -> PydanticProviderTrace:
         with db_registry.session() as session:
             provider_trace = ProviderTraceModel(**provider_trace_create.model_dump())
+            provider_trace.organization_id = actor.organization_id
             if provider_trace_create.request_json:
                 request_json_str = json_dumps(provider_trace_create.request_json)
                 provider_trace.request_json = json_loads(request_json_str)


### PR DESCRIPTION
## This PR

**Implementation Details:**

Since the concept of organization is more of an internal concept, we shouldn't expose it in our pydantic objects in the API. Removing this from the schema, but make sure we still store it in the database for permission checks by using the value from the header rather than passing it in manually

**Notes:**

Technically it is also a security vulnerability to also allow users to manually override the organization id since it bypasses the auth we have in our backend - we should be conscious of this.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.