### PR TITLE
fix: OpenAI Tool Return Serialisation

### DIFF
--- a/letta/server/rest_api/utils.py
+++ b/letta/server/rest_api/utils.py
@@ -504,6 +504,11 @@ def create_parallel_tool_messages_from_llm_response(
             )
         )
 
+    if not content and tool_returns:
+        primary_return = tool_returns[0]
+        if primary_return.func_response is not None:
+            content.append(TextContent(text=primary_return.func_response))
+
     tool_message = Message(
         role=MessageRole.tool,
         content=content,

--- a/tests/test_message_serialization.py
+++ b/tests/test_message_serialization.py
@@ -1,0 +1,45 @@
+from letta.schemas.enums import MessageRole
+from letta.schemas.letta_message_content import TextContent
+from letta.schemas.message import Message, ToolReturn
+
+
+def test_openai_responses_use_tool_returns_when_content_empty():
+    tool_return = ToolReturn(tool_call_id="call_abc123", status="success", func_response="tool payload")
+    message = Message(
+        role=MessageRole.tool,
+        content=[],
+        agent_id="agent-1",
+        model="gpt-5",
+        tool_call_id="call_abc123",
+        tool_returns=[tool_return],
+    )
+
+    serialized = Message.to_openai_responses_dicts_from_list([message])
+
+    assert serialized == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_abc123",
+            "output": "tool payload",
+        }
+    ]
+
+
+def test_openai_responses_fallbacks_to_content_when_no_tool_returns():
+    message = Message(
+        role=MessageRole.tool,
+        content=[TextContent(text="legacy payload")],
+        agent_id="agent-legacy",
+        model="gpt-5",
+        tool_call_id="call_legacy",
+    )
+
+    serialized = Message.to_openai_responses_dicts_from_list([message])
+
+    assert serialized == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_legacy",
+            "output": "legacy payload",
+        }
+    ]


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR is a potential fix for #3057. When a tool executes client-side (e.g., via letta-code) the resulting MessageRole.tool object persisted by the server contains populated tool_returns but an empty content list. The OpenAI Responses serializer in Message.to_openai_responses_dicts still assumes a single TextContent entry and asserts, causing every subsequent tool step to crash before the agent can continue.

Changes in the fix include:
- Reworked Message.to_openai_dict and Message.to_openai_responses_dicts so tool messages prefer the tool_returns payload (mirroring the Anthropic serializer) with fallback to legacy single-TextContent handling.
- Updated create_parallel_tool_messages_from_llm_response to inject a TextContent placeholder when only tool_returns are produced, preserving older consumers.
- Added test_message_serialization.py to validate both behaviors (tool-return-first and legacy fallback).

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?
- Configure an agent to use an OpenAI model, with upserted tools from letta-cli.
- Give the agent a request that relies on local tools to complete.

**Have you tested this PR?**
Post-fix, tools can run in letta-cli with OpenAI agents. E.g.:
<img width="1732" height="1340" alt="image" src="https://github.com/user-attachments/assets/87916021-24ec-4a52-9e8f-6bf4ac0d0d81" />

**Related issues or PRs**
This PR addresses #3057. 

**Is your PR over 500 lines of code?**
No.

**Additional context**
For transparency, this fix was vibecoded with GitHub Copilot.
