### PR TITLE
fix: require explicit AI tool disclosure in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,23 +15,32 @@ body:
       label: AI Disclosure
       description: |
         We require all issue authors to disclose AI usage per our [AI Policy](https://github.com/letta-ai/letta/blob/main/AI_POLICY.md).
-        Check **all** that apply.
+        Select **exactly one** authorship option, identify every AI tool used below, and acknowledge the policy.
       options:
         - label: This issue was written entirely by a human
-        - label: This issue was written with AI assistance (e.g. Copilot, ChatGPT, Claude) and **reviewed and edited by a human**
+        - label: This issue was written with AI assistance and **reviewed and edited by a human**
         - label: I have read the [AI Policy](https://github.com/letta-ai/letta/blob/main/AI_POLICY.md) and agree to its terms
           required: true
     validations:
       required: true
 
-  - type: textarea
-    id: human-verification
+  - type: input
+    id: ai-tools
     attributes:
-      label: Human Verification
+      label: AI Tool(s) Used
+      description: List every AI tool used to research or write this issue (for example, Claude Code, Cursor, Copilot, or ChatGPT). If no AI tool was used, enter `None`.
+      placeholder: "e.g. Claude Code and ChatGPT, or None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repository-acknowledgment
+    attributes:
+      label: Repository Acknowledgment
       description: |
-        To help us combat spam, please copy and paste the following phrase **exactly** into the box below:
-        `I have read the AI policy and I confirm this issue was reviewed by a human.`
-      placeholder: "I have read the AI policy and I confirm this issue was reviewed by a human."
+        Read [AGENTS.md](https://github.com/letta-ai/letta/blob/main/AGENTS.md), then copy and paste the following phrase **exactly**:
+        `I have read AGENTS.md and understand that issues about the current Letta server, agent harness, CLI, or channel integrations belong in letta-ai/letta-code, not this repository.`
+      placeholder: "I have read AGENTS.md and understand that issues about the current Letta server, agent harness, CLI, or channel integrations belong in letta-ai/letta-code, not this repository."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,23 +15,32 @@ body:
       label: AI Disclosure
       description: |
         We require all issue authors to disclose AI usage per our [AI Policy](https://github.com/letta-ai/letta/blob/main/AI_POLICY.md).
-        Check **all** that apply.
+        Select **exactly one** authorship option, identify every AI tool used below, and acknowledge the policy.
       options:
         - label: This issue was written entirely by a human
-        - label: This issue was written with AI assistance (e.g. Copilot, ChatGPT, Claude) and **reviewed and edited by a human**
+        - label: This issue was written with AI assistance and **reviewed and edited by a human**
         - label: I have read the [AI Policy](https://github.com/letta-ai/letta/blob/main/AI_POLICY.md) and agree to its terms
           required: true
     validations:
       required: true
 
-  - type: textarea
-    id: human-verification
+  - type: input
+    id: ai-tools
     attributes:
-      label: Human Verification
+      label: AI Tool(s) Used
+      description: List every AI tool used to research or write this issue (for example, Claude Code, Cursor, Copilot, or ChatGPT). If no AI tool was used, enter `None`.
+      placeholder: "e.g. Claude Code and ChatGPT, or None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repository-acknowledgment
+    attributes:
+      label: Repository Acknowledgment
       description: |
-        To help us combat spam, please copy and paste the following phrase **exactly** into the box below:
-        `I have read the AI policy and I confirm this issue was reviewed by a human.`
-      placeholder: "I have read the AI policy and I confirm this issue was reviewed by a human."
+        Read [AGENTS.md](https://github.com/letta-ai/letta/blob/main/AGENTS.md), then copy and paste the following phrase **exactly**:
+        `I have read AGENTS.md and understand that issues about the current Letta server, agent harness, CLI, or channel integrations belong in letta-ai/letta-code, not this repository.`
+      placeholder: "I have read AGENTS.md and understand that issues about the current Letta server, agent harness, CLI, or channel integrations belong in letta-ai/letta-code, not this repository."
     validations:
       required: true
 

--- a/.github/workflows/issue-guard.yml
+++ b/.github/workflows/issue-guard.yml
@@ -80,10 +80,10 @@ jobs:
 
             const failures = [];
 
-            // Check 1: Magic phrase
-            const magicPhrase = 'I have read the AI policy and I confirm this issue was reviewed by a human.';
-            if (!body.includes(magicPhrase)) {
-              failures.push('Missing human verification phrase');
+            // Check 1: Repository acknowledgment phrase
+            const repositoryAcknowledgment = 'I have read AGENTS.md and understand that issues about the current Letta server, agent harness, CLI, or channel integrations belong in letta-ai/letta-code, not this repository.';
+            if (!body.includes(repositoryAcknowledgment)) {
+              failures.push('Missing exact repository acknowledgment phrase');
             }
 
             // Check 2: AI disclosure checkbox (the required one: "I have read the AI Policy")
@@ -93,11 +93,24 @@ jobs:
               failures.push('AI Policy acknowledgment checkbox not checked');
             }
 
-            // Check 3: At least one of the two disclosure options is checked
+            // Check 3: Exactly one authorship option must be checked
             const humanWritten = /- \[[xX]\] This issue was written entirely by a human/.test(body);
             const aiAssisted = /- \[[xX]\] This issue was written with AI assistance/.test(body);
-            if (!humanWritten && !aiAssisted) {
-              failures.push('No AI disclosure option selected (must indicate whether issue is human-written or AI-assisted)');
+            if (humanWritten === aiAssisted) {
+              failures.push('Select exactly one authorship option (human-written or AI-assisted)');
+            }
+
+            // Check 4: AI tools must be explicitly disclosed. GitHub issue forms render
+            // input values under a level-three Markdown heading.
+            const aiToolsMatch = body.match(/### AI Tool\(s\) Used\s*\n+([\s\S]*?)(?=\n### |$)/i);
+            const aiTools = (aiToolsMatch?.[1] || '').trim();
+            const noTools = /^(none|n\/a|no ai(?: tools?)?)\.?$/i.test(aiTools);
+            if (!aiTools || /^_?no response_?$/i.test(aiTools)) {
+              failures.push('AI Tool(s) Used must list every tool used, or state None');
+            } else if (aiAssisted && noTools) {
+              failures.push('AI-assisted issues must name the AI tool(s) used');
+            } else if (humanWritten && !noTools) {
+              failures.push('Human-written issues must state None under AI Tool(s) Used');
             }
 
             if (failures.length === 0) {
@@ -116,9 +129,10 @@ jobs:
               ``,
               `**To submit an issue, please:**`,
               `1. Use one of the [issue templates](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose)`,
-              `2. Fill out the **AI Disclosure** checkboxes`,
-              `3. Copy the **Human Verification** phrase exactly as shown`,
-              `4. Read our [AI Policy](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/AI_POLICY.md)`,
+              `2. Select exactly one **AI Disclosure** authorship option`,
+              `3. Name every AI tool used, or state **None**`,
+              `4. Copy the **Repository Acknowledgment** phrase exactly as shown`,
+              `5. Read our [AI Policy](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/AI_POLICY.md) and [AGENTS.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/AGENTS.md)`,
               ``,
               `If you believe this was a mistake, please reach out on [Discord](https://discord.gg/9GEQrxmVyE).`,
             ].join('\n');

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -35,9 +35,10 @@ Do not file issues or pull requests in this repository with an expectation that 
 Issues that do not comply with this policy will be **automatically closed and locked**.
 Specifically, all issues must:
 
-1. Fill out the **AI Disclosure** checkboxes indicating whether the issue was human-written or AI-assisted.
-2. Include the **Human Verification** phrase as instructed in the issue template.
+1. Select exactly one **AI Disclosure** option indicating whether the issue was human-written or AI-assisted.
+2. Name every AI tool used to research or write the issue, or explicitly state `None` if no AI tool was used.
 3. Acknowledge that they have read this policy.
+4. Include the exact **Repository Acknowledgment** phrase from the issue template confirming that they read [AGENTS.md](AGENTS.md) and understand which issues belong in [letta-ai/letta-code](https://github.com/letta-ai/letta-code).
 
 Members of the [letta-ai](https://github.com/letta-ai) GitHub organization and
 [trusted contributors](.github/TRUSTED_CONTRIBUTORS) are exempt from automated checks,


### PR DESCRIPTION
## Summary
- require issue authors to name every AI tool used, or explicitly state None
- require an exact AGENTS.md acknowledgment routing current server, harness, CLI, and channel reports to letta-ai/letta-code
- auto-close contradictory or incomplete disclosures while preserving maintainer and trusted-contributor exemptions

👾 Generated with [Letta Code](https://letta.com)