### PR TITLE
fix: add missing 'properties' field for object schemas in normalize_mcp_schema

### DIFF
--- a/letta/functions/schema_generator.py
+++ b/letta/functions/schema_generator.py
@@ -586,9 +586,10 @@ def generate_schema_from_args_schema_v2(
 def normalize_mcp_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
     """
     Normalize an MCP JSON schema to fix common issues:
-    1. Add explicit 'additionalProperties': false to all object types
-    2. Add explicit 'type' field to properties using $ref
-    3. Process $defs recursively
+    1. Add empty 'properties': {} to object types missing it
+    2. Add explicit 'additionalProperties': false to all object types
+    3. Add explicit 'type' field to properties using $ref
+    4. Process $defs recursively
 
     Args:
         schema: The JSON schema to normalize (will be modified in-place)
@@ -604,8 +605,10 @@ def normalize_mcp_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
     def normalize_object_schema(obj_schema: Dict[str, Any], defs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Recursively normalize an object schema."""
 
-        # If this is an object type, add additionalProperties if missing
+        # If this is an object type, add additionalProperties and properties if missing
         if obj_schema.get("type") == "object":
+            if "properties" not in obj_schema:
+                obj_schema["properties"] = {}
             if "additionalProperties" not in obj_schema:
                 obj_schema["additionalProperties"] = False
 
@@ -710,8 +713,11 @@ def generate_tool_schema_for_mcp(
     # assert "required" in parameters_schema, parameters_schema
 
     # Normalize the schema to fix common issues with MCP schemas
-    # This adds additionalProperties: false and explicit types for $ref properties
+    # This adds additionalProperties: false, explicit types for $ref properties,
+    # and ensures object schemas have a 'properties' field
     parameters_schema = normalize_mcp_schema(parameters_schema)
+
+    assert "properties" in parameters_schema, parameters_schema
 
     # Zero-arg tools often omit "required" because nothing is required.
     # Normalise so downstream code can treat it consistently.

--- a/tests/mcp_tests/test_mcp_schema_validation.py
+++ b/tests/mcp_tests/test_mcp_schema_validation.py
@@ -94,6 +94,23 @@ def test_empty_object_in_required_marked_invalid():
     assert any("config" in reason for reason in reasons)
 
 
+def test_mcp_schema_healing_adds_missing_properties_for_object_root():
+    """Object schemas without `properties` should be normalized to include an empty properties map."""
+    mcp_tool = MCPTool(
+        name="object_root_without_properties",
+        inputSchema={
+            "type": "object",
+        },
+    )
+
+    schema = generate_tool_schema_for_mcp(mcp_tool, append_heartbeat=False, strict=False)
+
+    assert schema["parameters"]["type"] == "object"
+    assert "properties" in schema["parameters"]
+    assert schema["parameters"]["properties"] == {}
+    assert schema["parameters"]["additionalProperties"] is False
+
+
 @pytest.mark.asyncio
 async def test_add_mcp_tool_accepts_non_strict_schemas():
     """Test that adding MCP tools with non-strict schemas is allowed."""


### PR DESCRIPTION
## Summary

Some MCP servers (e.g. Zapier, custom zero-arg tools) return tool schemas where the top-level parameters object has `"type": "object"` but no `"properties"` key. This causes an `AssertionError` in `generate_tool_schema_for_mcp` because the assertion `"properties" in parameters_schema` fires **before** `normalize_mcp_schema()` has a chance to fix up the schema.

This PR fixes the issue by:

- **Adding `"properties": {}` to any object schema missing it** inside `normalize_object_schema`, so all object types are guaranteed to have a `properties` field after normalization.
- **Moving the `"properties"` assertion to after the `normalize_mcp_schema()` call**, so the schema is fully normalized before we validate it.
- Updating the docstring and inline comments to reflect the new normalization step.

## Changes

- `letta/functions/schema_generator.py`:
  - `normalize_object_schema()`: Insert `if "properties" not in obj_schema: obj_schema["properties"] = {}` before the existing `additionalProperties` fix.
  - `generate_tool_schema_for_mcp()`: Move `assert "properties" in parameters_schema` to after `normalize_mcp_schema()`.
  - Update docstring (3 items → 4 items) and inline comments.

Fixes #3145

## Test plan

- [ ] Existing tests continue to pass (no behavioral change for schemas that already have `properties`)
- [ ] MCP tools with zero arguments (no `properties` key in schema) no longer crash with `AssertionError`
- [ ] Schemas with nested object types missing `properties` are also fixed recursively