### PR TITLE
Correct provider name for openai-proxy in LLMConfig

### DIFF
--- a/letta/agents/letta_agent_v3.py
+++ b/letta/agents/letta_agent_v3.py
@@ -1488,6 +1488,9 @@ class LettaAgentV3(LettaAgentV2):
             # provider type when only a model name is given.
             if "/" in summarizer_config.model:
                 provider, model_name = summarizer_config.model.split("/", 1)
+                if provider == "openai-proxy":
+                    # fix for pydantic LLMConfig validation
+                    provider = "openai"
             else:
                 provider = agent_llm_config.model_endpoint_type
                 model_name = summarizer_config.model


### PR DESCRIPTION
This pull request includes a targeted fix to the LLM configuration logic in `letta_agent_v3.py`. The change addresses a compatibility issue with Pydantic validation by normalizing the provider name when using the `openai-proxy` provider.

LLM configuration fix:

* Updated the `_build_summarizer_llm_config` function to convert the provider name from `openai-proxy` to `openai` when parsing the model string, ensuring compatibility with Pydantic LLMConfig validation.

Fixes summarization for OpenAI compatible endpoints.