### PR TITLE
fix: preserve agent context_window when applying conversation model override

### DIFF
--- a/letta/server/rest_api/routers/v1/conversations.py
+++ b/letta/server/rest_api/routers/v1/conversations.py
@@ -420,6 +420,9 @@ async def send_conversation_message(
         conversation_llm_config = await server.get_llm_config_from_handle_async(
             actor=actor,
             handle=conversation.model,
+            # Preserve the agent's context window (capped at the new model's max).
+            # Without this, the context window resets to the model/global default.
+            context_window_limit=agent.llm_config.context_window,
         )
         if conversation.model_settings is not None:
             update_params = conversation.model_settings._to_legacy_config_params()


### PR DESCRIPTION
## Summary

- When a conversation has a model override, the server rebuilds `llm_config` from the model handle but drops the agent's `context_window_limit`, resetting it to `min(model_default, global_max_context_window_limit)`
- This causes `CONTEXT_WINDOW_EXCEEDED` errors for agents with large context windows when they switch models on non-default conversations
- Fix: pass `agent.llm_config.context_window` to `get_llm_config_from_handle_async` in the conversation model override path

Reproducer: agent with custom context window → switch to a different model in a non-default conversation → context window silently resets to model/global default → system prompt exceeds new limit.

Fixes LET-7991.

## Test plan

- [ ] Agent with custom context_window_limit switches models in non-default conversation — context window preserved
- [ ] Agent with default context window switches models — no regression
- [ ] `override_model` on the request still works independently

🐾 Generated with [Letta Code](https://letta.com)