### PR TITLE
docs: correct Python SDK import names in MCP documentation

### DIFF
--- a/fern/pages/mcp/sse.mdx
+++ b/fern/pages/mcp/sse.mdx
@@ -31,14 +31,14 @@ Letta recognizes templated variables in the custom header and auth token fields 
 <CodeGroup>
 ```python title="python" maxLines=50
 from letta_client import Letta
-from letta_client.types import StreamableHTTPServerConfig, MCPServerType
+from letta_client.types import StreamableHttpServerConfig, McpServerType
 
 client = Letta(token="LETTA_API_KEY")
 
 # Connect a Streamable HTTP server with Bearer token auth
-streamable_config = StreamableHTTPServerConfig(
+streamable_config = StreamableHttpServerConfig(
     server_name="my-server",
-    type=MCPServerType.STREAMABLE_HTTP,
+    type=McpServerType.StreamableHttp,
     server_url="https://mcp-server.example.com/mcp",
     auth_header="Authorization",
     auth_token="Bearer your-token",  # Include "Bearer " prefix
@@ -48,9 +48,9 @@ streamable_config = StreamableHTTPServerConfig(
 client.tools.add_mcp_server(request=streamable_config)
 
 # Example with templated variables for agent-scoped authentication
-agent_scoped_config = StreamableHTTPServerConfig(
+agent_scoped_config = StreamableHttpServerConfig(
     server_name="user-specific-server",
-    type=MCPServerType.STREAMABLE_HTTP,
+    type=McpServerType.StreamableHttp,
     server_url="https://api.example.com/mcp",
     auth_header="Authorization",
     auth_token="Bearer {{AGENT_API_KEY | api_key}}",  # Agent-specific API key
@@ -126,14 +126,14 @@ Letta recognizes templated variables in the custom header and auth token fields 
 <CodeGroup>
 ```python title="python" maxLines=50
 from letta_client import Letta
-from letta_client.types import SseServerConfig, MCPServerType
+from letta_client.types import SseServerConfig, McpServerType
 
 client = Letta(token="LETTA_API_KEY")
 
 # Connect a SSE server (legacy)
 sse_config = SseServerConfig(
     server_name="legacy-server",
-    type=MCPServerType.SSE,
+    type=McpServerType.Sse,
     server_url="https://legacy-mcp.example.com/sse",
     auth_header="Authorization",
     auth_token="Bearer optional-token"  # Include "Bearer " prefix


### PR DESCRIPTION
## Summary
This PR fixes incorrect import statements in the MCP documentation based on user feedback.

## User Feedback
A user reported on https://docs.letta.com/guides/mcp/remote that the code examples had incorrect imports:
- The imports `from letta_client.types import StreamableHTTPServerConfig, MCPServerType` were incorrect
- They should be `from letta_client.types import StreamableHttpServerConfig, McpServerType` (note the casing)

## The Issue
The documentation was using internal Letta naming conventions instead of the generated SDK naming. The Fern SDK generator converts naming to camelCase for the Python client SDK.

## Changes Made
Fixed all Python import statements and enum values in `fern/pages/mcp/sse.mdx`:
- `StreamableHTTPServerConfig` → `StreamableHttpServerConfig`
- `MCPServerType` → `McpServerType`  
- `MCPServerType.STREAMABLE_HTTP` → `McpServerType.StreamableHttp`
- `MCPServerType.SSE` → `McpServerType.Sse`

The TypeScript examples were already correct and didn't need changes.

## Testing
The corrected imports match what's actually generated in the `letta-client` Python SDK package published to PyPI.