### PR TITLE
fix: update pgvector image from ankane/pgvector:v0.5.1 to pgvector/pgvector:pg17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with pgvector base for builder
-FROM pgvector/pgvector:pg17 AS builder
+FROM pgvector/pgvector:pg18 AS builder
 # comment to trigger ci
 # Install Python and required packages
 RUN apt-get update && apt-get install -y \
@@ -39,7 +39,7 @@ COPY . .
 RUN uv sync --frozen --no-dev --all-extras --python 3.11
 
 # Runtime stage
-FROM pgvector/pgvector:pg17 AS runtime
+FROM pgvector/pgvector:pg18 AS runtime
 
 # Overridable Node.js version with --build-arg NODE_VERSION
 ARG NODE_VERSION=22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with pgvector base for builder
-FROM pgvector/pgvector:0.8.1-pg15 AS builder
+FROM pgvector/pgvector:pg17 AS builder
 # comment to trigger ci
 # Install Python and required packages
 RUN apt-get update && apt-get install -y \
@@ -39,7 +39,7 @@ COPY . .
 RUN uv sync --frozen --no-dev --all-extras --python 3.11
 
 # Runtime stage
-FROM pgvector/pgvector:0.8.1-pg15 AS runtime
+FROM pgvector/pgvector:pg17 AS runtime
 
 # Overridable Node.js version with --build-arg NODE_VERSION
 ARG NODE_VERSION=22

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   letta_db:
-    image: ankane/pgvector:v0.5.1
+    image: pgvector/pgvector:pg17
     networks:
       default:
         aliases:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   letta_db:
-    image: pgvector/pgvector:pg17
+    image: pgvector/pgvector:pg18
     networks:
       default:
         aliases:
@@ -11,7 +11,7 @@ services:
       - POSTGRES_PASSWORD=${LETTA_PG_PASSWORD:-letta}
       - POSTGRES_DB=${LETTA_PG_DB:-letta}
     volumes:
-      - ./.persist/pgdata:/var/lib/postgresql/data
+      - ./.persist/pgdata:/var/lib/postgresql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "${LETTA_PG_PORT:-5432}:5432"

--- a/db/Dockerfile.simple
+++ b/db/Dockerfile.simple
@@ -43,10 +43,10 @@
 # where user, password, and db are the values you set in the init-letta.sql file,
 # all defaulting to 'letta'.
 
-# Version tags can be found here: https://hub.docker.com/r/ankane/pgvector/tags
-ARG PGVECTOR=v0.5.1
+# Version tags can be found here: https://hub.docker.com/r/pgvector/pgvector/tags
+ARG PGVECTOR=pg17
 # Set up a minimal postgres image
-FROM ankane/pgvector:${PGVECTOR}
+FROM pgvector/pgvector:${PGVECTOR}
 RUN sed -e 's/^    //' >/docker-entrypoint-initdb.d/01-initletta.sql <<'EOF'
     -- Title: Init Letta Database
 

--- a/db/Dockerfile.simple
+++ b/db/Dockerfile.simple
@@ -16,21 +16,21 @@
 #   --name letta-db \
 #   -p 5432:5432 \
 #   -e POSTGRES_PASSWORD=password \
-#   -v letta_db:/var/lib/postgresql/data \
+#   -v letta_db:/var/lib/postgresql \
 #   letta-db:latest
 #
 # -d: run in the background
 # --rm: remove the container when it exits
 # --name letta-db: name the container letta-db
 # -p 5432:5432: map port 5432 on the host to port 5432 in the container
-# -v letta_db:/var/lib/postgresql/data: map the volume letta_db to /var/lib/postgresql/data in the container
+# -v letta_db:/var/lib/postgresql: map the volume letta_db to /var/lib/postgresql in the container
 # letta-db:latest: use the image letta-db:latest
 #
 # After the first time, you do not need the POSTGRES_PASSWORD.
 # docker run -d --rm \
 #   --name letta-db \
 #   -p 5432:5432 \
-#   -v letta_db:/var/lib/postgresql/data \
+#   -v letta_db:/var/lib/postgresql \
 #   letta-db:latest
 
 # Rather than a docker volume (letta_db), you can use an absolute path to a directory on the host.
@@ -44,7 +44,7 @@
 # all defaulting to 'letta'.
 
 # Version tags can be found here: https://hub.docker.com/r/pgvector/pgvector/tags
-ARG PGVECTOR=pg17
+ARG PGVECTOR=pg18
 # Set up a minimal postgres image
 FROM pgvector/pgvector:${PGVECTOR}
 RUN sed -e 's/^    //' >/docker-entrypoint-initdb.d/01-initletta.sql <<'EOF'

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -1,6 +1,6 @@
 services:
   letta_db:
-    image: pgvector/pgvector:0.8.1-pg15
+    image: pgvector/pgvector:pg17
     networks:
       default:
         aliases:

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -1,6 +1,6 @@
 services:
   letta_db:
-    image: pgvector/pgvector:pg17
+    image: pgvector/pgvector:pg18
     networks:
       default:
         aliases:
@@ -11,7 +11,7 @@ services:
       - POSTGRES_PASSWORD=${LETTA_PG_PASSWORD:-letta}
       - POSTGRES_DB=${LETTA_PG_DB:-letta}
     volumes:
-      - ./.persist/pgdata-test:/var/lib/postgresql/data
+      - ./.persist/pgdata-test:/var/lib/postgresql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - '5432:5432'

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   postgres:
-    image: pgvector/pgvector:pg17
+    image: pgvector/pgvector:pg18
     container_name: postgres
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
@@ -28,5 +28,5 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: letta
     volumes:
-      - ./data/postgres:/var/lib/postgresql/data
+      - ./data/postgres:/var/lib/postgresql
       - ./scripts/postgres-db-init/init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   postgres:
-    image: ankane/pgvector
+    image: pgvector/pgvector:pg17
     container_name: postgres
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']


### PR DESCRIPTION
## Summary

The `ankane/pgvector` Docker image is deprecated in favor of the official `pgvector/pgvector` image. This PR updates all references across the project:

- **Dockerfile** — both builder and runtime stages
- **compose.yaml** — `letta_db` service image
- **dev-compose.yaml** — `letta_db` service image
- **db/Dockerfile.simple** — `ARG`, `FROM`, and Docker Hub comment URL
- **scripts/docker-compose.yml** — `postgres` service image

The new `pgvector/pgvector:pg17` image is the official pgvector image based on PostgreSQL 17.

Fixes #3136