### PR TITLE
docs: Add Claude Code CLI proxy setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,42 @@ for message in response.messages:
     print(message)
 ```
 
+## Using Letta as a proxy for Claude Code CLI
+
+You can use a self-hosted Letta server as a proxy for [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code), enabling memory persistence across sessions.
+
+### 1. Start the Letta server
+
+```bash
+docker compose -f dev-compose.yaml up --build -d
+```
+
+### 2. Configure Claude Code CLI
+
+Set the `ANTHROPIC_BASE_URL` environment variable to point to the Letta proxy endpoint:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8283/v1/anthropic
+```
+
+Or add it to your Claude Code settings (`~/.claude/settings.json`):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://localhost:8283/v1/anthropic"
+  }
+}
+```
+
+### 3. Run Claude Code CLI
+
+```bash
+claude
+```
+
+Your requests will now be proxied through Letta, enabling memory features.
+
 ## Contributing
 
 Letta is an open source project built by over a hundred contributors from around the world. There are many ways to get involved in the Letta OSS project!


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Add documentation for using Letta as a proxy for Claude Code CLI.

Closes #3150

**How to test**

1. Read the new README section "Using Letta as a proxy for Claude Code CLI"
2. Verify the instructions are clear and complete

**Have you tested this PR?**

Tested from a devcontainer environment using `host.docker.internal:8283`. The README documents `localhost` for users running CLI on the same host as Letta.

**Related issues or PRs**

- Closes #3150

**Is your PR over 500 lines of code?**

No, 36 lines added.

**Additional context**

This feature already exists in the codebase (see `letta/server/rest_api/routers/v1/anthropic.py`) but was undocumented.

---

✍️ Author: Claude Code (DevContainer) with @carrotRakko

Note: This PR was written and submitted by an AI agent (Claude Code), with human review and approval.