### PR TITLE
fix: database configuration mismatch causing SQLite syntax errors on PostgreSQL #3125

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,27 @@ configure with.
 
 
 ##########################################################
+            Database configuration
+##########################################################
+# Letta uses SQLite by default (stored in ~/.letta/letta.db)
+# To use PostgreSQL instead, configure one of the following:
+
+# Option 1: Full PostgreSQL URI (recommended)
+# LETTA_PG_URI=postgresql+pg8000://postgres:postgres@localhost:5432/letta
+
+# Option 2: Individual PostgreSQL parameters (all 5 required)
+# LETTA_PG_DB=letta
+# LETTA_PG_USER=postgres
+# LETTA_PG_PASSWORD=postgres
+# LETTA_PG_HOST=localhost
+# LETTA_PG_PORT=5432
+
+# Note: If using Docker Compose with the provided PostgreSQL service,
+# the URI should point to the database container:
+# LETTA_PG_URI=postgresql+pg8000://postgres:postgres@letta_db:5432/letta
+
+
+##########################################################
                 OpenAI configuration
 ##########################################################
 # OPENAI_API_KEY=sk-...


### PR DESCRIPTION
Problem:
When no PostgreSQL configuration was provided, letta would incorrectly attempt to connect to PostgreSQL using a hardcoded default URI, while the application logic believed it was using SQLite. This caused SQLite-specific SQL syntax to be executed against PostgreSQL, resulting in errors like:
- "syntax error at or near 'OR'" (INSERT OR IGNORE)
- "function json_extract() does not exist"

Root cause:
- db.py used settings.letta_pg_uri which always returns a PostgreSQL URI (with hardcoded default: "postgresql+pg8000://letta:letta@localhost:5432/letta")
- settings.database_engine correctly detected SQLite should be used
- This inconsistency meant PostgreSQL connection with SQLite dialect assumptions

Fix:
1. Added settings.letta_db_uri property that returns the correct database URI based on database_engine (PostgreSQL or SQLite)
2. Updated db.py to use letta_db_uri instead of letta_pg_uri
3. Made database pooling configuration conditional (PostgreSQL-only)
4. Added @model_validator to validate database configuration at startup
5. Updated .env.example with clear database configuration documentation

Behavior after fix:
- Without config: Uses SQLite by default (matches documentation)
- With PostgreSQL config: Validates completeness and uses PostgreSQL
- With partial config: Shows warning, falls back to SQLite
- Fails fast with actionable error messages for misconfiguration

Bugfix:
[issues](https://github.com/letta-ai/letta/issues/3125)

**How to test**
Run docker without a PG URL configured

**Have you tested this PR?**
I ran tests and got some failures, but nothing seemed to be related to the change.


