### PR TITLE
fix: forward actual LLM error message to client for rate limit errors

### DIFF
--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -704,19 +704,13 @@ def create_application() -> "FastAPI":
 
     @app.exception_handler(LLMRateLimitError)
     async def llm_rate_limit_error_handler(request: Request, exc: LLMRateLimitError):
-        is_byok = exc.details.get("is_byok") if isinstance(exc.details, dict) else None
-        if is_byok:
-            message = (
-                "Rate limit exceeded on your API key. Please check your provider's rate limits and billing, or reduce request frequency."
-            )
-        else:
-            message = "Rate limit exceeded for LLM model provider. Please wait before making another request."
+        # Forward the actual LLM error message to the client
         return JSONResponse(
             status_code=429,
             content={
                 "error": {
                     "type": "llm_rate_limit",
-                    "message": message,
+                    "message": exc.message,
                     "detail": str(exc),
                 }
             },

--- a/letta/services/streaming_service.py
+++ b/letta/services/streaming_service.py
@@ -659,7 +659,7 @@ class StreamingService:
                 error_message = LettaErrorMessage(
                     run_id=run_id,
                     error_type="llm_rate_limit",
-                    message="Rate limit exceeded for LLM model provider. Please wait before making another request.",
+                    message=e.message,
                     detail=str(e),
                 )
                 error_data = {"error": error_message.model_dump()}


### PR DESCRIPTION
## Summary
- Forward the actual LLM provider error message to clients instead of a generic "Rate limit exceeded" message
- Fixes both REST API responses (`app.py`) and streaming responses (`streaming_service.py`)

**Before:** Users saw generic message, actual error buried in `detail` field
```json
{
  "message": "Rate limit exceeded for LLM model provider. Please wait before making another request.",
  "detail": "RATE_LIMIT_EXCEEDED: Rate limited by OpenAI: Error code: 429 - {'error': {'code': '1113', 'message': 'Insufficient balance or no resource package. Please recharge.'}} [BYOK]"
}
```

**After:** Users see the actual error directly
```json
{
  "message": "Rate limited by OpenAI: Error code: 429 - {'error': {'code': '1113', 'message': 'Insufficient balance or no resource package. Please recharge.'}}",
  "detail": "..."
}
```

## Test plan
- [ ] Trigger a rate limit error with BYOK and verify the actual LLM error is shown in `message`
- [ ] Test streaming endpoint returns correct error message
- [ ] Test REST endpoint returns correct error message

🤖 Generated with [Letta Code](https://letta.com)