### PR TITLE
Add sandbox functionality

### DIFF
--- a/letta/constants.py
+++ b/letta/constants.py
@@ -143,7 +143,7 @@ MEMORY_TOOLS_LINE_NUMBER_PREFIX_REGEX = re.compile(
 )
 
 # Built in tools
-BUILTIN_TOOLS = ["run_code", "web_search", "fetch_webpage"]
+BUILTIN_TOOLS = ["run_code", "web_search", "fetch_webpage", "get_sandbox_id", "run_bash"]
 
 # Built in tools
 FILES_TOOLS = ["open_files", "grep_files", "semantic_search_files"]

--- a/letta/constants.py
+++ b/letta/constants.py
@@ -143,7 +143,7 @@ MEMORY_TOOLS_LINE_NUMBER_PREFIX_REGEX = re.compile(
 )
 
 # Built in tools
-BUILTIN_TOOLS = ["run_code", "web_search", "fetch_webpage", "get_sandbox_id", "run_bash"]
+BUILTIN_TOOLS = ["run_code", "web_search", "fetch_webpage", "get_sandbox_id", "run_bash", "run_ls", "open_file"]
 
 # Built in tools
 FILES_TOOLS = ["open_files", "grep_files", "semantic_search_files"]

--- a/letta/functions/function_sets/builtin.py
+++ b/letta/functions/function_sets/builtin.py
@@ -86,3 +86,25 @@ async def run_bash(command: str) -> str:
     """
     raise NotImplementedError("This is only available on the latest agent architecture. Please contact the Letta team.")
 
+
+async def run_ls() -> str:
+    """
+    Run ls command in the agent's sandbox.
+
+    Returns:
+        JSON-encoded string containing ls results
+    """
+    raise NotImplementedError("This is only available on the latest agent architecture. Please contact the Letta team.")
+
+
+async def open_file(self, file_path: str) -> str:
+    """
+    Open a file in the agent's sandbox.
+
+    Args:
+        file_path: The path to the file to open
+
+    Returns:
+        JSON-encoded string containing the file contents
+    """
+    raise NotImplementedError("This is only available on the latest agent architecture. Please contact the Letta team.")

--- a/letta/functions/function_sets/builtin.py
+++ b/letta/functions/function_sets/builtin.py
@@ -64,3 +64,25 @@ async def fetch_webpage(url: str) -> str:
         String containing the webpage content in markdown/text format
     """
     raise NotImplementedError("This is only available on the latest agent architecture. Please contact the Letta team.")
+
+async def get_sandbox_id() -> str:
+    """
+    Get the sandbox ID attached to the agent. This is the sandbox that agent actions should be conducted in.
+
+    Returns:
+        The sandbox ID as a string
+    """
+    raise NotImplementedError("This is only available on the latest agent architecture. Please contact the Letta team.")
+
+async def run_bash(command: str) -> str:
+    """
+    Run a bash command in the agent's sandbox.
+
+    Args:
+        command: The command to run
+
+    Returns:
+        JSON-encoded string containing bash command results
+    """
+    raise NotImplementedError("This is only available on the latest agent architecture. Please contact the Letta team.")
+

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -62,7 +62,7 @@ from letta.server.server import SyncServer
 from letta.services.lettuce import LettuceClient
 from letta.services.run_manager import RunManager
 from letta.services.streaming_service import StreamingService
-from letta.settings import settings
+from letta.settings import settings, tool_settings
 from letta.utils import is_1_0_sdk_version, safe_create_shielded_task, safe_create_task, truncate_file_visible_content
 from letta.validators import AgentId, BlockId, FileId, MessageId, SourceId, ToolId
 
@@ -2067,3 +2067,154 @@ async def capture_messages(
         run_ids = await sleeptime_agent_loop.run_sleeptime_agents()
 
     return JSONResponse({"success": True, "messages_created": len(response_messages), "run_ids": run_ids})
+
+
+
+
+
+class AttachSandboxRequest(BaseModel):
+    """Request body for attaching a sandbox to an agent."""
+    timeout: Optional[int] = Field(None, description="Optional timeout in seconds for sandbox creation.")
+
+
+@router.patch("/{agent_id}/sandbox/attach", response_model=Optional[AgentState], operation_id="attach_sandbox_to_agent")
+async def attach_sandbox_to_agent(
+    agent_id: AgentId,
+    request: Optional[AttachSandboxRequest] = Body(None),
+    server: "SyncServer" = Depends(get_letta_server),
+    headers: HeaderParams = Depends(get_headers),
+):
+    """
+    Attaches a sandbox to an agent and stores its ID in the agent's metadata.
+
+    In current implementation, we create a new sandbox for each agent
+    and assume each agent has just one corresponding sandbox.
+    """
+    from e2b_code_interpreter import AsyncSandbox
+    from letta.settings import tool_settings
+    
+    actor = await server.user_manager.get_actor_or_default_async(actor_id=headers.actor_id)
+    
+    # Get the current agent to preserve existing metadata
+    agent = await server.agent_manager.get_agent_by_id_async(agent_id=agent_id, actor=actor)
+    
+    try:
+        if tool_settings.e2b_api_key is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="E2B_API_KEY is not set. Cannot create a new sandbox."
+            )
+
+        # Create a new sandbox (uses auto_pause=True)
+        if request and request.timeout:
+            sandbox = await AsyncSandbox.beta_create(api_key=tool_settings.e2b_api_key, timeout=request.timeout, auto_pause=True)
+        else:
+            sandbox = await AsyncSandbox.beta_create(api_key=tool_settings.e2b_api_key, auto_pause=True)
+        
+        sandbox_id = sandbox.sandbox_id
+        
+        # Update agent metadata with sandbox_id
+        current_metadata = agent.metadata or {}
+        current_metadata["sandbox_id"] = sandbox_id
+        
+        update_agent = UpdateAgent(metadata=current_metadata)
+        await server.agent_manager.update_agent_async(
+            agent_id=agent_id,
+            agent_update=update_agent,
+            actor=actor
+        )
+        
+        if is_1_0_sdk_version(headers):
+            return None
+        # TODO: Unfortunately we need this to preserve our current API behavior (as per previous functions in this file)
+        return await server.agent_manager.get_agent_by_id_async(agent_id=agent_id, actor=actor)
+        
+    except Exception as e:
+        logger.error(f"Error attaching sandbox to agent {agent_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to attach sandbox: {str(e)}"
+        )
+
+
+@router.post("/{agent_id}/sandbox/upload", response_model=Dict[str, Any], operation_id="upload_file_to_agent_sandbox")
+async def upload_file_to_agent_sandbox(
+    agent_id: AgentId,
+    file: UploadFile = File(...),
+    path: Optional[str] = Form(None, description="Optional path in the sandbox where the file should be uploaded. If not provided, uses the filename in the current working directory."),
+    server: "SyncServer" = Depends(get_letta_server),
+    headers: HeaderParams = Depends(get_headers),
+):
+    """
+    Upload a file to the agent's sandbox.
+    
+    Requires that a sandbox has been attached to the agent via the /sandbox/attach endpoint.
+    The sandbox_id should be stored in agent.metadata['sandbox_id'].
+    """
+    from e2b_code_interpreter import AsyncSandbox
+
+    actor = await server.user_manager.get_actor_or_default_async(actor_id=headers.actor_id)
+    
+    # Get the agent and check for sandbox_id in metadata
+    agent = await server.agent_manager.get_agent_by_id_async(agent_id=agent_id, actor=actor)
+    
+    sandbox_id = None
+    if agent.metadata:
+        sandbox_id = agent.metadata.get("sandbox_id")
+    
+    if not sandbox_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No sandbox attached to this agent. Please attach a sandbox first using /sandbox/attach endpoint."
+        )
+    
+    try:
+        # Try to connect to the existing sandbox
+        if tool_settings.e2b_api_key is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="E2B_API_KEY is not set in tool_settings. Cannot connect to sandbox."
+            )
+        sandbox = await AsyncSandbox.connect(api_key=tool_settings.e2b_api_key, sandbox_id=sandbox_id)
+        
+        # Set the file path in the sandbox
+        if path:
+            sandbox_file_path = path
+        else:
+            # If no path is provided, use the uploaded filename in the current working directory
+            sandbox_file_path = file.filename or "uploaded_file"
+        
+        content = await file.read()  # bytes
+        try:
+            # Make sandbox directory if it doesn't exist
+            dir_path = '/'.join(sandbox_file_path.split('/')[:-1])
+            if dir_path:
+                await sandbox.run_code(f"mkdir -p {dir_path}", language="bash")
+            
+            await sandbox.files.write(sandbox_file_path, content)
+            
+        except Exception as e:
+            import traceback
+            error_traceback = traceback.format_exc()
+            logger.error(f"Error uploading file to sandbox for agent {agent_id}: {str(e)}\n{error_traceback}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to upload file to sandbox: {str(e)}"
+            )
+        
+        return {
+            "status": "success",
+            "message": f"File uploaded successfully to {sandbox_file_path}",
+            "sandbox_id": sandbox_id,
+            "file_path": sandbox_file_path,
+            "file_size": len(content),
+            "filename": file.filename,
+        }
+
+    # If sandbox connection fails, raise an error
+    except Exception as e:
+        logger.error(f"Error uploading file to sandbox for agent {agent_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to upload file to sandbox: {str(e)}"
+        )


### PR DESCRIPTION
Add route for agent to attach sandbox / upload file to the sandbox. Records the sandbox ID in agent metadata (`sandbox_id`) for retrieval during tool use.

Example testing/usage:
```
echo "Attaching sandbox to agent $AGENT_ID..."
curl -X PATCH "http://localhost:8283/v1/agents/$AGENT_ID/sandbox/attach" \
    -H 'Content-Type: application/json'

echo -e "\n\nUploading test.txt to sandbox..."
curl -X POST "http://localhost:8283/v1/agents/$AGENT_ID/sandbox/upload" \
    -F "file=@test.txt" \
    -F "path=/home/user/new_test.txt"
```

Add built in tool (server side) to run bash commands called `run_bash` that agent can call to run code inside its designated sandbox.
