### PR TITLE
fix: normalize_mcp_schema adds missing 'properties' for object schemas

### DIFF
--- a/letta/functions/schema_generator.py
+++ b/letta/functions/schema_generator.py
@@ -586,9 +586,10 @@ def generate_schema_from_args_schema_v2(
 def normalize_mcp_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
     """
     Normalize an MCP JSON schema to fix common issues:
-    1. Add explicit 'additionalProperties': false to all object types
-    2. Add explicit 'type' field to properties using $ref
-    3. Process $defs recursively
+    1. Add empty 'properties': {} to object types missing it
+    2. Add explicit 'additionalProperties': false to all object types
+    3. Add explicit 'type' field to properties using $ref
+    4. Process $defs recursively
 
     Args:
         schema: The JSON schema to normalize (will be modified in-place)
@@ -604,8 +605,10 @@ def normalize_mcp_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
     def normalize_object_schema(obj_schema: Dict[str, Any], defs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Recursively normalize an object schema."""
 
-        # If this is an object type, add additionalProperties if missing
+        # If this is an object type, add additionalProperties and properties if missing
         if obj_schema.get("type") == "object":
+            if "properties" not in obj_schema:
+                obj_schema["properties"] = {}
             if "additionalProperties" not in obj_schema:
                 obj_schema["additionalProperties"] = False
 
@@ -705,12 +708,14 @@ def generate_tool_schema_for_mcp(
     description = mcp_tool.description
 
     assert "type" in parameters_schema, parameters_schema
-    assert "properties" in parameters_schema, parameters_schema
     # assert "required" in parameters_schema, parameters_schema
 
     # Normalize the schema to fix common issues with MCP schemas
-    # This adds additionalProperties: false and explicit types for $ref properties
+    # This adds additionalProperties: false, explicit types for $ref properties,
+    # and ensures object schemas have a 'properties' field
     parameters_schema = normalize_mcp_schema(parameters_schema)
+
+    assert "properties" in parameters_schema, parameters_schema
 
     # Zero-arg tools often omit "required" because nothing is required.
     # Normalise so downstream code can treat it consistently.


### PR DESCRIPTION
## Summary
- `normalize_mcp_schema` now adds `"properties": {}` to any object schema that is missing it, fixing import failures for zero-argument MCP tools
- Moved the `properties` assertion in `generate_tool_schema_for_mcp` to after normalization so the fix takes effect before validation
- Handles both top-level and nested object schemas via the recursive `normalize_object_schema` helper

## Problem
MCP servers (particularly those using the [mcp-go library](https://github.com/mark3labs/mcp-go/issues/694)) may return tool schemas like `{"type": "object"}` without a `properties` field. This caused validation failures:
```
Failed to auto-sync tools from MCP server: {'type': 'object', 'additionalProperties': False}.
Server was created successfully but tools were not persisted.
```

## Root Cause
The mcp-go library drops empty `properties` maps during JSON serialization, producing `{"type": "object"}` instead of `{"type": "object", "properties": {}}`. Letta's `normalize_mcp_schema` already handled adding `additionalProperties` but did not add the missing `properties` field.

## Changes
**`letta/functions/schema_generator.py`**:
1. In `normalize_object_schema`: Added `properties: {}` when missing for object types (before the existing `additionalProperties` fix)
2. In `generate_tool_schema_for_mcp`: Moved `assert "properties" in parameters_schema` to after `normalize_mcp_schema()` is called, so normalization can fix the schema before validation

## Test plan
- [ ] Verify that a schema like `{"type": "object"}` is normalized to `{"type": "object", "properties": {}, "additionalProperties": false}`
- [ ] Verify that schemas that already have `properties` are unaffected
- [ ] Verify that nested object schemas without `properties` are also fixed
- [ ] Run existing MCP schema tests to ensure no regressions

Fixes #3145

🤖 Generated with [Claude Code](https://claude.com/claude-code)